### PR TITLE
define `__CHAR_BIT__` for Mac

### DIFF
--- a/Extension/bin/msvc.64.darwin.json
+++ b/Extension/bin/msvc.64.darwin.json
@@ -2,7 +2,8 @@
     "defaults": [
       "--clang",
       "--pack_alignment",
-      "8"
+      "8",
+      "-D__CHAR_BIT__=8"
     ],
     "defaults_op" :  "merge"
   }


### PR DESCRIPTION
The same define is already set on linux.  For some reason it was not added to the Mac config.  This is needed for #1510 since default defines won't make it into the Feb release.