### PR TITLE
Prevent package.json rewrite from being checked in with test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,9 @@ script:
   - npm install
   - npm run tslint
   - npm run compile
-  - npm run test
+  # pr-check needs to run before test. test modifies package.json.
   - npm run pr-check
+  - npm run test
 
 after_failure:
   - find ~ -name "integrationTests.log" -type f -exec cat {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - npm run tslint
   - npm run compile
   - npm run test
+  - npm run pr-check
 
 after_failure:
   - find ~ -name "integrationTests.log" -type f -exec cat {} \;

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -9,6 +9,7 @@ const gulp = require('gulp');
 const env = require('gulp-env')
 const tslint = require('gulp-tslint');
 const mocha = require('gulp-mocha');
+const fs = require('fs');
 
 gulp.task('allTests', () => {
     gulp.start('unitTests');
@@ -73,4 +74,12 @@ gulp.task('tslint', () => {
             summarizeFailureOutput: false,
             emitError: false
         }))
+});
+
+gulp.task('pr-check', () => {
+    const packageJson = JSON.parse(fs.readFileSync('./package.json').toString());
+    if (packageJson.activationEvents.length !== 1 &&  packageJson.activationEvents[0] !== '*') {
+        console.log('Please make sure to not check in package.json that has been rewritten by the extension activation. If you have modified package.json, please only make your changes. If you did not, please run `git checkout package.json`.');
+        process.exit(1);
+    }
 });

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('tslint', () => {
 gulp.task('pr-check', () => {
     const packageJson = JSON.parse(fs.readFileSync('./package.json').toString());
     if (packageJson.activationEvents.length !== 1 &&  packageJson.activationEvents[0] !== '*') {
-        console.log('Please make sure to not check in package.json that has been rewritten by the extension activation. If you have modified package.json, please only make your changes. If you did not, please run `git checkout package.json`.');
+        console.log('Please make sure to not check in package.json that has been rewritten by the extension activation. If you intended to have changes in package.json, please only check-in your changes. If you did not, please run `git checkout -- package.json`.');
         process.exit(1);
     }
 });

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1109,6 +1109,7 @@
     "integrationTests": "gulp integrationTests",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "tsc -p ./",
+    "pr-check": "gulp pr-check",
     "test": "gulp allTests",
     "tslint": "gulp tslint",
     "unitTests": "gulp unitTests",

--- a/Extension/src/abTesting.ts
+++ b/Extension/src/abTesting.ts
@@ -80,16 +80,17 @@ export function downloadCpptoolsJsonPkg(): Promise<void> {
 export function processCpptoolsJson(cpptoolsString: string): Promise<void> {
     let cpptoolsObject: any = JSON.parse(cpptoolsString);
     let intelliSenseEnginePercentage: number = cpptoolsObject.intelliSenseEngine_default_percentage;
+    let packageJson: any = util.getRawPackageJson();
 
-    if (!util.packageJson.extensionFolderPath.includes(".vscode-insiders")) {
-        let prevIntelliSenseEngineDefault: any = util.packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default;
+    if (!packageJson.extensionFolderPath.includes(".vscode-insiders")) {
+        let prevIntelliSenseEngineDefault: any = packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default;
         if (util.extensionContext.globalState.get<number>(userBucketString, userBucketMax + 1) <= intelliSenseEnginePercentage) {
-            util.packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default = "Default";
+            packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default = "Default";
         } else {
-            util.packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default = "Tag Parser";
+            packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default = "Tag Parser";
         }
-        if (prevIntelliSenseEngineDefault !== util.packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default) {
-            return util.writeFileText(util.getPackageJsonPath(), util.getPackageJsonString());
+        if (prevIntelliSenseEngineDefault !== packageJson.contributes.configuration.properties["C_Cpp.intelliSenseEngine"].default) {
+            return util.writeFileText(util.getPackageJsonPath(), util.stringifyPackageJson(packageJson));
         }
     }
 }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -20,17 +20,33 @@ export function setExtensionContext(context: vscode.ExtensionContext): void {
     extensionContext = context;
 }
 
-export let packageJson: any = vscode.extensions.getExtension("ms-vscode.cpptools").packageJSON;
+// Use this package.json to read values
+export const packageJson: any = vscode.extensions.getExtension("ms-vscode.cpptools").packageJSON;
+
+// Use getRawPackageJson to read and write back to package.json
+// This prevents obtaining any of VSCode's expanded variables.
+let rawPackageJson: any = null;
+export function getRawPackageJson(): any {
+    if (rawPackageJson === null) {
+        const fileContents: Buffer = fs.readFileSync(getPackageJsonPath());
+        rawPackageJson = JSON.parse(fileContents.toString());
+    }
+    return rawPackageJson;
+}
+
+// This function is used to stringify the rawPackageJson.
+// Do not use with util.packageJson or else the expanded
+// package.json will be written back.
+export function stringifyPackageJson(packageJson: string): string {
+    return JSON.stringify(packageJson, null, 2);
+}
 
 export function getExtensionFilePath(extensionfile: string): string {
     return path.resolve(extensionContext.extensionPath, extensionfile);
 }
+
 export function getPackageJsonPath(): string {
     return getExtensionFilePath("package.json");
-}
-export function getPackageJsonString(): string {
-    packageJson.main = "./out/src/main"; // Needs to be reset, because the relative path is removed by VS Code.
-    return JSON.stringify(packageJson, null, 2);
 }
 
 // Extension is ready if install.lock exists and debugAdapters folder exist.

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -287,7 +287,9 @@ async function finalizeExtensionActivation(): Promise<void> {
 
 function rewriteManifest(): Promise<void> {
     // Replace activationEvents with the events that the extension should be activated for subsequent sessions.
-    util.packageJson.activationEvents = [
+    let packageJson: any = util.getRawPackageJson();
+    
+    packageJson.activationEvents = [
         "onLanguage:cpp",
         "onLanguage:c",
         "onCommand:extension.pickNativeProcess",
@@ -310,5 +312,5 @@ function rewriteManifest(): Promise<void> {
         "onDebug"
     ];
 
-    return util.writeFileText(util.getPackageJsonPath(), util.getPackageJsonString());
+    return util.writeFileText(util.getPackageJsonPath(), util.stringifyPackageJson(packageJson));
 }


### PR DESCRIPTION
VSCode package.json is readonly.

Rewriting package.json will use the disk package.json to prevent getting
expanded fields from VSCode. It will only read from disk once.

Added `gulp pr-check` to make sure that package.json activationEvents has
not been rewritten for open source contributers.