### PR TITLE
Adding snippet to fix pipeProgram in pipeTransport

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 import * as process from 'process';
 import * as vscode from 'vscode';
 
@@ -43,36 +44,50 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
             config.pipeTransport &&
             config.pipeTransport.pipeProgram &&
             !fs.existsSync(config.pipeTransport.pipeProgram)) {
-            const winDir: string = process.env.WINDIR ? process.env.WINDIR.toLowerCase() : null;
-            const winDirAltDirSep: string =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
-
-            if (config.pipeTransport.pipeProgram.toLowerCase().indexOf(winDir) === 0 || config.pipeTransport.pipeProgram.toLowerCase().indexOf(winDirAltDirSep) === 0) {
-                const pipeProgramStr: string = config.pipeTransport.pipeProgram.toLowerCase();
-
-                if (process.arch === 'x64') {
-                    const pathSep: string = checkForFolderInPath(pipeProgramStr, "sysnative");
-                    if (pathSep) {
-                        // User has sysnative but is running VSCode 64 bit. Should be using System32 since sysnative is a 32bit concept.
-                        config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}sysnative${pathSep}`, `${pathSep}system32${pathSep}`);
-                        getOutputChannelLogger().appendLine(`WARNING: 64-bit VSCode should use System32 for the directory for pipeProgram.`);
-                        getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
-                        showOutputChannel();
-                    }
-                } else if (process.arch === 'ia32') {
-                    const pathSep: string = checkForFolderInPath(pipeProgramStr, "system32");
-                    if (pathSep) {
-                        // User has System32 but is running VSCode 32 bit. Should be using sysnative
-                        config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}system32${pathSep}`, `${pathSep}sysnative${pathSep}`);
-                        getOutputChannelLogger().appendLine(`WARNING: 32-bit VSCode should use sysnative for the directory for pipeProgram.`);
-                        getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
-                        showOutputChannel();
-                    }
-                }
+            const pipeProgramStr: string = config.pipeTransport.pipeProgram.toLowerCase().trim();
+            
+            // If pipeProgram does not get replaced and there is a pipeCwd, concatenate with pipeProgramStr and attempt to replace.
+            if (!checkAndReplaceWSLPipeProgram(config, pipeProgramStr) && config.pipeTransport.pipeCwd) {
+                const pipeCwdStr: string = config.pipeTransport.pipeCwd.toLowerCase().trim();
+                checkAndReplaceWSLPipeProgram(config, path.join(pipeCwdStr, pipeProgramStr));
             }
         }
 
         return config;
     }   
+}
+
+function checkAndReplaceWSLPipeProgram(config: any, pipeProgramStr: string): boolean {
+    let success: boolean = false;
+    const winDir: string = process.env.WINDIR ? process.env.WINDIR.toLowerCase() : null;
+    const winDirAltDirSep: string =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
+    const winDirEnv: string = "${env:windir}";
+
+    if (winDir && winDirAltDirSep && (pipeProgramStr.indexOf(winDir) === 0 || pipeProgramStr.indexOf(winDirAltDirSep) === 0 || pipeProgramStr.indexOf(winDirEnv) === 0)) {
+        if (process.arch === 'x64') {
+            const pathSep: string = checkForFolderInPath(pipeProgramStr, "sysnative");
+            if (pathSep) {
+                // User has sysnative but is running VSCode 64 bit. Should be using System32 since sysnative is a 32bit concept.
+                config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}sysnative${pathSep}`, `${pathSep}system32${pathSep}`);
+                getOutputChannelLogger().appendLine(`WARNING: 64-bit VSCode should use System32 for the directory for pipeProgram.`);
+                getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
+                showOutputChannel();
+                success = true;
+            }
+        } else if (process.arch === 'ia32') {
+            const pathSep: string = checkForFolderInPath(pipeProgramStr, "system32");
+            if (pathSep) {
+                // User has System32 but is running VSCode 32 bit. Should be using sysnative
+                config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}system32${pathSep}`, `${pathSep}sysnative${pathSep}`);
+                getOutputChannelLogger().appendLine(`WARNING: 32-bit VSCode should use sysnative for the directory for pipeProgram.`);
+                getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
+                showOutputChannel();
+                success = true;
+            }
+        }
+    }
+
+    return success;
 }
 
 // Checks to see if the folder name is in the path using both win and unix style path seperators.

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -37,8 +37,7 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
         }
 
         // Help WSL users with using the correct bash.exe
