### PR TITLE
Disable recursive `includePath` for ${workspaceFolder} in default c_cpp_properties.json

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -207,7 +207,7 @@ export class CppProperties {
 
             if (!settings.defaultIncludePath) {
                 // We don't add system includes to the includePath anymore. The language server has this information.
-                configuration.includePath = ["${workspaceFolder}/**"].concat(this.vcpkgIncludes);
+                configuration.includePath = ["${workspaceFolder}"].concat(this.vcpkgIncludes);
             }
             if (!settings.defaultBrowsePath) {
                 // We don't add system includes to the includePath anymore. The language server has this information.


### PR DESCRIPTION
# Disable recursive `includePath` for ${workspaceFolder} in default c_cpp_properties.json

## Origin c_cpp_properties.json generated

```
"includePath": [
	"${workspaceFolder}/**"
],
```

## Now

```
"includePath": [
	"${workspaceFolder}"
],
```

## Why

On macOS 10.13.4, VS Code Version 1.23.1. **C/C++ Extension 0.17.3**

Maybe you can test the Extension based on this environment.

If we use the origin auto-generated c_cpp_properties.json which suggest `${workspaceFolder}/**` in includePath, this will cause the automatic completion to fail, and sometimes it will lead to high CPU usage.

<img width="706" alt="qq20180530-123411 2x" src="https://user-images.githubusercontent.com/23468295/40699473-1760a420-6407-11e8-8e46-26aba462dd50.png">

After I change `${workspaceFolder}/**` to `${workspaceFolder}` in includePath, Automatic completion started working properly.

<img width="917" alt="screen shot 2018-05-30 at 12 35 48 pm" src="https://user-images.githubusercontent.com/23468295/40699503-42ab0936-6407-11e8-8bf7-9e00fb541107.png">

I searched the internet and I found this bug not only happened to me. I just happened to find that disable recursive `includePath` for ${workspaceFolder} in default c_cpp_properties.json can solve this problem. (But I think this may be a bug about recursive `includePath`.)