### PR TITLE
Add multi-pass environment variable resolution

### DIFF
--- a/Extension/.vscode/launch.json
+++ b/Extension/.vscode/launch.json
@@ -24,7 +24,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test"
+				"--extensionTestsPath=${workspaceFolder}/out/test/unitTests"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -18,7 +18,11 @@ gulp.task('allTests', () => {
 });
 
 gulp.task('unitTests', () => {
-    gulp.src('./out/test/unitTests', {read: false}).pipe(
+    env.set({
+            CODE_TESTS_PATH: "./out/test/unitTests",
+        }
+    );
+    gulp.src('./test/runVsCodeTestsWithAbsolutePaths.js', {read: false}).pipe(
         mocha({
             ui: "tdd"
         })

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -199,6 +199,10 @@ function expandNestedVariable(input: string, additionalEnvironment: {[key: strin
         }
 
         const closeIndex: number = indexOfMatchingCloseBrace(openIndex + 2, stackInput);
+        if (closeIndex < 0) {
+            break;
+        }
+
         stack.push({
             prefix: stackInput.substring(0, openIndex),
             postfix: stackInput.substring(closeIndex + 1)
@@ -276,13 +280,15 @@ export function resolveVariables(input: string, additionalEnvironment: {[key: st
 
     // Replace environment and configuration variables.
     let ret: string = input;
+    const cycleCache: Set<string> = new Set([ ret ]);
     const openTagRegex: RegExp = /\$\{/;
     while (openTagRegex.test(ret)) {
         const expansion: string = expandNestedVariable(ret, additionalEnvironment);
-        const doneExpanding: boolean = expansion === ret;
+        const doneExpanding: boolean = cycleCache.has(expansion);
         if (doneExpanding) {
             break;
         }
+        cycleCache.add(expansion);
         ret = expansion;
     }
 

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -169,107 +169,6 @@ export function showReleaseNotes(): void {
     vscode.commands.executeCommand('vscode.previewHtml', vscode.Uri.file(getExtensionFilePath("ReleaseNotes.html")), vscode.ViewColumn.One, "C/C++ Extension Release Notes");
 }
 
-function indexOfMatchingCloseBrace(startingPos: number, input: string): number {
-    let closeBracesToFind: number = 1;
-    for (let i: number = startingPos; i < input.length; i++) {
-        if (input[i] === "$" && i + 1 < input.length && input[i + 1] === "{") {
-            closeBracesToFind += 1;
-        } else if (input[i] === "}") {
-            closeBracesToFind -= 1;
-            if (closeBracesToFind < 1) {
-                return i;
-            }
-        }
-    }
-    return -1;
-}
-
-interface StackEntry {
-    prefix: string;
-    postfix: string;
-}
-
-function expandNestedVariable(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
-    let stack: StackEntry[] = [];
-    let stackInput: string = input;
-    while (stackInput !== "") {
-        const openIndex: number = stackInput.indexOf("${");
-        if (openIndex < 0) {
-            break;
-        }
-
-        const closeIndex: number = indexOfMatchingCloseBrace(openIndex + 2, stackInput);
-        if (closeIndex < 0) {
-            break;
-        }
-
-        stack.push({
-            prefix: stackInput.substring(0, openIndex),
-            postfix: stackInput.substring(closeIndex + 1)
-        });
-        stackInput = stackInput.substring(openIndex + 2, closeIndex);
-    }
-
-    let ret: string = stackInput;
-    while (stack.length !== 0) {
-        let stackEntry: StackEntry = stack.pop();
-        let resolvedItem: string =  resolveSingleVariableBlock(input, "${" + ret + "}", ret, additionalEnvironment);
-        ret = stackEntry.prefix + resolvedItem + stackEntry.postfix;
-    }
-
-    return ret;
-}
-
-function resolveSingleVariableBlock(originalInput: string, wholeVariable: string, innerVariable: string, additionalEnvironment: {[key: string]: string | string[]}): string {
-    let varType: string;
-    let name: string = innerVariable.replace(/(env|config|workspaceFolder)[\.|:](.*)/, (ignored: string, type: string, rest: string) => {
-        varType = type;
-        return rest;
-    });
-
-    // Historically, if the variable didn't have anything before the "." or ":"
-    // it was assumed to be an environment variable
-    if (varType === undefined) {
-        varType = "env";
-    }
-    let newValue: string = undefined;
-    switch (varType) {
-        case "env": {
-            let v: string | string[] = additionalEnvironment[name];
-            if (typeof v === "string") {
-                newValue = v;
-            } else if (originalInput === wholeVariable && v instanceof Array) {
-                newValue = v.join(";");
-            }
-            if (!newValue) {
-                newValue = process.env[name];
-            }
-            break;
-        }
-        case "config": {
-            let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-            if (config) {
-                newValue = config.get<string>(name);
-            }
-            break;
-        }
-        case "workspaceFolder": {
-            // Only replace ${workspaceFolder:name} variables for now.
-            // We may consider doing replacement of ${workspaceFolder} here later, but we would have to update the language server and also
-            // intercept messages with paths in them and add the ${workspaceFolder} variable back in (e.g. for light bulb suggestions)
-            if (name && vscode.workspace && vscode.workspace.workspaceFolders) {
-                let folder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders.find(folder => folder.name.toLocaleLowerCase() === name.toLocaleLowerCase());
-                if (folder) {
-                    newValue = folder.uri.fsPath;
-                }
-            }
-            break;
-        }
-        default: { assert.fail("unknown varType matched"); }
-    }
-    return (newValue) ? newValue : wholeVariable;
-}
-
 export function resolveVariables(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
     if (!input) {
         return "";
@@ -279,22 +178,59 @@ export function resolveVariables(input: string, additionalEnvironment: {[key: st
     }
 
     // Replace environment and configuration variables.
+    let regexp: () => RegExp = () => /\$\{((env|config|workspaceFolder)(\.|:))?(.*?)\}/g;
     let ret: string = input;
-    const cycleCache: Set<string> = new Set([ ret ]);
-    const openTagRegex: RegExp = /\$\{/;
-    while (openTagRegex.test(ret)) {
-        const expansion: string = expandNestedVariable(ret, additionalEnvironment);
-        const doneExpanding: boolean = cycleCache.has(expansion);
-        if (doneExpanding) {
-            break;
-        }
-        cycleCache.add(expansion);
-        ret = expansion;
+    let cycleCache: Set<string> = new Set();
+    while (!cycleCache.has(ret)) {
+        cycleCache.add(ret);
+        ret = ret.replace(regexp(), (match: string, ignored1: string, varType: string, ignored2: string, name: string) => {
+            // Historically, if the variable didn't have anything before the "." or ":"
+            // it was assumed to be an environment variable
+            if (varType === undefined) {
+                varType = "env";
+            }
+            let newValue: string = undefined;
+            switch (varType) {
+                case "env": {
+                    let v: string | string[] = additionalEnvironment[name];
+                    if (typeof v === "string") {
+                        newValue = v;
+                    } else if (input === match && v instanceof Array) {
+                        newValue = v.join(";");
+                    }
+                    if (!newValue) {
+                        newValue = process.env[name];
+                    }
+                    break;
+                }
+                case "config": {
+                    let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+                    if (config) {
+                        newValue = config.get<string>(name);
+                    }
+                    break;
+                }
+                case "workspaceFolder": {
+                    // Only replace ${workspaceFolder:name} variables for now.
+                    // We may consider doing replacement of ${workspaceFolder} here later, but we would have to update the language server and also
+                    // intercept messages with paths in them and add the ${workspaceFolder} variable back in (e.g. for light bulb suggestions)
+                    if (name && vscode.workspace && vscode.workspace.workspaceFolders) {
+                        let folder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders.find(folder => folder.name.toLocaleLowerCase() === name.toLocaleLowerCase());
+                        if (folder) {
+                            newValue = folder.uri.fsPath;
+                        }
+                    }
+                    break;
+                }
+                default: { assert.fail("unknown varType matched"); }
+            }
+            return (newValue) ? newValue : match;
+        });
     }
 
     // Resolve '~' at the start of the path.
-    let regexp: RegExp = /^\~/g;
-    ret = ret.replace(regexp, (match: string, name: string) => {
+    regexp = () => /^\~/g;
+    ret = ret.replace(regexp(), (match: string, name: string) => {
         let newValue: string = process.env.HOME;
         return (newValue) ? newValue : match;
     });

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -178,7 +178,7 @@ export function resolveVariables(input: string, additionalEnvironment: {[key: st
     }
 
     // Replace environment and configuration variables.
-    let regexp: RegExp = /\$\{((env|config|workspaceFolder)(.|:))?(.*?)\}/g;
+    let regexp: RegExp = /\$\{((env|config|workspaceFolder)(\.|:))?(.*?)\}/g;
     let ret: string = input.replace(regexp, (match: string, ignored1: string, varType: string, ignored2: string, name: string) => {
         // Historically, if the variable didn't have anything before the "." or ":"
         // it was assumed to be an environment variable

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -169,7 +169,54 @@ export function showReleaseNotes(): void {
     vscode.commands.executeCommand('vscode.previewHtml', vscode.Uri.file(getExtensionFilePath("ReleaseNotes.html")), vscode.ViewColumn.One, "C/C++ Extension Release Notes");
 }
 
-export function resolveInnerVariable(originalInput: string, wholeVariable: string, innerVariable: string, additionalEnvironment: {[key: string]: string | string[]}): string {
+function indexOfMatchingCloseBrace(startingPos: number, input: string): number {
+    let closeBracesToFind: number = 1;
+    for (let i: number = startingPos; i < input.length; i++) {
+        if (input[i] === "$" && i + 1 < input.length && input[i + 1] === "{") {
+            closeBracesToFind += 1;
+        } else if (input[i] === "}") {
+            closeBracesToFind -= 1;
+            if (closeBracesToFind < 1) {
+                return i;
+            }
+        }
+    }
+    return -1;
+}
+
+interface StackEntry {
+    prefix: string;
+    postfix: string;
+}
+
+function expandNestedVariable(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
+    let stack: StackEntry[] = [];
+    let stackInput: string = input;
+    while (stackInput !== "") {
+        const openIndex: number = stackInput.indexOf("${");
+        if (openIndex < 0) {
+            break;
+        }
+
+        const closeIndex: number = indexOfMatchingCloseBrace(openIndex + 2, stackInput);
+        stack.push({
+            prefix: stackInput.substring(0, openIndex),
+            postfix: stackInput.substring(closeIndex + 1)
+        });
+        stackInput = stackInput.substring(openIndex + 2, closeIndex);
+    }
+
+    let ret: string = stackInput;
+    while (stack.length !== 0) {
+        let stackEntry: StackEntry = stack.pop();
+        let resolvedItem: string =  resolveSingleVariableBlock(input, "${" + ret + "}", ret, additionalEnvironment);
+        ret = stackEntry.prefix + resolvedItem + stackEntry.postfix;
+    }
+
+    return ret;
+}
+
+function resolveSingleVariableBlock(originalInput: string, wholeVariable: string, innerVariable: string, additionalEnvironment: {[key: string]: string | string[]}): string {
     let varType: string;
     let name: string = innerVariable.replace(/(env|config|workspaceFolder)[\.|:](.*)/, (ignored: string, type: string, rest: string) => {
         varType = type;
@@ -219,54 +266,6 @@ export function resolveInnerVariable(originalInput: string, wholeVariable: strin
     return (newValue) ? newValue : wholeVariable;
 }
 
-function indexOfMatchingCloseBrace(startingPos: number, input: string): number {
-    let balanceFactor: number = 0;
-    for (let i: number = startingPos; i < input.length; i++) {
-        if (input[i] === "$" && i + 1 < input.length && input[i + 1] === "{") {
-            balanceFactor += 1;
-        } else if (input[i] === "}") {
-            if (balanceFactor === 0) {
-                return i;
-            } else {
-                balanceFactor -= 1;
-            }
-        }
-    }
-    return -1;
-}
-
-interface StackEntry {
-    prefix: string;
-    postfix: string;
-}
-
-function expandVariables(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
-    let stack: StackEntry[] = [];
-    let stackInput: string = input;
-    while (stackInput !== "") {
-        const openIndex: number = stackInput.indexOf("${");
-        if (-1 < openIndex) {
-            const closeIndex: number = indexOfMatchingCloseBrace(openIndex + 2, stackInput);
-            stack.push({
-                prefix: stackInput.substring(0, openIndex),
-                postfix: stackInput.substring(closeIndex + 1)
-            });
-            stackInput = stackInput.substring(openIndex + 2, closeIndex);
-        } else {
-            break;
-        }
-    }
-
-    let ret: string = stackInput;
-    while (stack.length !== 0) {
-        let stackEntry: StackEntry = stack.pop();
-        let resolvedItem: string =  resolveInnerVariable(input, "${" + ret + "}", ret, additionalEnvironment);
-        ret = stackEntry.prefix + resolvedItem + stackEntry.postfix;
-    }
-
-    return ret;
-}
-
 export function resolveVariables(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
     if (!input) {
         return "";
@@ -279,9 +278,9 @@ export function resolveVariables(input: string, additionalEnvironment: {[key: st
     let ret: string = input;
     const openTagRegex: RegExp = /\$\{/;
     while (openTagRegex.test(ret)) {
-        const expansion: string = expandVariables(ret, additionalEnvironment);
-        // Needed to prevent infinite loop in the failed lookup case
-        if (expansion === ret) {
+        const expansion: string = expandNestedVariable(ret, additionalEnvironment);
+        const doneExpanding: boolean = expansion === ret;
+        if (doneExpanding) {
             break;
         }
         ret = expansion;

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -219,10 +219,10 @@ export function resolveInnerVariable(originalInput: string, wholeVariable: strin
     return (newValue) ? newValue : wholeVariable;
 }
 
-function indexOfMatchingCloseBrace(startingPos: number, input: string) {
-    let balanceFactor = 0;
-    for (let i = startingPos; i < input.length; i++) {
-        if (input[i] === "$" && i + 1 < input.length && input[i+1] === "{") {
+function indexOfMatchingCloseBrace(startingPos: number, input: string): number {
+    let balanceFactor: number = 0;
+    for (let i: number = startingPos; i < input.length; i++) {
+        if (input[i] === "$" && i + 1 < input.length && input[i + 1] === "{") {
             balanceFactor += 1;
         } else if (input[i] === "}") {
             if (balanceFactor === 0) {
@@ -242,11 +242,11 @@ interface StackEntry {
 
 function expandVariables(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
     let stack: StackEntry[] = [];
-    let stackInput = input;
+    let stackInput: string = input;
     while (stackInput !== "") {
-        const openIndex = stackInput.indexOf("${");
+        const openIndex: number = stackInput.indexOf("${");
         if (-1 < openIndex) {
-            const closeIndex = indexOfMatchingCloseBrace(openIndex+2, stackInput);
+            const closeIndex: number = indexOfMatchingCloseBrace(openIndex + 2, stackInput);
             stack.push({
                 prefix: stackInput.substring(0, openIndex),
                 postfix: stackInput.substring(closeIndex + 1)
@@ -259,8 +259,8 @@ function expandVariables(input: string, additionalEnvironment: {[key: string]: s
 
     let ret: string = stackInput;
     while (stack.length !== 0) {
-        let stackEntry = stack.pop();
-        let resolvedItem =  resolveInnerVariable(input, "${" + ret + "}", ret, additionalEnvironment);
+        let stackEntry: StackEntry = stack.pop();
+        let resolvedItem: string =  resolveInnerVariable(input, "${" + ret + "}", ret, additionalEnvironment);
         ret = stackEntry.prefix + resolvedItem + stackEntry.postfix;
     }
 
@@ -277,9 +277,9 @@ export function resolveVariables(input: string, additionalEnvironment: {[key: st
 
     // Replace environment and configuration variables.
     let ret: string = input;
-    let openTagRegex = /\$\{/;
+    const openTagRegex: RegExp = /\$\{/;
     while (openTagRegex.test(ret)) {
-        let expansion = expandVariables(ret, additionalEnvironment);
+        const expansion: string = expandVariables(ret, additionalEnvironment);
         // Needed to prevent infinite loop in the failed lookup case
         if (expansion === ret) {
             break;

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -81,6 +81,47 @@ suite("Common Utility validation", () => {
             assert.equal(resolveVariables(input, {}), input);
         });
 
+        test("env input with 1 level of nested variables anchored at end", () => {
+            const input = "${foo${test}}";
+
+            const env = {
+                "foobar": success,
+                "test": "bar"
+            };
+            assert.equal(resolveVariables(input, env), success);
+        });
+
+        test("env input with 1 level of nested variables anchored in the middle", () => {
+            const input = "${f${test}r}";
+
+            const env = {
+                "foobar": success,
+                "test": "ooba"
+            };
+            assert.equal(resolveVariables(input, env), success);
+        });
+
+        test("env input with 1 level of nested variable anchored at front", () => {
+            const input = "${${test}bar}";
+
+            const env = {
+                "foobar": success,
+                "test": "foo"
+            };
+            assert.equal(resolveVariables(input, env), success);
+        });
+
+        test("env input with 3 levels of nested variables", () => {
+            const input = "${foo${a${b${c}}}}";
+            const env = {
+                "foobar": success,
+                "a1": "bar",
+                "b2": "1",
+                "c": "2"
+            };
+            assert.equal(resolveVariables(input, env), success);
+        });
+
         test("env input contains env", () => {
             shouldSuccessfullyLookupInEnv("${envRoot}", "envRoot");
         });

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -1,16 +1,79 @@
 import * as assert from "assert";
-import * as vscode from "vscode";
-import { resolveVariables } from "../../src/common";
+import {  resolveVariables } from "../../src/common";
 
 suite("Common Utility validation", () => {
     suite("resolveVariables", () => {
+        const success = "success";
+        const home = process.env.HOME;
+
         test("raw input", () => {
             const input = "test";
             assert.equal(resolveVariables(input, {}), input);
         });
 
+        test("raw input with tilde", () => {
+            const input = "~/test";
+            assert.equal(resolveVariables(input, {}), `${home}/test`)
+        });
+
+        test("env input with tilde", () => {
+            const input = "${path}/test";
+            const actual = resolveVariables(input, {
+                path: home
+            }); 
+            assert.equal(actual, `${home}/test`)
+        });
+
+        test("solo env input resulting in array", () => {
+            const input = "${test}";
+            const actual = resolveVariables(input, {
+                test: ["foo", "bar"]
+            }); 
+            assert.equal(actual, "foo;bar")
+        });
+
+        test("mixed raw and env input resulting in array", () => {
+            const input = "baz${test}";
+            const actual = resolveVariables(input, {
+                test: ["foo", "bar"]
+            }); 
+            assert.equal(actual, input)
+        });
+
+        test("solo env input not in env config finds process env", () => {
+            const processKey = `cpptoolstests_${Date.now()}`;
+            const input = "foo${" + processKey + "}";
+            let actual: string;
+            try {
+                process.env[processKey] = "bar";
+                actual = resolveVariables(input, {});
+            } finally {
+                delete process.env[processKey];
+            }
+            assert.equal(actual, "foobar");
+        });
+
         test("env input", () => {
             shouldSuccessfullyLookupInEnv("${test}", "test");
+        });
+
+        test("env input mixed with plain text", () => {
+            const input = "${test}bar";
+            const env = {
+                test: "foo"
+            };
+            const result = resolveVariables(input, env);
+            assert.equal(result, "foobar");
+        });
+
+        test("env input with two variables", () => {
+            const input = "f${a}${b}r";
+            const env = {
+                a: "oo",
+                b: "ba"
+            };
+            const result = resolveVariables(input, env);
+            assert.equal(result, "foobar");
         });
 
         test("env input not in env", () => {
@@ -38,8 +101,8 @@ suite("Common Utility validation", () => {
             shouldSuccessfullyLookupInEnv("${env:Root}", "Root");
         });
 
+
         const shouldSuccessfullyLookupInEnv = (input: string, expectedResolvedKey: string) => {
-            const success = "success";
             const env = {};
             env[expectedResolvedKey] = success;
             const result = resolveVariables(input, env);

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -90,6 +90,15 @@ suite("Common Utility validation", () => {
                 .shouldResolveTo(input);
         });
 
+        test("env with macro inside environment definition", () => {
+            resolveVariablesWithInput("${arm6.include}")
+                .withEnvironment({
+                    "envRoot": "apps/tool/buildenv",
+                    "arm6.include": "${envRoot}/arm6/include"
+                })
+                .shouldResolveTo("apps/tool/buildenv/arm6/include");
+        });
+
         test("env input with 1 level of nested variables anchored at end", () => {
             resolveVariablesWithInput("${foo${test}}")
                 .withEnvironment({

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -124,7 +124,7 @@ suite("Common Utility validation", () => {
                     "b": "${c}",
                     "c": "${a}"
                 })
-                .shouldResolveTo("${c}");
+                .shouldResolveTo("${a}");
         });
 
         test("env input with 1 level of nested variables anchored at end", () => {
@@ -133,7 +133,7 @@ suite("Common Utility validation", () => {
                     "foobar": success,
                     "test": "bar"
                 })
-                .shouldResolveTo(success);
+                .shouldResolveTo("${foo${test}}");
         });
 
         test("env input with 1 level of nested variables anchored in the middle", () => {
@@ -142,7 +142,7 @@ suite("Common Utility validation", () => {
                     "foobar": success,
                     "test": "ooba"
                 })
-                .shouldResolveTo(success);
+                .shouldResolveTo("${f${test}r}");
         });
 
         test("env input with 1 level of nested variable anchored at front", () => {
@@ -151,7 +151,7 @@ suite("Common Utility validation", () => {
                     "foobar": success,
                     "test": "foo"
                 })
-                .shouldResolveTo(success);
+                .shouldResolveTo("${${test}bar}");
         });
 
         test("env input with 3 levels of nested variables", () => {
@@ -162,7 +162,7 @@ suite("Common Utility validation", () => {
                     "b2": "1",
                     "c": "2"
                 })
-                .shouldResolveTo(success);
+                .shouldResolveTo("${foo${a${b${c}}}}");
         });
 
         test("env input contains env", () => {

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -1,0 +1,49 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { resolveVariables } from "../../src/common";
+
+suite("Common Utility validation", () => {
+    suite("resolveVariables", () => {
+        test("raw input", () => {
+            const input = "test";
+            assert.equal(resolveVariables(input, {}), input);
+        });
+
+        test("env input", () => {
+            shouldSuccessfullyLookupInEnv("${test}", "test");
+        });
+
+        test("env input not in env", () => {
+            const input = "${test}";
+            assert.equal(resolveVariables(input, {}), input);
+        });
+
+        test("env input contains env", () => {
+            shouldSuccessfullyLookupInEnv("${envRoot}", "envRoot");
+        });
+
+        test("env input contains config", () => {
+            shouldSuccessfullyLookupInEnv("${configRoot}", "configRoot");
+        });
+
+        test("env input contains workspaceFolder", () => {
+            shouldSuccessfullyLookupInEnv("${workspaceFolderRoot}", "workspaceFolderRoot");
+        });
+
+        test("input contains env.", () => {
+            shouldSuccessfullyLookupInEnv("${env.Root}", "Root");
+        });
+
+        test("input contains env:", () => {
+            shouldSuccessfullyLookupInEnv("${env:Root}", "Root");
+        });
+
+        const shouldSuccessfullyLookupInEnv = (input: string, expectedResolvedKey: string) => {
+            const success = "success";
+            const env = {};
+            env[expectedResolvedKey] = success;
+            const result = resolveVariables(input, env);
+            assert.equal(result, success);
+        }
+    });
+});

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -99,6 +99,34 @@ suite("Common Utility validation", () => {
                 .shouldResolveTo("apps/tool/buildenv/arm6/include");
         });
 
+        test("env nested with half open variable", () => {
+            resolveVariablesWithInput("${arm6.include}")
+                .withEnvironment({
+                    "envRoot": "apps/tool/buildenv",
+                    "arm6.include": "${envRoot/arm6/include"
+                })
+                .shouldResolveTo("${envRoot/arm6/include");
+        });
+
+        test("env nested with half closed variable", () => {
+            resolveVariablesWithInput("${arm6.include}")
+                .withEnvironment({
+                    "envRoot": "apps/tool/buildenv",
+                    "arm6.include": "envRoot}/arm6/include"
+                })
+                .shouldResolveTo("envRoot}/arm6/include");
+        });
+
+        test("env nested with a cycle", () => {
+            resolveVariablesWithInput("${a}")
+                .withEnvironment({
+                    "a": "${b}",
+                    "b": "${c}",
+                    "c": "${a}"
+                })
+                .shouldResolveTo("${c}");
+        });
+
         test("env input with 1 level of nested variables anchored at end", () => {
             resolveVariablesWithInput("${foo${test}}")
                 .withEnvironment({


### PR DESCRIPTION
Per issue [#2057](https://github.com/Microsoft/vscode-cpptools/issues/2057).

This allows a user to nest environment tags, or define tags based on the definition of other environment variables. If the result of a resolution still contains a `${...}` tag, we will continue to scan the input until we reach a steady state where the variable expansion results in the same input.

This should allow the following forms which were previously not possible in the environment definition:

* Dependent variable definition
```
"env": {
    "envRoot": "apps/tool/builldenv",
    "arm6.include": "${envRoot}/arm6/include"
},
...
"some_config": "${arm6.include}
```

* Nested variable definition of any degree
```
"env": {
    "root": "apps/tool",
    "armVersion": "${config:armVersion}",
    "arm5.include": "${root}/legacy/arm/include",
    "arm6.include": "${root}/arm/include",
    "armTestPath": "${arm${armVersion}.include}/test"
}
```

* Additionally, this fixes an open bug that was not reported. If a variable contained "env", "config", or "workspaceFolder" it would not be parsed correctly. If you used a variable ${envRoot} it would match "envR" as the type and "oot" as the variable. This has been resolved.

