### PR TITLE
Adding file validation for download and unzip.

### DIFF
--- a/Extension/package-lock.json
+++ b/Extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cpptools",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -409,3 +409,25 @@ export function checkDistro(platformInfo: PlatformInformation): void {
         getOutputChannelLogger().appendLine(`Warning: Debugging has not been tested for this platform. ${getReadmeMessage()}`);
     }
 }
+
+export async function unlinkPromise(fileName: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        fs.unlink(fileName, err => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve();
+        });
+    });
+}
+
+export async function renamePromise(oldName: string, newName: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        fs.rename(oldName, newName, err => {
+            if (err) {
+                return reject(err);
+            }
+            return resolve();
+        });
+    });
+}

--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -370,7 +370,7 @@ export class PackageManager {
                                                 await util.unlinkPromise(absoluteEntryTempFile);
                                             } catch (err) {
                                                 return reject(new PackageManagerError(`Error unlinking file ${absoluteEntryTempFile}`, 'InstallPackage', pkg, err));
-                                            };
+                                            }
                                         }
 
                                         // Make sure executable files have correct permissions when extracted
@@ -383,7 +383,7 @@ export class PackageManager {
                                                 await util.renamePromise(absoluteEntryTempFile, absoluteEntryPath);
                                             } catch (err) {
                                                 return reject(new PackageManagerError(`Error renaming file ${absoluteEntryTempFile}`, 'InstallPackage', pkg, err));
-                                            };
+                                            }
                                             // Wait till output is done writing before reading the next zip entry.
                                             // Otherwise, it's possible to try to launch the .exe before it is done being created.
                                             zipfile.readEntry();


### PR DESCRIPTION
Refactored the download retry code.

Added error handlers for read and write streams.

WriteStream writes to a *.tmp file and then renames. This catches the
case if VSCode dies in the middle of this process and the file is
partially written. We will continue where we left off.

Hopefully addresses issues like https://github.com/Microsoft/vscode-cpptools/issues/1661