### PR TITLE
Fix rename error and its message and linux build

### DIFF
--- a/Extension/src/Debugger/copyScript.ts
+++ b/Extension/src/Debugger/copyScript.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All Rights Reserved.
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
+'use strict';
 
 /**
  * This file is used for packaging the application and should not be referenced

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -151,7 +151,7 @@ function removeUnnecessaryFile(): Promise<void> {
         if (fs.existsSync(sourcePath)) {
             fs.rename(sourcePath, util.getDebugAdaptersPath("bin/OpenDebugAD7.exe.config.unused"), (err: NodeJS.ErrnoException) => {
                 if (err) {
-                    getOutputChannelLogger().appendLine(`ERROR: fs.rename failed with "${err.message}". Delete ${sourcePath} manually.`);
+                    getOutputChannelLogger().appendLine(`ERROR: fs.rename failed with "${err.message}". Delete ${sourcePath} manually to enable debugging.`);
                 }
             });
         }

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -78,6 +78,9 @@ async function offlineInstallation(): Promise<void> {
     setInstallationStage('makeOfflineBinariesExecutable');
     await makeOfflineBinariesExecutable(info);
 
+    setInstallationStage('removeUnnecessaryFile');
+    await removeUnnecessaryFile();
+
     setInstallationStage('rewriteManifest');
     await rewriteManifest();
 
@@ -147,7 +150,9 @@ function removeUnnecessaryFile(): Promise<void> {
         let sourcePath: string = util.getDebugAdaptersPath("bin/OpenDebugAD7.exe.config");
         if (fs.existsSync(sourcePath)) {
             fs.rename(sourcePath, util.getDebugAdaptersPath("bin/OpenDebugAD7.exe.config.unused"), (err: NodeJS.ErrnoException) => {
-                getOutputChannelLogger().appendLine("removeUnnecessaryFile: fs.rename failed");
+                if (err) {
+                    getOutputChannelLogger().appendLine(`ERROR: fs.rename failed with "${err.message}". Delete ${sourcePath} manually.`);
+                }
             });
         }
     }


### PR DESCRIPTION
Rename was always outputting an error message since the callback is
always called. Included and error check. For offline install, if
opendebug.exe.config exists, rename needs to happen too. Added function
call for offline installation.

'use strict' was erroring on ubuntu build in copyScript.ts