### PR TITLE
"taskName" changed to "label" as per version 2.0.0

### DIFF
--- a/Code Samples/SampleClangProject/.vscode/tasks.json
+++ b/Code Samples/SampleClangProject/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "clang++",
+            "label": "clang++",
             "command": "clang++ --debug -o main.exe main.cpp",
                 // "--debug" enables debugging symbols
                 // "-o main.exe" specifies the output executable


### PR DESCRIPTION
Reference Link: https://code.visualstudio.com/docs/editor/tasks#_migrating-to-tasks-200