### PR TITLE
Fix syntax error in JSON

### DIFF
--- a/Documentation/LanguageServer/c_cpp_properties.json.md
+++ b/Documentation/LanguageServer/c_cpp_properties.json.md
@@ -9,7 +9,7 @@
             "intelliSenseMode": "msvc-x64",
             "includePath": [ "${workspaceRoot}" ],
             "defines": [ "FOO", "BAR=100" ],
-            "compileCommands": "/path/to/compile_commands.json"
+            "compileCommands": "/path/to/compile_commands.json",
             "browse": {
                 "path": [ "${workspaceRoot}" ],
                 "limitSymbolsToIncludedHeaders": true,


### PR DESCRIPTION
The `c_cpp_properties.json` example file was missing a comma in the reference for `c_cpp_properties.json`