### PR TITLE
TypeScript compile needs to happen as part of prepublish step.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1105,7 +1105,7 @@
     }
   },
   "scripts": {
-    "compile": "npm run vscode:prepublish && tsc -p ./",
+    "compile": "npm run vscode:prepublish",
     "integrationTests": "gulp integrationTests",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "tsc -p ./",

--- a/Extension/src/Support/copyDebuggerDependencies.ts
+++ b/Extension/src/Support/copyDebuggerDependencies.ts
@@ -200,8 +200,6 @@ function makeDirectory(dir: string): void {
     }
 }
 
-let devWorkFlowMessage: string = '\nWARNING: If you are trying to build and run the extension locally, please set the environment variable CPPTOOLS_DEV=1 and try again.\n';
-
 if (enableDevWorkflow()) {
     removeFolder("./debugAdapters");
 }
@@ -213,5 +211,6 @@ if (enableDevWorkflow()) {
     copyMonoDependencies();
     copyBinaryDependencies();
 } else {
-    console.warn(devWorkFlowMessage);
+    console.warn('WARNING: Debugger dependencies are missing.');
+    console.log('If you are trying to build and run the extension from source and need the debugger dependencies, set the environment variable CPPTOOLS_DEV=1 and try again.');
 }

--- a/Extension/src/Support/prepublish.js
+++ b/Extension/src/Support/prepublish.js
@@ -12,22 +12,21 @@
 const fs = require("fs");
 const cp = require("child_process");
 const path = require("path");
+
 if (!process.env.CPPTOOLS_DEV && fs.existsSync('./node_modules')) {
-    console.log("Skipping npm install since it appears to have been executed already.");
+    console.warn("WARNING: Skipping npm install since it appears to have been executed already.");
 } else {
     console.log(">> npm install");
     cp.execSync("npm install", { stdio: [0, 1, 2] });
 }
 
+// Compile the TypeScript code
+console.log(">> tsc -p ./");
+cp.execSync("tsc -p ./", {stdio:[0, 1, 2]});
+
 // If the required debugger file doesn't exist, make sure it is copied.
-if (process.env.CPPTOOLS_DEV || !fs.existsSync('./debugAdapters/bin/cpptools.ad7Engine.json')) {
-    const outDir = './out/src/Support/'
-    const copyDebuggerDependenciesJSFile = path.join(outDir, 'copyDebuggerDependencies.js');
-    if (!fs.existsSync('./out/src/Support/copyDebuggerDependencies.js'))
-    {
-        console.log(">> tsc ./src/Support/copyDebuggerDependencies.ts -- outDir" + outDir);
-        cp.execSync("tsc ./src/Support/copyDebuggerDependencies.ts --outDir " + outDir, { stdio: [0, 1, 2] });
-    }
+if (process.env.CPPTOOLS_DEV || !fs.existsSync('./debugAdapters/bin/cppdbg.ad7Engine.json')) {
+    const copyDebuggerDependenciesJSFile = './out/src/Support/copyDebuggerDependencies.js';
 
     // Required for nightly builds. Nightly builds do not enable CPPTOOLS_DEV.
     console.log(">> node " + copyDebuggerDependenciesJSFile);


### PR DESCRIPTION
* Need to compile all code as part of prepublish.
* remove duplicate compile in "compile" step which calls prepublish
* Fix fs check for debugger file (wrong file name)