### PR TITLE
Update WSL config docs

### DIFF
--- a/Documentation/LanguageServer/Windows Subsystem for Linux.md
+++ b/Documentation/LanguageServer/Windows Subsystem for Linux.md
@@ -55,11 +55,11 @@ For C projects, simply remove the c++ lines:
     "intelliSenseMode": "clang-x64",
     "includePath": [
         "${workspaceRoot}",
-        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-        "${localappdata}/lxss/rootfs/usr/local/include",
-        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-        "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-        "${localappdata}/lxss/rootfs/usr/include"
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include"
     ],
     "defines": [
         "__linux__",
@@ -67,11 +67,11 @@ For C projects, simply remove the c++ lines:
     ],
     "browse": {
         "path": [
-            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-            "${localappdata}/lxss/rootfs/usr/local/include",
-            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-            "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-            "${localappdata}/lxss/rootfs/usr/include/*"
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/*"
         ],
         "limitSymbolsToIncludedHeaders": true,
         "databaseFilename": ""

--- a/Documentation/LanguageServer/Windows Subsystem for Linux.md
+++ b/Documentation/LanguageServer/Windows Subsystem for Linux.md
@@ -1,6 +1,90 @@
-For developers using the Windows Subsystem for Linux, we recommend you start with the following **c_cpp_properties.json** template.  Select "C/Cpp: Edit Configurations" from the command palette to create this file if you haven't already.
+# Windows Subsystem for Linux
+
+To use the Windows Subsystem for Linux with this extension you need to add a configuration to your **c_cpp_properties.json** file which adds the necessary header paths from within the WSL filesystem to the `includePath`.
+
+Select "C/Cpp: Edit Configurations" from the command palette to create the **c_cpp_properties.json** file if you haven't already.
+
+## Release
+
+For developers using Ubuntu with the current version of WSL released with the Fall Creators Update, you can add the following configuration template to your **c_cpp_properties.json** file.  
+
+```json
+        {
+            "name": "WSL",
+            "intelliSenseMode": "clang-x64",
+            "includePath": [
+                "${workspaceRoot}",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5/backward",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include"
+            ],
+            "defines": [
+                "__linux__",
+                "__x86_64__"
+            ],
+            "browse": {
+                "path": [
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/*"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
 
 ```
+
+The `includePath` above includes the system header paths that gcc uses for C++ projects and matches the output of `gcc -v -E -x c++ - < /dev/null`. The intelliSenseMode should be set to **"clang-x64"** to get WSL projects to work properly with IntelliSense.
+
+Note that `${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/` is the path to the root of the Ubuntu filesystem. This will be different if you are using a different distro.
+
+For C projects, simply remove the c++ lines:
+
+```json
+        {
+            "name": "WSL",
+            "intelliSenseMode": "clang-x64",
+            "includePath": [
+                "${workspaceRoot}",
+                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+                "${localappdata}/lxss/rootfs/usr/local/include",
+                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+                "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+                "${localappdata}/lxss/rootfs/usr/include"
+            ],
+            "defines": [
+                "__linux__",
+                "__x86_64__"
+            ],
+            "browse": {
+                "path": [
+                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+                    "${localappdata}/lxss/rootfs/usr/local/include",
+                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+                    "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+                    "${localappdata}/lxss/rootfs/usr/include/*"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
+```
+
+## Beta
+
+For developers using Bash on Ubuntu on Windows with the beta version of WSL from before the Fall Creators Update, you can add the following configuration template to your **c_cpp_properties.json** file.
+
+```json
         {
             "name": "WSL",
             "intelliSenseMode": "clang-x64",
@@ -38,37 +122,11 @@ For developers using the Windows Subsystem for Linux, we recommend you start wit
 
 The `includePath` above includes the system header paths that gcc uses for C++ projects and matches the output of `gcc -v -E -x c++ - < /dev/null`. The intelliSenseMode should be set to **"clang-x64"** to get WSL projects to work properly with IntelliSense.
 
-For C projects, simply remove the c++ lines:
+Note that `${localappdata}/lxss/rootfs/` is the path to the root of the filesystem for Bash on Ubuntu on Windows.
 
-```
-        {
-            "name": "WSL",
-            "intelliSenseMode": "clang-x64",
-            "includePath": [
-                "${workspaceRoot}",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                "${localappdata}/lxss/rootfs/usr/local/include",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                "${localappdata}/lxss/rootfs/usr/include"
-            ],
-            "defines": [
-                "__linux__",
-                "__x86_64__"
-            ],
-            "browse": {
-                "path": [
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                    "${localappdata}/lxss/rootfs/usr/local/include",
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                    "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                    "${localappdata}/lxss/rootfs/usr/include/*"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            }
-        }
-```
+For C projects, simply remove the c++ lines as in the previous example.
+
+---
 
 With these configurations, you should be all set up to use the new IntelliSense engine for linting, memberlist autocomplete, and quick info (tooltips).  Add `"C_Cpp.intelliSenseEngine": "Default"` to your **settings.json** file to try out the new IntelliSense engine.
 

--- a/Documentation/LanguageServer/Windows Subsystem for Linux.md
+++ b/Documentation/LanguageServer/Windows Subsystem for Linux.md
@@ -9,39 +9,38 @@ Select "C/Cpp: Edit Configurations" from the command palette to create the **c_c
 For developers using Ubuntu with the current version of WSL released with the Fall Creators Update, you can add the following configuration template to your **c_cpp_properties.json** file.  
 
 ```json
-        {
-            "name": "WSL",
-            "intelliSenseMode": "clang-x64",
-            "includePath": [
-                "${workspaceRoot}",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5/backward",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
-                "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include"
-            ],
-            "defines": [
-                "__linux__",
-                "__x86_64__"
-            ],
-            "browse": {
-                "path": [
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
-                    "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/*"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            }
-        }
-
+{
+    "name": "WSL",
+    "intelliSenseMode": "clang-x64",
+    "includePath": [
+        "${workspaceRoot}",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5/backward",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+        "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include"
+    ],
+    "defines": [
+        "__linux__",
+        "__x86_64__"
+    ],
+    "browse": {
+        "path": [
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/c++/5",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/local/include",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/x86_64-linux-gnu",
+            "${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp1fndgsc/LocalState/rootfs/usr/include/*"
+        ],
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+    }
+}
 ```
 
 The `includePath` above includes the system header paths that gcc uses for C++ projects and matches the output of `gcc -v -E -x c++ - < /dev/null`. The intelliSenseMode should be set to **"clang-x64"** to get WSL projects to work properly with IntelliSense.
@@ -51,33 +50,33 @@ Note that `${localappdata}/Packages/CanonicalGroupLimited.UbuntuonWindows_79rhkp
 For C projects, simply remove the c++ lines:
 
 ```json
-        {
-            "name": "WSL",
-            "intelliSenseMode": "clang-x64",
-            "includePath": [
-                "${workspaceRoot}",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                "${localappdata}/lxss/rootfs/usr/local/include",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                "${localappdata}/lxss/rootfs/usr/include"
-            ],
-            "defines": [
-                "__linux__",
-                "__x86_64__"
-            ],
-            "browse": {
-                "path": [
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                    "${localappdata}/lxss/rootfs/usr/local/include",
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                    "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                    "${localappdata}/lxss/rootfs/usr/include/*"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            }
-        }
+{
+    "name": "WSL",
+    "intelliSenseMode": "clang-x64",
+    "includePath": [
+        "${workspaceRoot}",
+        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+        "${localappdata}/lxss/rootfs/usr/local/include",
+        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+        "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+        "${localappdata}/lxss/rootfs/usr/include"
+    ],
+    "defines": [
+        "__linux__",
+        "__x86_64__"
+    ],
+    "browse": {
+        "path": [
+            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+            "${localappdata}/lxss/rootfs/usr/local/include",
+            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+            "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+            "${localappdata}/lxss/rootfs/usr/include/*"
+        ],
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+    }
+}
 ```
 
 ## Beta
@@ -85,39 +84,38 @@ For C projects, simply remove the c++ lines:
 For developers using Bash on Ubuntu on Windows with the beta version of WSL from before the Fall Creators Update, you can add the following configuration template to your **c_cpp_properties.json** file.
 
 ```json
-        {
-            "name": "WSL",
-            "intelliSenseMode": "clang-x64",
-            "includePath": [
-                "${workspaceRoot}",
-                "${localappdata}/lxss/rootfs/usr/include/c++/5",
-                "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu/c++/5",
-                "${localappdata}/lxss/rootfs/usr/include/c++/5/backward",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                "${localappdata}/lxss/rootfs/usr/local/include",
-                "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                "${localappdata}/lxss/rootfs/usr/include"
-            ],
-            "defines": [
-                "__linux__",
-                "__x86_64__"
-            ],
-            "browse": {
-                "path": [
-                    "${localappdata}/lxss/rootfs/usr/include/c++/5",
-                    "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu/c++/5",
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
-                    "${localappdata}/lxss/rootfs/usr/local/include",
-                    "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
-                    "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
-                    "${localappdata}/lxss/rootfs/usr/include/*"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            }
-        }
-
+{
+    "name": "WSL (Beta)",
+    "intelliSenseMode": "clang-x64",
+    "includePath": [
+        "${workspaceRoot}",
+        "${localappdata}/lxss/rootfs/usr/include/c++/5",
+        "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+        "${localappdata}/lxss/rootfs/usr/include/c++/5/backward",
+        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+        "${localappdata}/lxss/rootfs/usr/local/include",
+        "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+        "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+        "${localappdata}/lxss/rootfs/usr/include"
+    ],
+    "defines": [
+        "__linux__",
+        "__x86_64__"
+    ],
+    "browse": {
+        "path": [
+            "${localappdata}/lxss/rootfs/usr/include/c++/5",
+            "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu/c++/5",
+            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include",
+            "${localappdata}/lxss/rootfs/usr/local/include",
+            "${localappdata}/lxss/rootfs/usr/lib/gcc/x86_64-linux-gnu/5/include-fixed",
+            "${localappdata}/lxss/rootfs/usr/include/x86_64-linux-gnu",
+            "${localappdata}/lxss/rootfs/usr/include/*"
+        ],
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+    }
+}
 ```
 
 The `includePath` above includes the system header paths that gcc uses for C++ projects and matches the output of `gcc -v -E -x c++ - < /dev/null`. The intelliSenseMode should be set to **"clang-x64"** to get WSL projects to work properly with IntelliSense.


### PR DESCRIPTION
Docs needed an updated since the current version of WSL from the Fall Creators Update needs a different configuration to the beta version. See #1148.

It does feel kind of wrong having a path going inside a Windows App folder, but it works. I wonder whether WSL should add some environment variables for `rootfs` instead, though thats not really an issue for this repo.