### PR TITLE
adds settings for inactive region font & bg color

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 0.17.8: August 16, 2018
+* Add `inactiveRegionForegroundColor` and `inactiveRegionBackgroundColor` to settings. [#2212](https://github.com/Microsoft/vscode-cpptools/issues/2212)
+
 ## Version 0.17.7: July 22, 2018
 * Fix `Go to Definition` for code scoped with an aliased namespace. [#387](https://github.com/Microsoft/vscode-cpptools/issues/387)
 * Fix incorrect IntelliSense errors with template template-arguments. [#1014](https://github.com/Microsoft/vscode-cpptools/issues/1014)
@@ -24,7 +27,6 @@
 * Add a setting to silence configuration provider warnings. [#2292](https://github.com/Microsoft/vscode-cpptools/issues/2292)
 * Fix for debugging async Visual C++ causing debugger to hang.
 * Fix `main` snippet.
-* Add `inactiveRegionFontColor` and `inactiveRegionBackgroundColor` to settings. [#2212](https://github.com/Microsoft/vscode-cpptools/issues/2212)
 
 ## Version 0.17.6: July 2, 2018
 * Fix the database icon getting stuck with recursive includes. [#2104](https://github.com/Microsoft/vscode-cpptools/issues/2104)

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Version 0.17.7: July 19, 2018
+## Version 0.17.7: July 22, 2018
 * Fix `Go to Definition` for code scoped with an aliased namespace. [#387](https://github.com/Microsoft/vscode-cpptools/issues/387)
 * Fix incorrect IntelliSense errors with template template-arguments. [#1014](https://github.com/Microsoft/vscode-cpptools/issues/1014)
 * Fix crash when using designated initializer lists. [#1440](https://github.com/Microsoft/vscode-cpptools/issues/1440)
@@ -24,6 +24,7 @@
 * Add a setting to silence configuration provider warnings. [#2292](https://github.com/Microsoft/vscode-cpptools/issues/2292)
 * Fix for debugging async Visual C++ causing debugger to hang.
 * Fix `main` snippet.
+* Add `inactiveRegionFontColor` and `inactiveRegionBackgroundColor` to settings. [#2212](https://github.com/Microsoft/vscode-cpptools/issues/2212)
 
 ## Version 0.17.6: July 2, 2018
 * Fix the database icon getting stuck with recursive includes. [#2104](https://github.com/Microsoft/vscode-cpptools/issues/2104)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -154,6 +154,18 @@
           "minimum": 0.1,
           "maximum": 1
         },
+        "C_Cpp.inactiveRegionFontColor": {
+          "type": "string",
+          "default": null,
+          "description": "Controls the font coloring of inactive preprocessor blocks. Input is in the form a hexidecimal color code or a valid Theme Color. If not set, this defaults to the syntax coloring scheme of the editor. This setting only applies when inactive region dimming is enabled.",
+          "scope": "resource"
+        },
+        "C_Cpp.inactiveRegionBackgroundColor": {
+          "type": "string",
+          "default": null,
+          "description": "Controls the background coloring of inactive preprocessor blocks. Input is in the form a hexidecimal color code or a valid Theme Color. If not set, this defaults to transparent. This setting only applies when inactive region dimming is enabled.",
+          "scope": "resource"
+        },
         "C_Cpp.formatting": {
           "type": "string",
           "enum": [

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -154,16 +154,19 @@
           "minimum": 0.1,
           "maximum": 1
         },
-        "C_Cpp.inactiveRegionFontColor": {
-          "type": "string",
+        "C_Cpp.inactiveRegionForegroundColor": {
+          "type": [
+            "string",
+            "null"
+          ],
           "default": null,
-          "description": "Controls the font coloring of inactive preprocessor blocks. Input is in the form a hexidecimal color code or a valid Theme Color. If not set, this defaults to the syntax coloring scheme of the editor. This setting only applies when inactive region dimming is enabled.",
+          "description": "Controls the font coloring of inactive preprocessor blocks. Input is in the form a hexadecimal color code or a valid Theme Color. If not set, this defaults to the syntax coloring scheme of the editor. This setting only applies when inactive region dimming is enabled.",
           "scope": "resource"
         },
         "C_Cpp.inactiveRegionBackgroundColor": {
           "type": "string",
           "default": null,
-          "description": "Controls the background coloring of inactive preprocessor blocks. Input is in the form a hexidecimal color code or a valid Theme Color. If not set, this defaults to transparent. This setting only applies when inactive region dimming is enabled.",
+          "description": "Controls the background coloring of inactive preprocessor blocks. Input is in the form a hexadecimal color code or a valid Theme Color. If not set, this defaults to transparent. This setting only applies when inactive region dimming is enabled.",
           "scope": "resource"
         },
         "C_Cpp.formatting": {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -164,7 +164,10 @@
           "scope": "resource"
         },
         "C_Cpp.inactiveRegionBackgroundColor": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "default": null,
           "description": "Controls the background coloring of inactive preprocessor blocks. Input is in the form a hexadecimal color code or a valid Theme Color. If not set, this defaults to transparent. This setting only applies when inactive region dimming is enabled.",
           "scope": "resource"

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -840,6 +840,8 @@ class DefaultClient implements Client {
         
         let decoration: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType({
             opacity: settings.inactiveRegionOpacity.toString(),
+            backgroundColor: settings.inactiveRegionBackgroundColor,
+            color: settings.inactiveRegionFontColor,
             rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen
         });
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -841,7 +841,7 @@ class DefaultClient implements Client {
         let decoration: vscode.TextEditorDecorationType = vscode.window.createTextEditorDecorationType({
             opacity: settings.inactiveRegionOpacity.toString(),
             backgroundColor: settings.inactiveRegionBackgroundColor,
-            color: settings.inactiveRegionFontColor,
+            color: settings.inactiveRegionForegroundColor,
             rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen
         });
 

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -41,7 +41,7 @@ export class CppSettings extends Settings {
     public get errorSquiggles(): string { return super.Section.get<string>("errorSquiggles"); }
     public get dimInactiveRegions(): boolean { return super.Section.get<boolean>("dimInactiveRegions"); }
     public get inactiveRegionOpacity(): number { return super.Section.get<number>("inactiveRegionOpacity"); }
-    public get inactiveRegionFontColor(): string { return super.Section.get<string>("inactiveRegionFontColor"); }
+    public get inactiveRegionForegroundColor(): string { return super.Section.get<string>("inactiveRegionForegroundColor"); }
     public get inactiveRegionBackgroundColor(): string { return super.Section.get<string>("inactiveRegionBackgroundColor"); }
     public get autoComplete(): string { return super.Section.get<string>("autocomplete"); }
     public get loggingLevel(): string { return super.Section.get<string>("loggingLevel"); }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -41,6 +41,8 @@ export class CppSettings extends Settings {
     public get errorSquiggles(): string { return super.Section.get<string>("errorSquiggles"); }
     public get dimInactiveRegions(): boolean { return super.Section.get<boolean>("dimInactiveRegions"); }
     public get inactiveRegionOpacity(): number { return super.Section.get<number>("inactiveRegionOpacity"); }
+    public get inactiveRegionFontColor(): string { return super.Section.get<string>("inactiveRegionFontColor"); }
+    public get inactiveRegionBackgroundColor(): string { return super.Section.get<string>("inactiveRegionBackgroundColor"); }
     public get autoComplete(): string { return super.Section.get<string>("autocomplete"); }
     public get loggingLevel(): string { return super.Section.get<string>("loggingLevel"); }
     public get navigationLength(): number { return super.Section.get<number>("navigation.length", 60); }


### PR DESCRIPTION
This adds the inactiveRegionFontColor and inactiveRegionBackgroundColor
settings. If a preprocessor block is found to be inactive, it will be
colored by these fields if they are set. They accept hexadecimal font
strings or valid theme colors as their values.These fields also
interactive with the dimInactiveRegions setting.

This was requested in issue
https://github.com/Microsoft/vscode-cpptools/issues/2212.

I tried launching the tests, but they crashed for me with error `Error: Cannot find module 'C:\Users\John\Projects\vscode-cpptools\Extension\out\test'` but I don't think this is related to my change.

I also feel like `dimInactiveRegions` should now be changes to `colorizeInactiveRegions` as this verb change captures both changes in opacity and color, but I wanted to get input before I made a user-facing alteration.