### PR TITLE
shouldn't be attempting to re-register vscode's commands

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -437,14 +437,6 @@
         "category": "C/Cpp"
       },
       {
-        "command": "workbench.action.gotoSymbol",
-        "title": "Go to Symbol in File..."
-      },
-      {
-        "command": "workbench.action.showAllSymbols",
-        "title": "Go to Symbol in Workspace..."
-      },
-      {
         "command": "C_Cpp.ShowReleaseNotes",
         "title": "Show Release Notes",
         "category": "C/Cpp"


### PR DESCRIPTION
Noticed in customer logs for issue #1873