### PR TITLE
Adding snippet to fix pipeProgram in pipeTransport

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -6,7 +6,6 @@
 import * as debugUtils from './utils';
 import * as os from 'os';
 import * as path from 'path';
-import * as process from 'process';
 import * as vscode from 'vscode';
 
 import { IConfiguration, IConfigurationSnippet, DebuggerType, MIConfigurations, WindowsConfigurations, WSLConfigurations, PipeTransportConfigurations } from './configurations';
@@ -38,9 +37,8 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
             return undefined;
         }
 
-        // Modify WSL config on 64-bit VSCode for OpenDebugAD7
+        // Modify WSL config for OpenDebugAD7
         if (os.platform() === 'win32' &&
-            process.arch === 'x64' &&
             config.pipeTransport &&
             config.pipeTransport.pipeProgram) {
             let replacedPipeProgram: string = null;
@@ -50,7 +48,7 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
             replacedPipeProgram = debugUtils.ArchitectureReplacer.checkAndReplaceWSLPipeProgram(pipeProgramStr, debugUtils.ArchType.ia32);
 
             // If pipeProgram does not get replaced and there is a pipeCwd, concatenate with pipeProgramStr and attempt to replace.
-            if (!replacedPipeProgram && config.pipeTransport.pipeCwd) {
+            if (!replacedPipeProgram && !path.isAbsolute(pipeProgramStr) && config.pipeTransport.pipeCwd) {
                 const pipeCwdStr: string = config.pipeTransport.pipeCwd.toLowerCase().trim();
                 const newPipeProgramStr: string = path.join(pipeCwdStr, pipeProgramStr);
                 

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -3,8 +3,13 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import * as debugUtils from './utils';
+import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
+import * as process from 'process';
 import * as vscode from 'vscode';
+
 import { IConfiguration, IConfigurationSnippet, DebuggerType, MIConfigurations, WindowsConfigurations, WSLConfigurations, PipeTransportConfigurations } from './configurations';
 import { parse } from 'jsonc-parser';
 
@@ -32,6 +37,30 @@ abstract class CppConfigurationProvider implements vscode.DebugConfigurationProv
         if (config.type === 'cppvsdbg' && os.platform() !== 'win32') {
             vscode.window.showErrorMessage("Debugger of type: 'cppvsdbg' is only available on Windows. Use type: 'cppdbg' on the current OS platform.");
             return undefined;
+        }
+
+        // Modify WSL config on 64-bit VSCode for OpenDebugAD7
+        if (os.platform() === 'win32' &&
+            process.arch === 'x64' &&
+            config.pipeTransport &&
+            config.pipeTransport.pipeProgram) {
+            let replacedPipeProgram: string = null;
+            const pipeProgramStr: string = config.pipeTransport.pipeProgram.toLowerCase().trim();
+
+            // OpenDebugAD7 is a 32-bit process. Make sure the WSL pipe transport is using the correct program.
+            replacedPipeProgram = debugUtils.ArchitectureReplacer.checkAndReplaceWSLPipeProgram(pipeProgramStr, debugUtils.ArchType.ia32);
+
+            // If pipeProgram does not get replaced and there is a pipeCwd, concatenate with pipeProgramStr and attempt to replace.
+            if (!replacedPipeProgram && config.pipeTransport.pipeCwd) {
+                const pipeCwdStr: string = config.pipeTransport.pipeCwd.toLowerCase().trim();
+                const newPipeProgramStr: string = path.join(pipeCwdStr, pipeProgramStr);
+                
+                replacedPipeProgram = debugUtils.ArchitectureReplacer.checkAndReplaceWSLPipeProgram(newPipeProgramStr, debugUtils.ArchType.ia32);
+            }
+
+            if (replacedPipeProgram) {
+                config.pipeTransport.pipeProgram = replacedPipeProgram;
+            }
         }
 
         return config;

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as debugUtils from './utils';
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as process from 'process';

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -218,7 +218,8 @@ export class WindowsConfigurations extends Configuration {
 }
 
 export class WSLConfigurations extends Configuration {
-    public bashPipeProgram = "C:\\\\Windows\\\\sysnative\\\\bash.exe";
+    // Detects if the current VSCode is 32-bit and uses the correct bash.exe
+    public bashPipeProgram = process.arch === 'ia32' ? "${env:windir}\\\\sysnative\\\\bash.exe" : "${env:windir}\\\\system32\\\\bash.exe";
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
         let name: string = `(${this.MIMode}) Bash on Windows Launch`;

--- a/Extension/src/Debugger/utils.ts
+++ b/Extension/src/Debugger/utils.ts
@@ -1,0 +1,49 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export enum ArchType {
+    ia32,
+    x64
+}
+
+export class ArchitectureReplacer {
+    public static checkAndReplaceWSLPipeProgram(pipeProgramStr: string, expectedArch: ArchType): string {
+        let replacedPipeProgram: string = null;
+        const winDir: string = process.env.WINDIR ? process.env.WINDIR.toLowerCase() : null;
+        const winDirAltDirSep: string =  process.env.WINDIR ? process.env.WINDIR.replace('\\', '/').toLowerCase() : null;
+        const winDirEnv: string = "${env:windir}";
+
+        if (winDir && winDirAltDirSep && (pipeProgramStr.indexOf(winDir) === 0 || pipeProgramStr.indexOf(winDirAltDirSep) === 0 || pipeProgramStr.indexOf(winDirEnv) === 0)) {
+            if (expectedArch === ArchType.x64) {
+                const pathSep: string = ArchitectureReplacer.checkForFolderInPath(pipeProgramStr, "sysnative");
+                if (pathSep) {
+                    // User has sysnative but we expect 64 bit. Should be using System32 since sysnative is a 32bit concept.
+                    replacedPipeProgram = pipeProgramStr.replace(`${pathSep}sysnative${pathSep}`, `${pathSep}system32${pathSep}`);
+                }
+            } else if (expectedArch === ArchType.ia32) {
+                const pathSep: string = ArchitectureReplacer.checkForFolderInPath(pipeProgramStr, "system32");
+                if (pathSep) {
+                    // User has System32 but we expect 32 bit. Should be using sysnative
+                    replacedPipeProgram = pipeProgramStr.replace(`${pathSep}system32${pathSep}`, `${pathSep}sysnative${pathSep}`);
+                }
+            }
+        }
+
+        return replacedPipeProgram;
+    }
+
+    // Checks to see if the folder name is in the path using both win and unix style path seperators.
+    // Returns the path seperator it detected if the folder is in the path. 
+    // Or else it returns empty string to indicate it did not find it in the path.
+    public static checkForFolderInPath(path: string, folder: string): string {
+        if (path.indexOf(`/${folder}/`) >= 0) {
+            return '/';
+        } else if (path.indexOf(`\\${folder}\\`) >= 0) {
+            return '\\';
+        }
+
+        return "";
+    }
+}


### PR DESCRIPTION
Note: The other PR #1752 got into a bad state so I created a new one.

Now with VSCode 64 bit, WSL users need to use the correct pipeProgram in
the correct folder. We will attempt to help users with this.

@gregg-miskelly can you take a look at this one?