### PR TITLE
copySourceDependencies needs to be run every time

### DIFF
--- a/Extension/src/Support/prepublish.js
+++ b/Extension/src/Support/prepublish.js
@@ -18,6 +18,7 @@ if (!process.env.CPPTOOLS_DEV && fs.existsSync('./node_modules')) {
     cp.execSync("npm install", {stdio:[0, 1, 2]});
     console.log(">> tsc -p ./");
     cp.execSync("tsc -p ./", {stdio:[0, 1, 2]});
-    console.log(">> node ./out/src/Support/copyDebuggerDependencies.js");
-    cp.execSync("node ./out/src/Support/copyDebuggerDependencies.js", {stdio:[0, 1, 2]});
 }
+// Required for nightly builds. Nightly builds do not enable CPPTOOLS_DEV.
+console.log(">> node ./out/src/Support/copyDebuggerDependencies.js");
+cp.execSync("node ./out/src/Support/copyDebuggerDependencies.js", {stdio:[0, 1, 2]});


### PR DESCRIPTION
This fixes the nightly builds. It was missing cppdbg.ad7Engine.json.