-        if (os.platform() === 'win32' && config.pipeTransport && config.pipeTransport.pipeProgram)
-        {
+        if (os.platform() === 'win32' && config.pipeTransport && config.pipeTransport.pipeProgram) {
             const pipeProgramStr: string = config.pipeTransport.pipeProgram;
 
             if (pipeProgramStr.indexOf("sysnative") >= 0 && process.arch === 'x64') {

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as os from 'os';
-import * as path from 'path';
 import * as process from 'process';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
@@ -39,8 +38,8 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
             return undefined;
         }
 
-        const winDir = process.env.WINDIR? process.env.WINDIR.toLowerCase() : null;
-        const winDirAltDirSep =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
+        const winDir: string = process.env.WINDIR ? process.env.WINDIR.toLowerCase() : null;
+        const winDirAltDirSep: string =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
 
         // Help WSL users with using the correct pipeProgram if the one they selected does not exist.
         if (os.platform() === 'win32' &&
@@ -52,19 +51,16 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
 
             if (process.arch === 'x64') {
                 const pathSep: string = checkForFolderInPath(pipeProgramStr, "sysnative");
-                if (pathSep)
-                {
+                if (pathSep) {
                     // User has sysnative but is running VSCode 64 bit. Should be using System32 since sysnative is a 32bit concept.
                     config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}sysnative${pathSep}`, `${pathSep}system32${pathSep}`);
                     getOutputChannelLogger().appendLine(`WARNING: 64-bit VSCode should use System32 for the directory for pipeProgram.`);
                     getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
                     showOutputChannel();
                 }
-            }
-            else if (process.arch === 'ia32') {
+            } else if (process.arch === 'ia32') {
                 const pathSep: string = checkForFolderInPath(pipeProgramStr, "system32");
-                if (pathSep)
-                {
+                if (pathSep) {
                     // User has System32 but is running VSCode 32 bit. Should be using sysnative
                     config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}system32${pathSep}`, `${pathSep}sysnative${pathSep}`);
                     getOutputChannelLogger().appendLine(`WARNING: 32-bit VSCode should use sysnative for the directory for pipeProgram.`);
@@ -82,8 +78,7 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
 // Returns the path seperator it detected if the folder is in the path. 
 // Or else it returns empty string to indicate it did not find it in the path.
 function checkForFolderInPath(path: string, folder: string): string {
-    if (path.indexOf(`/${folder}/`) >= 0)
-    {
+    if (path.indexOf(`/${folder}/`) >= 0) {
         return '/';
     } else if (path.indexOf(`\\${folder}\\`) >= 0) {
         return '\\';

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -5,7 +5,6 @@
 
 import * as fs from 'fs';
 import * as os from 'os';
-import * as path from 'path';
 import * as process from 'process';
 import * as vscode from 'vscode';
 

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -4,11 +4,14 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as os from 'os';
-import * as vscode from 'vscode';
+import * as path from 'path';
 import * as process from 'process';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
 import { IConfiguration, IConfigurationSnippet, DebuggerType, MIConfigurations, WindowsConfigurations, WSLConfigurations, PipeTransportConfigurations } from './configurations';
 import { parse } from 'jsonc-parser';
-import { getOutputChannelLogger, showOutputChannel } from './../logger';
+import { getOutputChannelLogger, showOutputChannel } from '../logger';
 
 abstract class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
     private type: DebuggerType;
@@ -36,27 +39,57 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
             return undefined;
         }
 
-        // Help WSL users with using the correct bash.exe
-        if (os.platform() === 'win32' && config.pipeTransport && config.pipeTransport.pipeProgram) {
-            const pipeProgramStr: string = config.pipeTransport.pipeProgram;
+        const winDir = process.env.WINDIR? process.env.WINDIR.toLowerCase() : null;
+        const winDirAltDirSep =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
 
-            if (pipeProgramStr.indexOf("sysnative") >= 0 && process.arch === 'x64') {
-                // User has sysnative but is running VSCode 64 bit. Should be using System32
-                config.pipeTransport.pipeProgram = pipeProgramStr.replace("sysnative", "System32");
-                getOutputChannelLogger().appendLine(`WARNING: 64-bit VSCode should use System32 for the directory for pipeProgram.`);
-                getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
-                showOutputChannel();
-            } else if (pipeProgramStr.indexOf("System32") >= 0 && process.arch === 'ia32') {
-                // User has System32 but is running VSCode 32 bit. Should be using sysnative
-                config.pipeTransport.pipeProgram = pipeProgramStr.replace("System32", "sysnative");
-                getOutputChannelLogger().appendLine(`WARNING: 32-bit VSCode should use sysnative for the directory for pipeProgram.`);
-                getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
-                showOutputChannel();
+        // Help WSL users with using the correct pipeProgram if the one they selected does not exist.
+        if (os.platform() === 'win32' &&
+            config.pipeTransport &&
+            config.pipeTransport.pipeProgram &&
+            !fs.existsSync(config.pipeTransport.pipeProgram) &&
+            (config.pipeTransport.pipeProgram.toLowerCase().indexOf(winDir) >= 0 || config.pipeTransport.pipeProgram.toLowerCase().indexOf(winDirAltDirSep) >= 0)) {
+            const pipeProgramStr: string = config.pipeTransport.pipeProgram.toLowerCase();
+
+            if (process.arch === 'x64') {
+                const pathSep: string = checkForFolderInPath(pipeProgramStr, "sysnative");
+                if (pathSep)
+                {
+                    // User has sysnative but is running VSCode 64 bit. Should be using System32 since sysnative is a 32bit concept.
+                    config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}sysnative${pathSep}`, `${pathSep}system32${pathSep}`);
+                    getOutputChannelLogger().appendLine(`WARNING: 64-bit VSCode should use System32 for the directory for pipeProgram.`);
+                    getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
+                    showOutputChannel();
+                }
+            }
+            else if (process.arch === 'ia32') {
+                const pathSep: string = checkForFolderInPath(pipeProgramStr, "system32");
+                if (pathSep)
+                {
+                    // User has System32 but is running VSCode 32 bit. Should be using sysnative
+                    config.pipeTransport.pipeProgram = pipeProgramStr.replace(`${pathSep}system32${pathSep}`, `${pathSep}sysnative${pathSep}`);
+                    getOutputChannelLogger().appendLine(`WARNING: 32-bit VSCode should use sysnative for the directory for pipeProgram.`);
+                    getOutputChannelLogger().appendLine(`pipeProgram has been modified to be: ${config.pipeTransport.pipeProgram}`);
+                    showOutputChannel();
+                }
             }
         }
 
         return config;
     }   
+}
+
+// Checks to see if the folder name is in the path using both win and unix style path seperators.
+// Returns the path seperator it detected if the folder is in the path. 
+// Or else it returns empty string to indicate it did not find it in the path.
+function checkForFolderInPath(path: string, folder: string): string {
+    if (path.indexOf(`/${folder}/`) >= 0)
+    {
+        return '/';
+    } else if (path.indexOf(`\\${folder}\\`) >= 0) {
+        return '\\';
+    }
+
+    return "";
 }
 
 export class CppVsDbgConfigurationProvider extends CppConfigurationProvider {

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -218,7 +218,8 @@ export class WindowsConfigurations extends Configuration {
 }
 
 export class WSLConfigurations extends Configuration {
-    public bashPipeProgram = "C:\\\\Windows\\\\sysnative\\\\bash.exe";
+    // Detects if the current VSCode is 32-bit and uses the correct bash.exe
+    public bashPipeProgram = process.arch === 'ia32' ? "${env:windir}\\\\sysnative\\\\bash.exe" : "${env:windir}\\\\system32\\\\bash.exe";
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
         let name: string = `(${this.MIMode}) Bash on Windows Launch`;


### PR DESCRIPTION
Now with VSCode 64 bit, WSL users need to use the correct pipeProgram in
the correct folder. We will attempt to help users with this.

@gregg-miskelly