### PR TITLE
Fix sh command

### DIFF
--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -120,7 +120,7 @@ export class RemoteAttachPicker {
 
     private getRemoteOSAndProcesses(pipeCmd: string): Promise<AttachItem[]> {
         // Commands to get OS and processes
-        const command: string = `sh -c 'uname && if [ $(uname) == "Linux" ] ; then ${PsProcessParser.psLinuxCommand} ; elif [ $(uname) == "Darwin" ] ; ` +
+        const command: string = `sh -c 'uname && if [ $(uname) = "Linux" ] ; then ${PsProcessParser.psLinuxCommand} ; elif [ $(uname) = "Darwin" ] ; ` +
             `then ${PsProcessParser.psDarwinCommand}; fi'`;
 
         return execChildProcess(`${pipeCmd} "${command}"`, null, this._channel).then(output => {


### PR DESCRIPTION
When the change from bash to sh happened, the comparison operator was
not updated.

Fixes #2444