### PR TITLE
Update MinGW paths to 6.3.0.

### DIFF
--- a/Documentation/LanguageServer/MinGW.md
+++ b/Documentation/LanguageServer/MinGW.md
@@ -1,5 +1,7 @@
 For developers using MinGW on Windows, we recommend you start with the following **c_cpp_properties.json** template.  Select "C/Cpp: Edit Configurations" from the command palette to create this file if you haven't already.
 
+Note that you may have to change the MinGW version number to match what you have installed. Eg. `C:/MinGW/lib/gcc/mingw32/5.3.0/` to `C:/MinGW/lib/gcc/mingw32/x.x.x/`.
+
 ```
 {
     "configurations": [
@@ -8,12 +10,12 @@ For developers using MinGW on Windows, we recommend you start with the following
             "intelliSenseMode": "clang-x64",
             "includePath": [
                 "${workspaceRoot}",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include/c++",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include/c++/mingw32",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include/c++/backward",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include",
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include/c++",
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include/c++/mingw32",
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include/c++/backward",
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include",
                 "C:/MinGW/include",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include-fixed"
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include-fixed"
             ],
             "defines": [
                 "_DEBUG",
@@ -23,8 +25,8 @@ For developers using MinGW on Windows, we recommend you start with the following
             ],
             "browse": {
                 "path": [
-                    "C:/MinGW/lib/gcc/mingw32/5.3.0/include",
-                    "C:/MinGW/lib/gcc/mingw32/5.3.0/include-fixed",
+                    "C:/MinGW/lib/gcc/mingw32/6.3.0/include",
+                    "C:/MinGW/lib/gcc/mingw32/6.3.0/include-fixed",
                     "C:/MinGW/include/*"
                 ],
                 "limitSymbolsToIncludedHeaders": true,
@@ -35,7 +37,7 @@ For developers using MinGW on Windows, we recommend you start with the following
 }
 ```
 
-The `includePath` above includes the system header paths that gcc uses in version 5.3.0 for C++ projects and matches the output of `gcc -v -E -x c++ -`. The `intelliSenseMode` should be set to **"clang-x64"** to get MinGW projects to work properly with IntelliSense. The `__GNUC__=#` define should match the major version of the toolchain in your installation (5 in this example).
+The `includePath` above includes the system header paths that gcc uses in version 6.3.0 for C++ projects and matches the output of `gcc -v -E -x c++ -`. The `intelliSenseMode` should be set to **"clang-x64"** to get MinGW projects to work properly with IntelliSense. The `__GNUC__=#` define should match the major version of the toolchain in your installation (5 in this example).
 
 For C projects, simply remove the c++ lines:
 
@@ -47,9 +49,9 @@ For C projects, simply remove the c++ lines:
             "intelliSenseMode": "clang-x64",
             "includePath": [
                 "${workspaceRoot}",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include",
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include",
                 "C:/MinGW/include",
-                "C:/MinGW/lib/gcc/mingw32/5.3.0/include-fixed"
+                "C:/MinGW/lib/gcc/mingw32/6.3.0/include-fixed"
             ],
             "defines": [
                 "_DEBUG",
@@ -59,8 +61,8 @@ For C projects, simply remove the c++ lines:
             ],
             "browse": {
                 "path": [
-                    "C:/MinGW/lib/gcc/mingw32/5.3.0/include",
-                    "C:/MinGW/lib/gcc/mingw32/5.3.0/include-fixed",
+                    "C:/MinGW/lib/gcc/mingw32/6.3.0/include",
+                    "C:/MinGW/lib/gcc/mingw32/6.3.0/include-fixed",
                     "C:/MinGW/include/*"
                 ],
                 "limitSymbolsToIncludedHeaders": true,


### PR DESCRIPTION
As the latest recommended version of MinGW is 6.3.0 and MinGW strongly discourages using old versions, I think it's appropriate to update the version numbers for this file and add a notice informing users that they may have to change the MinGW file path to match their version.