### PR TITLE
The user settings were not considered when querying the active configuration

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -553,7 +553,7 @@ class DefaultClient implements Client {
     }
     
     public getCustomConfigurationProviderId(): Thenable<string|undefined> {
-        return this.queueTask(() => Promise.resolve(this.configuration.CurrentConfiguration.configurationProvider));
+        return this.queueTask(() => Promise.resolve(this.configuration.CurrentConfigurationProvider));
     }
 
     public getCurrentConfigName(): Thenable<string> {


### PR DESCRIPTION
If the following were true:
* VSCode opens a workspace that is being served by a custom config provider
* there is already a source file open when the editor loads
* the config provider is set via a vscode setting (instead of c_cpp_properties.json)

then the config provider would not be able to serve the configuration for the open file because the vscode settings had not been resolved/applied yet.