### PR TITLE
Grdowns/detect compile commands

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -762,7 +762,7 @@ class DefaultClient implements Client {
         }
 
         let compileCommandStr: string = params.paths.length > 1 ? "a compile_commands.json file" : params.paths[0];
-        let folderStr: string = vscode.workspace.workspaceFolders.length > 1 ? "the " + this.Name : "this";
+        let folderStr: string = (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 1) ? "the " + this.Name : "this";
         const message: string = `Would you like to use ${compileCommandStr} to auto-configure IntelliSense for ${folderStr} folder?`;
 
         const yes: string = "Yes";

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -783,7 +783,6 @@ class DefaultClient implements Client {
                     else {
                         this.configuration.setCompileCommands(params.paths[0]);
                     }
-
                     break;
                 case notNow:
                     break;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -773,10 +773,6 @@ class DefaultClient implements Client {
                             if (index < 0) {
                                 return;
                             }
-                            if (index >= params.paths.length) {
-                                this.handleConfigurationEditCommand();
-                                return;
-                            }
                             this.configuration.setCompileCommands(params.paths[index]);
                         });
                     } else {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,7 +761,7 @@ class DefaultClient implements Client {
             return;
         }
 
-        let compileCommandStr: string = params.paths.length > 1 ? "a compile_commands.json file" : params.paths[0].replace("${workspaceFolder}", this.Name);
+        let compileCommandStr: string = params.paths.length > 1 ? "a compile_commands.json file" : params.paths[0];
         let folderStr: string = vscode.workspace.workspaceFolders.length > 1 ? "the " + this.Name : "this";
         const message: string = `Would you like to use ${compileCommandStr} to auto-configure IntelliSense for ${folderStr} folder?`;
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -756,7 +756,7 @@ class DefaultClient implements Client {
             return;
         }
 
-        let showCompileCommandsSelection: PersistentState<boolean> = new PersistentState<boolean>("CPP.showIntelliSenseFallbackMessage", true);
+        let showCompileCommandsSelection: PersistentState<boolean> = new PersistentState<boolean>("CPP.showPromptCompileCommands", true);
         if (!showCompileCommandsSelection.Value) {
            return;
         }
@@ -769,7 +769,7 @@ class DefaultClient implements Client {
             switch (value) {
                 case yes:
                     ui.showCompileCommands(params.paths).then((index) => {
-                        if (index < 0) {
+                        if (index <= 0) {
                             return;
                         }
                         if (index >= params.paths.length) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,27 +761,33 @@ class DefaultClient implements Client {
             return;
         }
 
-        let message: string = "Detected compile_commands.json. Would you like to select a compile_commands.json for this configuration?";
+        let message: string = "Would you like to use compile_command.json files to auto-configure IntelliSense?";
         let yes: string = "Yes";
-        let later: string = "Later";
-        let dontShowAgain: string = "Don't Show Again";
-        vscode.window.showInformationMessage(message, yes, later, dontShowAgain).then((value) => {
+        let notNow: string = "Not Now";
+        let dontAskAgain: string = "Don't Ask Again";
+        vscode.window.showInformationMessage(message, yes, notNow, dontAskAgain).then((value) => {
             switch (value) {
                 case yes:
-                    ui.showCompileCommands(params.paths).then((index) => {
-                        if (index < 0) {
-                            return;
-                        }
-                        if (index >= params.paths.length) {
-                            this.handleConfigurationEditCommand();
-                            return;
-                        }
-                        this.configuration.setCompileCommands(params.paths[index]);
-                    });
+                    if (params.paths.length > 1) {
+                        ui.showCompileCommands(params.paths).then((index) => {
+                            if (index < 0) {
+                                return;
+                            }
+                            if (index >= params.paths.length) {
+                                this.handleConfigurationEditCommand();
+                                return;
+                            }
+                            this.configuration.setCompileCommands(params.paths[index]);
+                        });
+                    }
+                    else {
+                        this.configuration.setCompileCommands(params.paths[0]);
+                    }
+
                     break;
-                case later:
+                case notNow:
                     break;
-                case dontShowAgain:
+                case dontAskAgain:
                     showCompileCommandsSelection.Value = false;
                     break;
             }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,7 +761,20 @@ class DefaultClient implements Client {
             return;
         }
 
-        const message: string = "Would you like to use compile_command.json files to auto-configure IntelliSense?";
+        let message: string = "Would you like to use ";
+        if (params.paths.length > 1) {
+            message += "a compile_commands.json file";
+        } else {
+            message += params.paths[0];
+        }
+        message += " to auto-configure IntelliSense for ";
+        if (vscode.workspace.workspaceFolders.length > 1) {
+            message += "the " + this.Name;
+        } else {
+            message += "this";
+        }
+        message += " folder?";
+
         const yes: string = "Yes";
         const notNow: string = "Not Now";
         const dontAskAgain: string = "Don't Ask Again";

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -756,9 +756,9 @@ class DefaultClient implements Client {
             return;
         }
 
-        let showCompileCommandsSelection: PersistentState<boolean> = new PersistentState<boolean>("CPP.showPromptCompileCommands", true);
+        let showCompileCommandsSelection: PersistentState<boolean> = new PersistentState<boolean>("CPP.showCompileCommandsSelection", true);
         if (!showCompileCommandsSelection.Value) {
-           return;
+            return;
         }
 
         let message: string = "Detected compile_commands.json. Would you like to select a compile_commands.json for this configuration?";
@@ -769,7 +769,7 @@ class DefaultClient implements Client {
             switch (value) {
                 case yes:
                     ui.showCompileCommands(params.paths).then((index) => {
-                        if (index <= 0) {
+                        if (index < 0) {
                             return;
                         }
                         if (index >= params.paths.length) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,10 +761,10 @@ class DefaultClient implements Client {
             return;
         }
 
-        let message: string = "Would you like to use compile_command.json files to auto-configure IntelliSense?";
-        let yes: string = "Yes";
-        let notNow: string = "Not Now";
-        let dontAskAgain: string = "Don't Ask Again";
+        const message: string = "Would you like to use compile_command.json files to auto-configure IntelliSense?";
+        const yes: string = "Yes";
+        const notNow: string = "Not Now";
+        const dontAskAgain: string = "Don't Ask Again";
         vscode.window.showInformationMessage(message, yes, notNow, dontAskAgain).then((value) => {
             switch (value) {
                 case yes:

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,11 +761,11 @@ class DefaultClient implements Client {
            return;
         }
 
-        let message: string = "Blah";
+        let message: string = "Detected compile_commands.json. Would you like to select a compile_commands.json for this configuration?";
         let yes: string = "Yes";
         let later: string = "Later";
         let dontShowAgain: string = "Don't Show Again";
-        vscode.window.showInformationMessage(message, yes, dontShowAgain).then((value) => {
+        vscode.window.showInformationMessage(message, yes, later, dontShowAgain).then((value) => {
             switch (value) {
                 case yes:
                     ui.showCompileCommands(params.paths).then((index) => {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -779,8 +779,7 @@ class DefaultClient implements Client {
                             }
                             this.configuration.setCompileCommands(params.paths[index]);
                         });
-                    }
-                    else {
+                    } else {
                         this.configuration.setCompileCommands(params.paths[0]);
                     }
                     break;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -761,19 +761,9 @@ class DefaultClient implements Client {
             return;
         }
 
-        let message: string = "Would you like to use ";
-        if (params.paths.length > 1) {
-            message += "a compile_commands.json file";
-        } else {
-            message += params.paths[0];
-        }
-        message += " to auto-configure IntelliSense for ";
-        if (vscode.workspace.workspaceFolders.length > 1) {
-            message += "the " + this.Name;
-        } else {
-            message += "this";
-        }
-        message += " folder?";
+        let compileCommandStr: string = params.paths.length > 1 ? "a compile_commands.json file" : params.paths[0].replace("${workspaceFolder}", this.Name);
+        let folderStr: string = vscode.workspace.workspaceFolders.length > 1 ? "the " + this.Name : "this";
+        const message: string = `Would you like to use ${compileCommandStr} to auto-configure IntelliSense for ${folderStr} folder?`;
 
         const yes: string = "Yes";
         const notNow: string = "Not Now";

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -320,6 +320,17 @@ export class CppProperties {
         });
     }
 
+    public setCompileCommands(path: string): void {
+        this.handleConfigurationEditCommand((document: vscode.TextDocument) => {
+            telemetry.logLanguageServerEvent("addToIncludePath");
+            this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
+            let config: Configuration = this.configurationJson.configurations[this.CurrentConfiguration];
+            config.compileCommands = path;
+            fs.writeFileSync(this.propertiesFile.fsPath, JSON.stringify(this.configurationJson, null, 4));
+            this.updateServerOnFolderSettingsChange();
+        });
+    }
+
     public select(index: number): Configuration {
         if (index === this.configurationJson.configurations.length) {
             this.handleConfigurationEditCommand(vscode.window.showTextDocument);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -322,7 +322,6 @@ export class CppProperties {
 
     public setCompileCommands(path: string): void {
         this.handleConfigurationEditCommand((document: vscode.TextDocument) => {
-            telemetry.logLanguageServerEvent("addToIncludePath");
             this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
             let config: Configuration = this.configurationJson.configurations[this.CurrentConfiguration];
             config.compileCommands = path;

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -176,15 +176,14 @@ export class UI {
         for (let i: number = 0; i < paths.length; i++) {
             items.push({label: paths[i], description: "", index: i});
         }
-        items.push({ label: "Edit Configurations...", description: "", index: paths.length });
 
         return vscode.window.showQuickPick(items, options)
-        .then(selection => {
-            if (!selection) {
-                return -1;
-            }
-            return selection.index;
-        });
+            .then(selection => {
+                if (!selection) {
+                    return -1;
+                }
+                return selection.index;
+            });
     }
 
     public showWorkspaces(workspaceNames: { name: string; key: string }[]): Thenable<string> {

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -168,6 +168,25 @@ export class UI {
             });
     }
 
+    public showCompileCommands(paths: string[]): Thenable<number> {
+        let options: vscode.QuickPickOptions = {};
+        options.placeHolder = "Select a compile_commands.json...";
+
+        let items: IndexableQuickPickItem[] = [];
+        for (let i: number = 0; i < paths.length; i++) {
+            items.push({label: paths[i], description: "", index: i});
+        }
+        items.push({ label: "Edit Configurations...", description: "", index: paths.length });
+
+        return vscode.window.showQuickPick(items, options)
+        .then(selection => {
+            if (!selection) {
+                return -1;
+            }
+            return selection.index;
+        });
+    }
+
     public showWorkspaces(workspaceNames: { name: string; key: string }[]): Thenable<string> {
         let options: vscode.QuickPickOptions = {};
         options.placeHolder = "Select a Workspace...";


### PR DESCRIPTION
Respond to a `compileCommandsPaths` message by prompting the user to select a `compile_commands.json` which will then populate `compileCommands` in `c_cpp_properties.json` for the active configuration.