### PR TITLE
minor tweaks to config provider experience

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1068,7 +1068,7 @@ class DefaultClient implements Client {
 
     public handleConfigurationProviderSelectCommand(): void {
         this.notifyWhenReady(() => {
-            ui.showConfigurationProviders()
+            ui.showConfigurationProviders(this.configuration.CurrentConfigurationProvider)
                 .then(extensionId => {
                     if (extensionId === undefined) {
                         // operation was cancelled.

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -343,7 +343,11 @@ export class CppProperties {
                 });
             } else {
                 let settings: CppSettings = new CppSettings(this.rootUri);
-                settings.update("default.configurationProvider", providerId);
+                if (providerId) {
+                    settings.update("default.configurationProvider", providerId);
+                } else {
+                    settings.update("default.configurationProvider", undefined); // delete the setting
+                }
                 this.CurrentConfiguration.configurationProvider = providerId;
                 resolve();
             }
@@ -513,6 +517,13 @@ export class CppProperties {
                             this.resetToDefaultSettings(true);
                         }
                         this.applyDefaultIncludePathsAndFrameworks();
+                        let settings: CppSettings = new CppSettings(this.rootUri);
+                        if (settings.defaultConfigurationProvider) {
+                            this.configurationJson.configurations.forEach(config => {
+                                config.configurationProvider = settings.defaultConfigurationProvider;
+                            });
+                            settings.update("default.configurationProvider", undefined); // delete the setting
+                        }
                         edit.insert(document.uri, new vscode.Position(0, 0), JSON.stringify(this.configurationJson, null, 4));
                         vscode.workspace.applyEdit(edit).then((status) => {
                             // Fix for issue 163

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -164,14 +164,18 @@ export class UI {
             .then(selection => (selection) ? selection.index : -1);
     }
 
-    public showConfigurationProviders(): Thenable<string|undefined> {
+    public showConfigurationProviders(currentProvider: string|null): Thenable<string|undefined> {
         let options: vscode.QuickPickOptions = {};
         options.placeHolder = "Select a Configuration Provider...";
         let providers: CustomConfigurationProviderCollection = getCustomConfigProviders();
 
         let items: KeyedQuickPickItem[] = [];
         providers.forEach(provider => {
-            items.push({ label: provider.name, description: "", key: provider.extensionId });
+            let label: string = provider.name;
+            if (provider.extensionId === currentProvider) {
+                label += " (active)";
+            }
+            items.push({ label: label, description: "", key: provider.extensionId });
         });
         items.push({ label: "(none)", description: "Disable the active configuration provider, if applicable.", key: "" });
 


### PR DESCRIPTION
* In the Change Configuration Provider command, show which one is currently active
* If no `c_cpp_properties.json` is present, delete the workspace setting when the config provider is cleared
* When generating `c_cpp_properties.json` for a folder, delete the workspace setting (it is assumed this was added via the command or UI prompts)