### PR TITLE
Update language-service issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/language-service.md
+++ b/.github/ISSUE_TEMPLATE/language-service.md
@@ -4,10 +4,12 @@ about: 'Issues pertaining to IntelliSense, autocomplete, code editing, etc. '
 
 ---
 
-Type: LanguageService
-**----- Input information below -----**
+**Type: LanguageService**
+<!----- Input information below ----->
 
+<!--
 **Please review existing issues and our documentation at https://github.com/Microsoft/vscode-cpptools/tree/master/Documentation prior to filing an issue.**
+-->
 
 **Describe the bug**
 - OS and Version:
@@ -17,19 +19,21 @@ Type: LanguageService
 - A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-*Provide a code sample including configuration files such as c_cpp_properties.json*
+<!-- Steps to reproduce the behavior: -->
+<!-- *The most actionable issue reports include a code sample including configuration files such as c_cpp_properties.json* -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
+<!--
 *Call Stacks: For bugs like crashes, deadlocks, infinite loops, etc. that we are not able to repro and for which the call stack may be useful, please attach a debugger and/or create a dmp and provide the call stacks. Starting with 0.17.3, Windows binaries have symbols available in VS Code by setting your "symbolSearchPath" to "http://msdl.microsoft.com/download/symbols".*
 Add any other context about the problem here including log messages in your Output window ("C_Cpp.loggingLevel": "Debug" in settings.json).
+-->


### PR DESCRIPTION
Changing some boilerplate back to html comments so that they don't clutter the issue reports we get