### PR TITLE
define `__CHAR_BIT__` for Mac

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix error popup appearing with non-workspace files when using `compile_commands.json`. [#1475](https://github.com/Microsoft/vscode-cpptools/issues/1475)
 * Fix snippet completions being blocked after `#`. [#1531](https://github.com/Microsoft/vscode-cpptools/issues/1531)
 * Add more macros to `cpp.hint` (fixing missing symbols).
+* Add `__CHAR_BIT__=8` to default defines on Mac. [#1510](https://github.com/Microsoft/vscode-cpptools/issues/1510)
 * Added support for config variables to `c_cpp_properties.json`. [#314](https://github.com/Microsoft/vscode-cpptools/issues/314)
   * Joshua Cannon (@thejcannon) [PR #1529](https://github.com/Microsoft/vscode-cpptools/pull/1529)
 * Define `_UNICODE` by default on Windows platforms. [#1538](https://github.com/Microsoft/vscode-cpptools/issues/1538)

--- a/Extension/bin/msvc.64.darwin.json
+++ b/Extension/bin/msvc.64.darwin.json
@@ -2,7 +2,8 @@
     "defaults": [
       "--clang",
       "--pack_alignment",
-      "8"
+      "8",
+      "-D__CHAR_BIT__=8"
     ],
     "defaults_op" :  "merge"
   }


### PR DESCRIPTION
The same define is already set on linux. For some reason it was not added to the Mac config. This is needed for #1510 since default defines won't make it into the Feb release.