### PR TITLE
Adding OptionsSchema generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ script:
   # Build and then run tests
   - cd Extension
   - npm install
-  - npm run tslint
   - npm run compile
+  - npm run tslint
   # pr-check needs to run before test. test modifies package.json.
   - npm run pr-check
   - npm run test

--- a/Extension/.vscodeignore
+++ b/Extension/.vscodeignore
@@ -11,4 +11,5 @@ CMakeLists.txt
 debugAdapters/install.lock*
 out/src/Debugger/copyScript.js
 tools/**
+out/tools/**
 notices/**

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -10,6 +10,7 @@ const env = require('gulp-env')
 const tslint = require('gulp-tslint');
 const mocha = require('gulp-mocha');
 const fs = require('fs');
+const optionsSchemaGenerator = require('./out/tools/GenerateOptionsSchema');
 
 gulp.task('allTests', () => {
     gulp.start('unitTests');
@@ -82,4 +83,8 @@ gulp.task('pr-check', () => {
         console.log('Please make sure to not check in package.json that has been rewritten by the extension activation. If you intended to have changes in package.json, please only check-in your changes. If you did not, please run `git checkout -- package.json`.');
         process.exit(1);
     }
+});
+
+gulp.task('generateOptionsSchema', () => {
+    optionsSchemaGenerator.GenerateOptionsSchema();
 });

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -533,6 +533,7 @@
         },
         "configurationAttributes": {
           "launch": {
+            "type": "object",
             "required": [
               "program"
             ],
@@ -719,8 +720,8 @@
                 }
               },
               "logging": {
-                "type": "object",
                 "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
+                "type": "object",
                 "default": {},
                 "properties": {
                   "exceptions": {
@@ -759,10 +760,10 @@
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the MI-enabled debugger backend executable (such as gdb).",
                 "type": "object",
                 "default": {
-                  "pipeCwd": "${workspaceRoot}",
+                  "pipeCwd": "/usr/bin",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/gdb"
+                  "debuggerPath": "The full path to the debugger on the target machine, for example /usr/bin/gdb."
                 },
                 "properties": {
                   "pipeCwd": {
@@ -801,6 +802,7 @@
             }
           },
           "attach": {
+            "type": "object",
             "required": [
               "program",
               "processId"
@@ -883,8 +885,8 @@
                 }
               },
               "logging": {
-                "type": "object",
                 "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
+                "type": "object",
                 "default": {},
                 "properties": {
                   "exceptions": {
@@ -923,10 +925,10 @@
                 "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the MI-enabled debugger backend executable (such as gdb).",
                 "type": "object",
                 "default": {
-                  "pipeCwd": "${workspaceRoot}",
+                  "pipeCwd": "/usr/bin",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/gdb"
+                  "debuggerPath": "The full path to the debugger on the target machine, for example /usr/bin/gdb."
                 },
                 "properties": {
                   "pipeCwd": {
@@ -1007,6 +1009,7 @@
         },
         "configurationAttributes": {
           "launch": {
+            "type": "object",
             "required": [
               "program",
               "cwd"
@@ -1109,6 +1112,7 @@
             }
           },
           "attach": {
+            "type": "object",
             "required": [
               "processId"
             ],
@@ -1272,6 +1276,7 @@
   },
   "scripts": {
     "compile": "npm run vscode:prepublish",
+    "generateOptionsSchema": "gulp generateOptionsSchema",
     "integrationTests": "gulp integrationTests",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "tsc -p ./",

--- a/Extension/tools/GenerateOptionsSchema.ts
+++ b/Extension/tools/GenerateOptionsSchema.ts
@@ -96,7 +96,7 @@ function ReplaceReferences(definitions: any, objects: any) {
     return objects;
 }
 
-function mergeReferences(baseDefinitions: any, additionalDefinitions: any) : void {
+function MergeReferences(baseDefinitions: any, additionalDefinitions: any) : void {
     for (let key in additionalDefinitions) {
         if (baseDefinitions[key]) {
             throw `Error: '${key}' defined in multiple schema files.`;

--- a/Extension/tools/GenerateOptionsSchema.ts
+++ b/Extension/tools/GenerateOptionsSchema.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+
+function AppendFieldsToObject(reference: any, obj: any) {
+
+    // Make sure it is an object type
+    if (typeof obj == 'object') {
+        for (let referenceKey in reference) {
+            // If key exists in original object and is an object. 
+            if (obj.hasOwnProperty(referenceKey)) {
+                obj[referenceKey] = AppendFieldsToObject(reference[referenceKey], obj[referenceKey]);
+            } else {
+                // Does not exist in current object context
+                obj[referenceKey] = reference[referenceKey];
+            }
+        }
+    }
+
+    return obj;
+}
+
+// Combines two object's fields, giving the parentDefault a higher precedence. 
+function MergeDefaults(parentDefault: any, childDefault: any) {
+    let newDefault: any = {};
+
+    for (let attrname in childDefault) {
+        newDefault[attrname] = childDefault[attrname];
+    }
+
+    for (let attrname in parentDefault) {
+        newDefault[attrname] = parentDefault[attrname];
+    }
+
+    return newDefault;
+}
+
+function UpdateDefaults(object: any, defaults: any) {
+    if (defaults != null) {
+        for (let key in object) {
+            if (object[key].hasOwnProperty('type') && object[key].type === 'object' && object[key].properties !== null) {
+                object[key].properties = UpdateDefaults(object[key].properties, MergeDefaults(defaults, object[key].default));
+            } else if (key in defaults) {
+                object[key].default = defaults[key];
+            }
+        }
+    }
+
+    return object;
+}
+
+function RefReplace(definitions: any, ref: any): any {
+// $ref is formatted as "#/definitions/ObjectName"
+    let referenceStringArray: string[] = ref['$ref'].split('/');
+
+    // Getting "ObjectName"
+    let referenceName: string = referenceStringArray[referenceStringArray.length - 1];
+
+    // Make sure reference has replaced its own $ref fields and hope there are no recursive references.
+    definitions[referenceName] = ReplaceReferences(definitions, definitions[referenceName]);
+
+    // Retrieve ObjectName from definitions. (TODO: Does not retrieve inner objects)
+    // Need to deep copy, there are no functions in these objects.
+    let reference: any = JSON.parse(JSON.stringify(definitions[referenceName]));
+
+    ref = AppendFieldsToObject(reference, ref);
+
+    // Remove $ref field
+    delete ref['$ref'];
+
+    return ref;
+}
+
+function ReplaceReferences(definitions: any, objects: any) {
+    for (let key in objects) {
+        if (objects[key].hasOwnProperty('$ref')) {
+            objects[key] = RefReplace(definitions, objects[key]);
+        }
+
+        // Recursively replace references if this object has properties. 
+        if (objects[key].hasOwnProperty('type') && objects[key].type === 'object' && objects[key].properties !== null) {
+            objects[key].properties = ReplaceReferences(definitions, objects[key].properties);
+            objects[key].properties = UpdateDefaults(objects[key].properties, objects[key].default);
+        }
+
+        // Recursively replace references if the array has objects in items.
+        if (objects[key].hasOwnProperty('type') && objects[key].type === "array" && objects[key].items != null && objects[key].items.hasOwnProperty('$ref')) {
+            objects[key].items = RefReplace(definitions, objects[key].items);
+        }
+    }
+
+    return objects;
+}
+
+function mergeReferences(baseDefinitions: any, additionalDefinitions: any) : void {
+    for (let key in additionalDefinitions) {
+        if (baseDefinitions[key]) {
+            throw `Error: '${key}' defined in multiple schema files.`;
+        }
+        baseDefinitions[key] = additionalDefinitions[key];
+    }
+}
+
+export function GenerateOptionsSchema() {
+    let packageJSON: any = JSON.parse(fs.readFileSync('package.json').toString());
+    let schemaJSON: any = JSON.parse(fs.readFileSync('tools/OptionsSchema.json').toString());
+
+    schemaJSON.definitions = ReplaceReferences(schemaJSON.definitions, schemaJSON.definitions);
+
+    // Hard Code adding in configurationAttributes launch and attach.
+    // cppdbg
+    packageJSON.contributes.debuggers[0].configurationAttributes.launch = schemaJSON.definitions.CppdbgLaunchOptions;
+    packageJSON.contributes.debuggers[0].configurationAttributes.attach = schemaJSON.definitions.CppdbgAttachOptions;
+
+    // cppvsdbg
+    packageJSON.contributes.debuggers[1].configurationAttributes.launch = schemaJSON.definitions.CppvsdbgLaunchOptions;
+    packageJSON.contributes.debuggers[1].configurationAttributes.attach = schemaJSON.definitions.CppvsdbgAttachOptions;
+
+    let content = JSON.stringify(packageJSON, null, 2);
+    if (os.platform() === 'win32') {
+        content = content.replace(/\n/gm, "\r\n");
+    }
+    
+    // We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. This process will
+    // convert that from the readable espace sequence, to just an invisible character. Convert it back to the visible espace sequence.
+    content = content.replace(/\u200b/gm, "\\u200b");
+
+    fs.writeFileSync('package.json', content);
+}

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -1,0 +1,546 @@
+{
+  "_comment": "See README.md for information about this file",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "VS Code launch/attach options",
+  "description": "A json schema for the VS Code attach and launch options",
+  "type": "object",
+  "definitions": {
+    "PipeTransport": {
+      "type": "object",
+      "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the MI-enabled debugger backend executable (such as gdb).",
+      "default": {
+        "pipeCwd": "/usr/bin",
+        "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
+        "pipeArgs": [],
+        "debuggerPath": "The full path to the debugger on the target machine, for example /usr/bin/gdb."
+      },
+      "properties": {
+        "pipeCwd": {
+          "type": "string",
+          "description": "The fully qualified path to the working directory for the pipe program.",
+          "default": "/usr/bin"
+        },
+        "pipeProgram": {
+          "type": "string",
+          "description": "The fully qualified pipe command to execute.",
+          "default": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'"
+        },
+        "pipeArgs": {
+          "type": "array",
+          "description": "Command line arguments passed to the pipe program to configure the connection.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "debuggerPath": {
+          "type": "string",
+          "description": "The full path to the debugger on the target machine, for example /usr/bin/gdb.",
+          "default": "The full path to the debugger on the target machine, for example /usr/bin/gdb."
+        },
+        "pipeEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Environment variables passed to the pipe program.",
+          "default": {}
+        }
+      }
+    },
+    "Logging": {
+      "type": "object",
+      "default": {},
+      "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
+      "properties": {
+        "exceptions": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
+          "default": true
+        },
+        "moduleLoad": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",
+          "default": true
+        },
+        "programOutput": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether program output should be logged to the Debug Console. Defaults to true.",
+          "default": true
+        },
+        "engineLogging": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether diagnostic engine logs should be logged to the Debug Console. Defaults to false.",
+          "default": false
+        },
+        "trace": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the Debug Console. Defaults to false.",
+          "default": false
+        },
+        "traceResponse": {
+          "type": "boolean",
+          "description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the Debug Console. Defaults to false.",
+          "default": false
+        }
+      }
+    },
+    "SetupCommandsConfiguration": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The debugger command to execute.",
+          "default": ""
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional description for the command.",
+          "default": ""
+        },
+        "ignoreFailures": {
+          "type": "boolean",
+          "description": "If true, failures from the command should be ignored. Default value is false.",
+          "default": false
+        }
+      }
+    },
+    "KeyValuePair": {
+      "type": "object",
+      "properties": {
+        "name": "string",
+        "value": "string"
+      }
+    },
+    "CppdbgLaunchOptions": {
+      "type": "object",
+      "required": [
+        "program"
+      ],
+      "properties": {
+        "program": {
+          "type": "string",
+          "description": "Full path to program executable.",
+          "default": "${workspaceRoot}/a.out"
+        },
+        "args": {
+          "type": "array",
+          "description": "Command line arguments passed to the program.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the engine. Must be \"cppdbg\".",
+          "default": "cppdbg"
+        },
+        "targetArchitecture": {
+          "type": "string",
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86, arm, arm64, mips, x64, amd64, x86_64.",
+          "default": "x64"
+        },
+        "cwd": {
+          "type": "string",
+          "description": "The working directory of the target",
+          "default": "."
+        },
+        "setupCommands": {
+          "type": "array",
+          "description": "One or more GDB/LLDB commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"-enable-pretty-printing\", \"description\": \"Enable GDB pretty printing\", \"ignoreFailures\": true }].",
+          "items": {
+            "$ref": "#/definitions/SetupCommandsConfiguration"
+          },
+          "default": []
+        },
+        "customLaunchSetupCommands": {
+          "type": "array",
+          "description": "If provided, this replaces the default commands used to launch a target with some other commands. For example, this can be \"-target-attach\" in order to attach to a target process. An empty command list replaces the launch commands with nothing, which can be useful if the debugger is being provided launch options as command line options. Example: \"customLaunchSetupCommands\": [ { \"text\": \"target-run\", \"description\": \"run target\", \"ignoreFailures\": false }].",
+          "items": {
+            "$ref": "#/definitions/SetupCommandsConfiguration"
+          },
+          "default": []
+        },
+        "launchCompleteCommand": {
+          "enum": [
+            "exec-run",
+            "exec-continue",
+            "None"
+          ],
+          "description": "The command to execute after the debugger is fully setup in order to cause the target process to run. Allowed values are \"exec-run\", \"exec-continue\", \"None\". The default value is \"exec-run\".",
+          "default": "exec-run"
+        },
+        "visualizerFile": {
+          "type": "string",
+          "description": ".natvis file to be used when debugging this process. This option is not compatible with GDB pretty printing. Please also see \"showDisplayString\" if using this setting.",
+          "default": ""
+        },
+        "showDisplayString": {
+          "type": "boolean",
+          "description": "When a visualizerFile is specified, showDisplayString will enable the display string. Turning this option on can cause slower performance during debugging.",
+          "default": true
+        },
+        "environment": {
+          "type": "array",
+          "description": "Environment variables to add to the environment for the program. Example: [ { \"name\": \"squid\", \"value\": \"clam\" } ].",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "default": []
+        },
+        "additionalSOLibSearchPath": {
+          "type": "string",
+          "description": "Semicolon separated list of directories to use to search for .so files. Example: \"c:\\dir1;c:\\dir2\".",
+          "default": ""
+        },
+        "MIMode": {
+          "type": "string",
+          "description": "Indicates the console debugger that the MIDebugEngine will connect to. Allowed values are \"gdb\" \"lldb\".",
+          "default": "gdb"
+        },
+        "miDebuggerPath": {
+          "type": "string",
+          "description": "The path to the mi debugger (such as gdb). When unspecified, it will search path first for the debugger.",
+          "default": "/usr/bin/gdb"
+        },
+        "miDebuggerServerAddress": {
+          "type": "string",
+          "description": "Network address of the MI Debugger Server to connect to (example: localhost:1234).",
+          "default": "serveraddress:port"
+        },
+        "stopAtEntry": {
+          "type": "boolean",
+          "description": "Optional parameter. If true, the debugger should stop at the entrypoint of the target. If processId is passed, has no effect.",
+          "default": false
+        },
+        "debugServerPath": {
+          "type": "string",
+          "description": "Optional full path to debug server to launch. Defaults to null.",
+          "default": ""
+        },
+        "debugServerArgs": {
+          "type": "string",
+          "description": "Optional debug server args. Defaults to null.",
+          "default": ""
+        },
+        "serverStarted": {
+          "type": "string",
+          "description": "Optional server-started pattern to look for in the debug server output. Defaults to null.",
+          "default": ""
+        },
+        "filterStdout": {
+          "type": "boolean",
+          "description": "Search stdout stream for server-started pattern and log stdout to debug output. Defaults to true.",
+          "default": true
+        },
+        "filterStderr": {
+          "type": "boolean",
+          "description": "Search stderr stream for server-started pattern and log stderr to debug output. Defaults to false.",
+          "default": false
+        },
+        "serverLaunchTimeout": {
+          "type": "integer",
+          "description": "Optional time, in milliseconds, for the debugger to wait for the debugServer to start up. Default is 10000.",
+          "default": "10000"
+        },
+        "coreDumpPath": {
+          "type": "string",
+          "description": "Optional full path to a core dump file for the specified program. Defaults to null.",
+          "default": ""
+        },
+        "externalConsole": {
+          "type": "boolean",
+          "description": "If true, a console is launched for the debuggee. If false, no console is launched. Note this option is ignored in some cases for technical reasons.",
+          "default": false
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+          "default": {
+            "<source-path>": "<target-path>"
+          }
+        },
+        "logging": {
+          "$ref": "#/definitions/Logging",
+          "description": "Optional flags to determine what types of messages should be logged to the Debug Console."
+        },
+        "pipeTransport": {
+          "$ref": "#/definitions/PipeTransport",
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the MI-enabled debugger backend executable (such as gdb)."
+        }
+      }
+    },
+    "CppdbgAttachOptions": {
+      "type": "object",
+      "required": [
+        "program",
+        "processId"
+      ],
+      "properties": {
+        "program": {
+          "type": "string",
+          "description": "Full path to program executable.",
+          "default": "${workspaceRoot}/a.out"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the engine. Must be \"cppdbg\".",
+          "default": "cppdbg"
+        },
+        "targetArchitecture": {
+          "type": "string",
+          "description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86, arm, arm64, mips, x64, amd64, x86_64.",
+          "default": "x64"
+        },
+        "visualizerFile": {
+          "type": "string",
+          "description": ".natvis file to be used when debugging this process. This option is not compatible with GDB pretty printing. Please also see \"showDisplayString\" if using this setting.",
+          "default": ""
+        },
+        "showDisplayString": {
+          "type": "boolean",
+          "description": "When a visualizerFile is specified, showDisplayString will enable the display string. Turning this option on can cause slower performance during debugging.",
+          "default": true
+        },
+        "additionalSOLibSearchPath": {
+          "type": "string",
+          "description": "Semicolon separated list of directories to use to search for .so files. Example: \"c:\\dir1;c:\\dir2\".",
+          "default": ""
+        },
+        "MIMode": {
+          "type": "string",
+          "description": "Indicates the console debugger that the MIDebugEngine will connect to. Allowed values are \"gdb\" \"lldb\".",
+          "default": "gdb"
+        },
+        "miDebuggerPath": {
+          "type": "string",
+          "description": "The path to the mi debugger (such as gdb). When unspecified, it will search path first for the debugger.",
+          "default": "/usr/bin/gdb"
+        },
+        "miDebuggerServerAddress": {
+          "type": "string",
+          "description": "Network address of the MI Debugger Server to connect to (example: localhost:1234).",
+          "default": "serveraddress:port"
+        },
+        "processId": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Optional process id to attach the debugger to. Use \"${command:pickProcesss}\" to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+              "default": "${command:pickProcess}"
+            },
+            {
+              "type": "integer",
+              "description": "Optional process id to attach the debugger to. Use \"${command:pickProcesss}\" to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+              "default": 0
+            }
+          ]
+        },
+        "filterStdout": {
+          "type": "boolean",
+          "description": "Search stdout stream for server-started pattern and log stdout to debug output. Defaults to true.",
+          "default": true
+        },
+        "filterStderr": {
+          "type": "boolean",
+          "description": "Search stderr stream for server-started pattern and log stderr to debug output. Defaults to false.",
+          "default": false
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+          "default": {
+            "<source-path>": "<target-path>"
+          }
+        },
+        "logging": {
+          "$ref": "#/definitions/Logging",
+          "description": "Optional flags to determine what types of messages should be logged to the Debug Console."
+        },
+        "pipeTransport": {
+          "$ref": "#/definitions/PipeTransport",
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the MI-enabled debugger backend executable (such as gdb)."
+        },
+        "setupCommands": {
+          "type": "array",
+          "description": "One or more GDB/LLDB commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"-enable-pretty-printing\", \"description\": \"Enable GDB pretty printing\", \"ignoreFailures\": true }].",
+          "items": {
+            "$ref": "#/definitions/SetupCommandsConfiguration"
+          },
+          "default": []
+        }
+      }
+    },
+    "CppvsdbgLaunchOptions": {
+      "type": "object",
+      "required": [
+        "program",
+        "cwd"
+      ],
+      "properties": {
+        "program": {
+          "type": "string",
+          "description": "Full path to program executable.",
+          "default": "${workspaceRoot}/program.exe"
+        },
+        "args": {
+          "type": "array",
+          "description": "Command line arguments passed to the program.",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the engine. Must be \"cppvsdbg\".",
+          "default": "cppvsdbg"
+        },
+        "cwd": {
+          "type": "string",
+          "description": "The working directory of the target.",
+          "default": "${workspaceRoot}"
+        },
+        "environment": {
+          "type": "array",
+          "description": "Environment variables to add to the environment for the program. Example: [ { \"name\": \"squid\", \"value\": \"clam\" } ].",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "default": []
+        },
+        "symbolSearchPath": {
+          "type": "string",
+          "description": "Semicolon separated list of directories to use to search for symbol (that is, pdb) files. Example: \"c:\\dir1;c:\\dir2\".",
+          "default": ""
+        },
+        "stopAtEntry": {
+          "type": "boolean",
+          "description": "Optional parameter. If true, the debugger should stop at the entrypoint of the target. If processId is passed, has no effect.",
+          "default": false
+        },
+        "dumpPath": {
+          "type": "string",
+          "description": "Optional full path to a dump file for the specified program. Example: \"c:\\temp\\app.dmp\". Defaults to null.",
+          "default": ""
+        },
+        "visualizerFile": {
+          "type": "string",
+          "description": ".natvis file to be used when debugging this process.",
+          "default": ""
+        },
+        "externalConsole": {
+          "type": "boolean",
+          "description": "If true, a console is launched for the debuggee. If false, no console is launched.",
+          "default": false
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+          "default": {
+            "<source-path>": "<target-path>"
+          }
+        },
+        "logging": {
+          "type": "object",
+          "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
+          "default": {},
+          "properties": {
+            "exceptions": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "moduleLoad": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "programOutput": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether program output should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "engineLogging": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether diagnostic debug engine messages should be logged to the Debug Console. Defaults to false.",
+              "default": false
+            }
+          }
+        }
+      }
+    },
+    "CppvsdbgAttachOptions": {
+      "type": "object",
+      "required": [
+        "processId"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the engine. Must be \"cppvsdbg\".",
+          "default": "cppvsdbg"
+        },
+        "symbolSearchPath": {
+          "type": "string",
+          "description": "Semicolon separated list of directories to use to search for symbol (that is, pdb) files. Example: \"c:\\dir1;c:\\dir2\".",
+          "default": ""
+        },
+        "processId": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Optional process id to attach the debugger to. Use \"${command:pickProcesss}\" to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+              "default": "${command:pickProcess}"
+            },
+            {
+              "type": "integer",
+              "description": "Optional process id to attach the debugger to. Use \"${command:pickProcesss}\" to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+              "default": 0
+            }
+          ]
+        },
+        "visualizerFile": {
+          "type": "string",
+          "description": ".natvis file to be used when debugging this process.",
+          "default": ""
+        },
+        "sourceFileMap": {
+          "type": "object",
+          "description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'",
+          "default": {
+            "<source-path>": "<target-path>"
+          }
+        },
+        "logging": {
+          "type": "object",
+          "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
+          "default": {},
+          "properties": {
+            "exceptions": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "moduleLoad": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "programOutput": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether program output should be logged to the Debug Console. Defaults to true.",
+              "default": true
+            },
+            "trace": {
+              "type": "boolean",
+              "description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the Debug Console. Defaults to false.",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Extension/tools/README.md
+++ b/Extension/tools/README.md
@@ -1,0 +1,14 @@
+# OptionsSchema
+OptionsSchema.json defines the type for Launch/Attach options.
+
+# GenerateOptionsSchema
+If there are any modifications to the OptionsSchema.json file. Please run `npm run generateOptionsSchema` at the repo root.
+This will call GenerateOptionsSchema and update the package.json file.
+
+### Important notes:
+
+1. Any manual changes to package.json's object.contributes.debuggers[0].configurationAttributes (cppdbg) or object.contributes.debuggers[0].configurationAttributes (cppvsdbg) will be
+replaced by this generator.
+
+If there is any other type of options added in the future, you will need to modify the GenerateOptionsSchema function
+to have it appear in package.json. It only adds launch and attach.


### PR DESCRIPTION
This is to prevent repetitive fields from being copy and pasted
improperly.

There are some parts of OptionsSchema.json that needs to be fixed. E.g. logging for cppvsdbg. 