### PR TITLE
Changes to copy from installed extension if CPPTOOLS_DEV has been set.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1018,10 +1018,10 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "tsc -p ./ && node ./out/src/Debugger/copyScript.js",
+    "vscode:prepublish": "npm install && tsc -p ./ && node ./out/src/Debugger/copyScript.js",
     "pretest": "tsc -p ./",
     "test": "mocha -u tdd ./out/test",
-    "compile": "tsc -watch -p ./",
+    "compile": "npm run vscode:prepublish && tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {


### PR DESCRIPTION
We still allow overrides for different package locations but this will
use the vscode extension folder as a fallback if you have the extension
installed to get the extension location.

