### PR TITLE
Inactive region highlight

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -656,7 +656,7 @@ class DefaultClient implements Client {
         };
         let decoration: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType(renderOptions);
 
-        // As InactiveRegionParams.regions is deserialized as POD, we must convert to vscode.Ranges in order to make use of the API's
+        // We must convert to vscode.Ranges in order to make use of the API's
         let ranges: vscode.Range[] = [];
         params.regions.forEach(element => {
             let newRange : vscode.Range = new vscode.Range(element.startLine, 0, element.endLine, 0);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -75,8 +75,8 @@ interface InactiveRegionParams {
 }
 
 interface InputRange {
-    start: { line: number, character: number };
-    end: { line: number, character: number };
+    start: { line: number; character: number };
+    end: { line: number; character: number };
 }
 
 interface DecorationRangesPair {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -137,8 +137,9 @@ function collectSettingsForTelemetry(filter: (key: string, val: string, settings
         let curSetting: any = util.packageJson.contributes.configuration.properties["C_Cpp." + key];
         if (curSetting) {
             let curEnum: any[] = curSetting["enum"];
-            if (curEnum && curEnum.indexOf(val) === -1)
+            if (curEnum && curEnum.indexOf(val) === -1) {
                 continue;
+            }
         }
 
         if (filter(key, val, settings)) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -655,6 +655,12 @@ class DefaultClient implements Client {
             dark: { color: "rgba(155,155,155,1.0)" }
         };
         let decoration: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType(renderOptions);
+        // // Handle edge case where file is emptied of text
+        // if (params.ranges.length === 0) {
+        //     valuePair.decoration.dispose();
+        //     this.inactiveRegionsDecorations.delete(params.uri);
+        //     return;
+        // }
 
         // As InactiveRegionParams.ranges is deserialized as POD, we must convert to vscode.Ranges in order to make use of the API's
         let ranges: vscode.Range[] = [];
@@ -662,18 +668,20 @@ class DefaultClient implements Client {
             ranges.push(new vscode.Range(element.start.line, element.start.character, element.end.line, element.end.character));
         });
 
-        // Recycle the active text decorations when we receive a new set of inactive regions
+        // Find entry for cached file and act accordingly
         let valuePair: DecorationRangesPair = this.inactiveRegionsDecorations.get(params.uri);
         if (valuePair) {
-            // The language server will send notifications regardless of whether the ranges have changed, so we must check to see if the new data reflects a change
-            if (!this.areRangesEqual(valuePair.ranges, ranges)) {
-                // Disposing of and resetting the decoration will undo previously applied text decorations
-                valuePair.decoration.dispose();
-                valuePair.decoration = decoration;
+            // // Check to see if the new data reflects a change, as the language server will send notifications that we may not want to act upon
+            // if (this.areRangesEqual(valuePair.ranges, ranges)) {
+            //     return;
+            // }
 
-                // As vscode.TextEditor.setDecorations only applies to visible editors, we must cache the range for when another editor becomes visible
-                valuePair.ranges = ranges;
-            }
+            // Disposing of and resetting the decoration will undo previously applied text decorations
+            valuePair.decoration.dispose();
+            valuePair.decoration = decoration;
+
+            // As vscode.TextEditor.setDecorations only applies to visible editors, we must cache the range for when another editor becomes visible
+            valuePair.ranges = ranges;
         } else { // The entry does not exist. Make a new one
             let toInsert: DecorationRangesPair = {
                 decoration: decoration,

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -71,7 +71,12 @@ interface OutputNotificationBody {
 
 interface InactiveRegionParams {
     uri: string;
-    ranges: vscode.Range[];
+    ranges: InputRange[];
+}
+
+interface InputRange {
+    start: { line: number, character: number };
+    end: { line: number, character: number };
 }
 
 interface DecorationRangesPair {
@@ -651,22 +656,28 @@ class DefaultClient implements Client {
         };
         let decoration: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType(renderOptions);
 
+        // As InactiveRegionParams.ranges is deserialized as POD, we must convert to vscode.Ranges in order to make use of the API's
+        let ranges: vscode.Range[] = [];
+        params.ranges.forEach(element => {
+            ranges.push(new vscode.Range(element.start.line, element.start.character, element.end.line, element.end.character));
+        });
+
         // Recycle the active text decorations when we receive a new set of inactive regions
         let valuePair: DecorationRangesPair = this.inactiveRegionsDecorations.get(params.uri);
         if (valuePair) {
-            // The language server will send notifications regardless of whether the ranges have changed
-            if (!this.areRangesEqual(valuePair.ranges, params.ranges)) {
+            // The language server will send notifications regardless of whether the ranges have changed, so we must check to see if the new data reflects a change
+            if (!this.areRangesEqual(valuePair.ranges, ranges)) {
                 // Disposing of and resetting the decoration will undo previously applied text decorations
                 valuePair.decoration.dispose();
                 valuePair.decoration = decoration;
 
                 // As vscode.TextEditor.setDecorations only applies to visible editors, we must cache the range for when another editor becomes visible
-                valuePair.ranges = params.ranges;
+                valuePair.ranges = ranges;
             }
         } else { // The entry does not exist. Make a new one
             let toInsert: DecorationRangesPair = {
                 decoration: decoration,
-                ranges: params.ranges
+                ranges: ranges
             };
             this.inactiveRegionsDecorations.set(params.uri, toInsert);
         }
@@ -674,7 +685,7 @@ class DefaultClient implements Client {
         // Apply the decorations to all *visible* text editors
         let editors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => e.document.uri.toString() === params.uri);
         for (let e of editors) {
-            e.setDecorations(decoration, params.ranges);
+            e.setDecorations(decoration, ranges);
         }
     }
 


### PR DESCRIPTION
- Remove Ranges equality comparison as it is only a topical fix for incorrect messages on partial reparses of files from the language server
- InputRanges replaced with InputRegions. As inactive regions apply to the whole line, having the character number information is not needed