### PR TITLE
Fixing queuing logic that stalls LS on Mac

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -667,13 +667,14 @@ class DefaultClient implements Client {
                 }
             };
             
-            this.pendingRequests++;
-            console.assert(this.pendingRequests > 0);
-            if (this.pendingRequests === 1) {
+            console.assert(this.pendingRequests >= 0);
+            if (this.pendingRequests === 0) {
+                this.pendingRequests++;
                 this.pendingTask = nextTask();
                 return this.pendingTask;
             } else {
                 // We don't want the queue to stall because of a rejected promise.
+                this.pendingRequests++;
                 return this.pendingTask.then(nextTask, nextTask);
             }
         } else {
@@ -1125,7 +1126,7 @@ class DefaultClient implements Client {
 
         let settings: CppSettings = new CppSettings(this.RootUri);
         let out: logger.Logger = logger.getOutputChannelLogger();
-        if (settings.loggingLevel == "Debug") {
+        if (settings.loggingLevel === "Debug") {
             out.appendLine("Custom configurations received:");
         }
         let sanitized: SourceFileConfigurationItemAdapter[] = [];
@@ -1172,7 +1173,7 @@ class DefaultClient implements Client {
 
         let settings: CppSettings = new CppSettings(this.RootUri);
         let out: logger.Logger = logger.getOutputChannelLogger();
-        if (settings.loggingLevel == "Debug") {
+        if (settings.loggingLevel === "Debug") {
             out.appendLine(`Custom browse configuration received: ${JSON.stringify(sanitized, null, 2)}`);
         }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -536,7 +536,9 @@ class DefaultClient implements Client {
                 if (await currentProvider.canProvideBrowseConfiguration(tokenSource.token)) {
                     return currentProvider.provideBrowseConfiguration(tokenSource.token);
                 }
-                console.warn("failed to provide browse configuration");
+                if (currentProvider.version >= Version.v2) {
+                    console.warn("failed to provide browse configuration");
+                }
                 return Promise.reject("");
             };
             this.queueTaskWithTimeout(task, configProviderTimeout, tokenSource).then(

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -290,9 +290,8 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
             });
         }, error => reject(error));
     });
-    return p.catch((error: Error) => {
+    await p.catch((error: Error) => {
         telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
-        return Promise.reject(error);
     });
 }
 

--- a/Extension/src/cppTools.ts
+++ b/Extension/src/cppTools.ts
@@ -77,7 +77,7 @@ export class CppTools implements CppToolsTestApi {
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'notifyReady' ignored");
         } else {
-            console.assert(false, "provider should be registered before signaling it's ready to provide configurations");
+            console.warn(false, "provider should be registered before signaling it's ready to provide configurations");
         }
     }
 
@@ -86,12 +86,12 @@ export class CppTools implements CppToolsTestApi {
         let p: CustomConfigurationProvider1 = providers.get(provider);
 
         if (p) {
-            console.assert(p.isReady, "didChangeCustomConfiguration was invoked before notifyReady");
+            console.warn(p.isReady, "didChangeCustomConfiguration was invoked before notifyReady");
             LanguageServer.getClients().forEach(client => client.updateCustomConfigurations(p));
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomConfiguration' ignored");
         } else {
-            console.assert(false, "provider should be registered before sending config change messages");
+            console.warn(false, "provider should be registered before sending config change messages");
         }
     }
 
@@ -104,7 +104,7 @@ export class CppTools implements CppToolsTestApi {
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomBrowseConfiguration' ignored");
         } else {
-            console.assert(false, "provider should be registered before sending config change messages");
+            console.warn(false, "provider should be registered before sending config change messages");
         }
     }
 

--- a/Extension/src/cppTools.ts
+++ b/Extension/src/cppTools.ts
@@ -14,6 +14,7 @@ import * as test from './testHook';
 export class CppTools implements CppToolsTestApi {
     private version: Version;
     private providers: CustomConfigurationProvider1[] = [];
+    private failedRegistrations: CustomConfigurationProvider[] = [];
     private timers = new Map<string, NodeJS.Timer>();
 
     constructor(version: Version) {
@@ -57,6 +58,8 @@ export class CppTools implements CppToolsTestApi {
             this.providers.push(added);
             LanguageServer.getClients().forEach(client => client.onRegisterCustomConfigurationProvider(added));
             this.addNotifyReadyTimer(added);
+        } else {
+            this.failedRegistrations.push(provider);
         }
     }
 
@@ -71,6 +74,8 @@ export class CppTools implements CppToolsTestApi {
                 client.updateCustomConfigurations(p);
                 client.updateCustomBrowseConfiguration(p);
             });
+        } else if (this.failedRegistrations.find(p => p === provider)) {
+            console.warn("provider not successfully registered, 'notifyReady' ignored");
         } else {
             console.assert(false, "provider should be registered before signaling it's ready to provide configurations");
         }
@@ -83,6 +88,8 @@ export class CppTools implements CppToolsTestApi {
         if (p) {
             console.assert(p.isReady, "didChangeCustomConfiguration was invoked before notifyReady");
             LanguageServer.getClients().forEach(client => client.updateCustomConfigurations(p));
+        } else if (this.failedRegistrations.find(p => p === provider)) {
+            console.warn("provider not successfully registered, 'didChangeCustomConfiguration' ignored");
         } else {
             console.assert(false, "provider should be registered before sending config change messages");
         }
@@ -94,6 +101,8 @@ export class CppTools implements CppToolsTestApi {
 
         if (p) {
             LanguageServer.getClients().forEach(client => client.updateCustomBrowseConfiguration(p));
+        } else if (this.failedRegistrations.find(p => p === provider)) {
+            console.warn("provider not successfully registered, 'didChangeCustomBrowseConfiguration' ignored");
         } else {
             console.assert(false, "provider should be registered before sending config change messages");
         }


### PR DESCRIPTION
* adding additional logging for custom configuration providers
* remove an assertion causing the LS to fail to activate when invalid configuration providers attempt to register
* fixing a queuing bug that causes an indefinite hang on Mac
* removing an unhandled promise rejection