### PR TITLE
Add a setting to manage inactive region colorization

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,8 +1,10 @@
 # C/C++ for Visual Studio Code Change Log
 
 ## Version 0.15.1: March 2018
+* Enable autocomplete for local and global scopes. [#13](https://github.com/Microsoft/vscode-cpptools/issues/13)
 * Support additional multiline comment patterns. [#1100](https://github.com/Microsoft/vscode-cpptools/issues/1100),[#1539](https://github.com/Microsoft/vscode-cpptools/issues/1539)
   * Added new setting: `C_Cpp.commentContinuationPatterns`
+* Add a setting to disable inactive region highlighting. [#1592](https://github.com/Microsoft/vscode-cpptools/issues/1592)
 
 ## Version 0.15.0: February 15, 2018
 * Add colorization for inactive regions. [#1466](https://github.com/Microsoft/vscode-cpptools/issues/1466)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -139,6 +139,12 @@
           "description": "Controls whether suspected compile errors detected by the IntelliSense engine will be reported back to the editor. Warnings about #includes that could not be located will always be reported to the editor. This setting is ignored by the Tag Parser engine.",
           "scope": "resource"
         },
+        "C_Cpp.dimInactiveRegions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether inactive preprocessor blocks are colored differently than active code. This setting is ignored by the Tag Parser engine.",
+          "scope": "resource"
+        },
         "C_Cpp.formatting": {
           "type": "string",
           "enum": [
@@ -265,6 +271,11 @@
       {
         "command": "C_Cpp.ToggleIncludeFallback",
         "title": "Toggle IntelliSense Engine Fallback on Include Errors",
+        "category": "C/Cpp"
+      },
+      {
+        "command": "C_Cpp.ToggleDimInactiveRegions",
+        "title": "Toggle Inactive Region Colorization",
         "category": "C/Cpp"
       },
       {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -394,6 +394,7 @@ class DefaultClient implements Client {
                 intelliSenseEngineFallback: settings.intelliSenseEngineFallback,
                 autocomplete: settings.autoComplete,
                 errorSquiggles: settings.errorSquiggles,
+                dimInactiveRegions: settings.dimInactiveRegions,
                 loggingLevel: settings.loggingLevel,
                 workspaceParsingPriority: settings.workspaceParsingPriority,
                 exclusionPolicy: settings.exclusionPolicy
@@ -450,11 +451,14 @@ class DefaultClient implements Client {
     }
 
     public onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
-        //Apply text decorations to inactive regions
-        for (let e of editors) {
-            let valuePair: DecorationRangesPair = this.inactiveRegionsDecorations.get(e.document.uri.toString());
-            if (valuePair) {
-                e.setDecorations(valuePair.decoration, valuePair.ranges); // VSCode clears the decorations when the text editor becomes invisible
+        let settings: CppSettings = new CppSettings(this.RootUri);
+        if (settings.dimInactiveRegions) {
+            //Apply text decorations to inactive regions
+            for (let e of editors) {
+                let valuePair: DecorationRangesPair = this.inactiveRegionsDecorations.get(e.document.uri.toString());
+                if (valuePair) {
+                    e.setDecorations(valuePair.decoration, valuePair.ranges); // VSCode clears the decorations when the text editor becomes invisible
+                }
             }
         }
     }
@@ -729,10 +733,13 @@ class DefaultClient implements Client {
             this.inactiveRegionsDecorations.set(params.uri, toInsert);
         }
 
-        // Apply the decorations to all *visible* text editors
-        let editors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => e.document.uri.toString() === params.uri);
-        for (let e of editors) {
-            e.setDecorations(decoration, ranges);
+        let settings: CppSettings = new CppSettings(this.RootUri);
+        if (settings.dimInactiveRegions) {
+            // Apply the decorations to all *visible* text editors
+            let editors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => e.document.uri.toString() === params.uri);
+            for (let e of editors) {
+                e.setDecorations(decoration, ranges);
+            }
         }
     }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -193,6 +193,7 @@ function registerCommands(): void {
     disposables.push(vscode.commands.registerCommand('C_Cpp.AddToIncludePath', onAddToIncludePath));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ToggleErrorSquiggles', onToggleSquiggles));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ToggleIncludeFallback', onToggleIncludeFallback));
+    disposables.push(vscode.commands.registerCommand('C_Cpp.ToggleDimInactiveRegions', onToggleDimInactiveRegions));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ShowReleaseNotes', onShowReleaseNotes));
     disposables.push(vscode.commands.registerCommand('C_Cpp.PauseParsing', onPauseParsing));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ResumeParsing', onResumeParsing));
@@ -333,6 +334,13 @@ function onToggleIncludeFallback(): void {
     // This only applies to the active client.
     let settings: CppSettings = new CppSettings(clients.ActiveClient.RootUri);
     settings.toggleSetting("intelliSenseEngineFallback", "Enabled", "Disabled");
+}
+
+function onToggleDimInactiveRegions(): void {
+    onActivationEvent();
+    // This only applies to the active client.
+    let settings: CppSettings = new CppSettings(clients.ActiveClient.RootUri);
+    settings.update<boolean>("dimInactiveRegions", !settings.dimInactiveRegions);
 }
 
 function onShowReleaseNotes(): void {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -39,6 +39,7 @@ export class CppSettings extends Settings {
     public get intelliSenseEngine(): string { return super.Section.get<string>("intelliSenseEngine"); }
     public get intelliSenseEngineFallback(): string { return super.Section.get<string>("intelliSenseEngineFallback"); }
     public get errorSquiggles(): string { return super.Section.get<string>("errorSquiggles"); }
+    public get dimInactiveRegions(): boolean { return super.Section.get<boolean>("dimInactiveRegions"); }
     public get autoComplete(): string { return super.Section.get<string>("autocomplete"); }
     public get loggingLevel(): string { return super.Section.get<string>("loggingLevel"); }
     public get navigationLength(): number { return super.Section.get<number>("navigation.length", 60); }
@@ -50,6 +51,9 @@ export class CppSettings extends Settings {
     public toggleSetting(name: string, value1: string, value2: string): void {
         let value: string = super.Section.get<string>(name);
         super.Section.update(name, value === value1 ? value2 : value1, getTarget());
+    }
+    public update<T>(name: string, value: T): void {
+        super.Section.update(name, value);
     }
 }
 

--- a/Extension/src/commands.ts
+++ b/Extension/src/commands.ts
@@ -21,6 +21,7 @@ class TemporaryCommandRegistrar {
         "C_Cpp.PeekDeclaration",
         "C_Cpp.ToggleErrorSquiggles",
         "C_Cpp.ToggleIncludeFallback",
+        "C_Cpp.ToggleDimInactiveRegions",
         "C_Cpp.ShowReleaseNotes",
         "C_Cpp.ResetDatabase",
         "C_Cpp.PauseParsing",

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -300,6 +300,7 @@ function rewriteManifest(): Promise<void> {
         "onCommand:C_Cpp.PeekDeclaration",
         "onCommand:C_Cpp.ToggleErrorSquiggles",
         "onCommand:C_Cpp.ToggleIncludeFallback",
+        "onCommand:C_Cpp.ToggleDimInactiveRegions",
         "onCommand:C_Cpp.ShowReleaseNotes",
         "onCommand:C_Cpp.ResetDatabase",
         "onCommand:C_Cpp.PauseParsing",


### PR DESCRIPTION
It still needs a corresponding change from the language server process so that the lightbulb and toggle commands work, but this handles the TypeScript part.