### PR TITLE
Correct Fix to make sure debugger dependencies are copied

### DIFF
--- a/Extension/src/Support/prepublish.js
+++ b/Extension/src/Support/prepublish.js
@@ -11,15 +11,25 @@
 
 const fs = require("fs");
 const cp = require("child_process");
+const path = require("path");
 if (!process.env.CPPTOOLS_DEV && fs.existsSync('./node_modules')) {
     console.log("Skipping npm install since it appears to have been executed already.");
 } else {
     console.log(">> npm install");
-    cp.execSync("npm install", {stdio:[0, 1, 2]});
+    cp.execSync("npm install", { stdio: [0, 1, 2] });
 }
 
-console.log(">> tsc -p ./");
-cp.execSync("tsc -p ./", {stdio:[0, 1, 2]});
-// Required for nightly builds. Nightly builds do not enable CPPTOOLS_DEV.
-console.log(">> node ./out/src/Support/copyDebuggerDependencies.js");
-cp.execSync("node ./out/src/Support/copyDebuggerDependencies.js", {stdio:[0, 1, 2]});
+// If the required debugger file doesn't exist, make sure it is copied.
+if (process.env.CPPTOOLS_DEV || !fs.existsSync('./debugAdapters/bin/cpptools.ad7Engine.json')) {
+    const outDir = './out/src/Support/'
+    const copyDebuggerDependenciesJSFile = path.join(outDir, 'copyDebuggerDependencies.js');
+    if (!fs.existsSync('./out/src/Support/copyDebuggerDependencies.js'))
+    {
+        console.log(">> tsc -p ./src/Support/copyDebuggerDependencies.ts");
+        cp.execSync("tsc ./src/Support/copyDebuggerDependencies.ts --outDir " + outDir, { stdio: [0, 1, 2] });
+    }
+
+    // Required for nightly builds. Nightly builds do not enable CPPTOOLS_DEV.
+    console.log(">> node " + copyDebuggerDependenciesJSFile);
+    cp.execSync("node " + copyDebuggerDependenciesJSFile, { stdio: [0, 1, 2] });
+}

--- a/Extension/src/Support/prepublish.js
+++ b/Extension/src/Support/prepublish.js
@@ -25,7 +25,7 @@ if (process.env.CPPTOOLS_DEV || !fs.existsSync('./debugAdapters/bin/cpptools.ad7
     const copyDebuggerDependenciesJSFile = path.join(outDir, 'copyDebuggerDependencies.js');
     if (!fs.existsSync('./out/src/Support/copyDebuggerDependencies.js'))
     {
-        console.log(">> tsc ./src/Support/copyDebuggerDependencies.ts");
+        console.log(">> tsc ./src/Support/copyDebuggerDependencies.ts -- outDir" + outDir);
         cp.execSync("tsc ./src/Support/copyDebuggerDependencies.ts --outDir " + outDir, { stdio: [0, 1, 2] });
     }
 

--- a/Extension/src/Support/prepublish.js
+++ b/Extension/src/Support/prepublish.js
@@ -25,7 +25,7 @@ if (process.env.CPPTOOLS_DEV || !fs.existsSync('./debugAdapters/bin/cpptools.ad7
     const copyDebuggerDependenciesJSFile = path.join(outDir, 'copyDebuggerDependencies.js');
     if (!fs.existsSync('./out/src/Support/copyDebuggerDependencies.js'))
     {
-        console.log(">> tsc -p ./src/Support/copyDebuggerDependencies.ts");
+        console.log(">> tsc ./src/Support/copyDebuggerDependencies.ts");
         cp.execSync("tsc ./src/Support/copyDebuggerDependencies.ts --outDir " + outDir, { stdio: [0, 1, 2] });
     }
 


### PR DESCRIPTION
Fix double compile and make sure that it is only run once.

@bobbrow This should fix the items in the email you sent me.