### PR TITLE
Only serialize tasks that require it

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -155,10 +155,11 @@ class BlockingTask<T> {
             try {
                 let result: T = await task();
                 resolve(result);
+                this.done = true;
             } catch (err) {
                 reject(err);
+                this.done = true;
             }
-            this.done = true;
         });
         this.dependency = dependency;
     }
@@ -545,10 +546,10 @@ class DefaultClient implements Client {
 
     public updateCustomBrowseConfiguration(requestingProvider?: CustomConfigurationProvider1): Thenable<void> {
         return this.notifyWhenReady(() => {
-            console.log("updateCustomBrowseConfiguration");
             if (!this.configurationProvider) {
                 return;
             }
+            console.log("updateCustomBrowseConfiguration");
             let currentProvider: CustomConfigurationProvider1 = getCustomConfigProviders().get(this.configurationProvider);
             if (!currentProvider || (requestingProvider && requestingProvider.extensionId !== currentProvider.extensionId)) {
                 return;
@@ -576,10 +577,10 @@ class DefaultClient implements Client {
     public async provideCustomConfiguration(document: vscode.TextDocument): Promise<void> {
         let tokenSource: CancellationTokenSource = new CancellationTokenSource();
         let providers: CustomConfigurationProviderCollection = getCustomConfigProviders();
-        console.log("provideCustomConfiguration");
         if (providers.size === 0) {
             return Promise.resolve();
         }
+        console.log("provideCustomConfiguration");
         let providerId: string|undefined = await this.getCustomConfigurationProviderId();
         if (!providerId) {
             return Promise.resolve();

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -145,6 +145,33 @@ const InactiveRegionNotification:  NotificationType<InactiveRegionParams, void> 
 const CompileCommandsPathsNotification:  NotificationType<CompileCommandsPaths, void> = new NotificationType<CompileCommandsPaths, void>('cpptools/compileCommandsPaths');
 const UpdateClangFormatPathNotification: NotificationType<string, void> = new NotificationType<string, void>('cpptools/updateClangFormatPath');
 
+class BlockingTask<T> {
+    private dependency: BlockingTask<any>;
+    private done: boolean = false;
+    private promise: Promise<T>;
+
+    constructor(task: () => T, dependency?: BlockingTask<any>) {
+        this.promise = new Promise<T>(async (resolve, reject) => {
+            try {
+                let result: T = await task();
+                resolve(result);
+            } catch (err) {
+                reject(err);
+            }
+            this.done = true;
+        });
+        this.dependency = dependency;
+    }
+
+    public get Done(): boolean {
+        return this.done && (!this.dependency || this.dependency.Done);
+    }
+
+    public then(onSucceeded: (value: T) => any, onRejected: (err) => any): Promise<any> {
+        return this.promise.then(onSucceeded, onRejected);
+    }
+}
+
 let failureMessageShown: boolean = false;
 
 interface ClientModel {
@@ -174,7 +201,6 @@ export interface Client {
     getCurrentConfigName(): Thenable<string>;
     takeOwnership(document: vscode.TextDocument): void;
     queueTask<T>(task: () => Thenable<T>): Thenable<T>;
-    queueTaskWithTimeout(thenable: () => Thenable<any>, ms: number, tokenSource?: CancellationTokenSource): Thenable<any>;
     requestWhenReady(request: () => Thenable<any>): Thenable<any>;
     notifyWhenReady(notify: () => void): void;
     requestGoToDeclaration(): Thenable<void>;
@@ -183,8 +209,6 @@ export interface Client {
     activeDocumentChanged(document: vscode.TextDocument): void;
     activate(): void;
     selectionChanged(selection: Range): void;
-    sendCustomConfigurations(configs: any): void;
-    sendCustomBrowseConfiguration(config: any): Thenable<void>;
     resetDatabase(): void;
     deactivate(): void;
     pauseParsing(): void;
@@ -267,8 +291,7 @@ class DefaultClient implements Client {
      * @see notifyWhenReady(notify)
      */
 
-    private pendingTask: Thenable<any>;
-    private pendingRequests: number = 0;
+    private pendingTask: BlockingTask<void>;
 
     constructor(allClients: ClientCollection, workspaceFolder?: vscode.WorkspaceFolder) {
         try {
@@ -281,7 +304,7 @@ class DefaultClient implements Client {
             ui.bind(this);
 
             // requests/notifications are deferred until this.languageClient is set.
-            this.queueTask(() => languageClient.onReady().then(
+            this.queueBlockingTask(() => languageClient.onReady().then(
                 () => {
                     this.configuration = new configs.CppProperties(this.RootUri);
                     this.configuration.ConfigurationsChanged((e) => this.onConfigurationsChanged(e));
@@ -588,7 +611,7 @@ class DefaultClient implements Client {
         return this.queueTaskWithTimeout(provideConfigurationAsync, configProviderTimeout, tokenSource).then(
             (configs: SourceFileConfigurationItem[]) => {
                 if (configs && configs.length > 0) {
-                    this.sendCustomConfigurations(configs);
+                    this.sendCustomConfigurations(configs, true);
                 }
             },
             (err) => {
@@ -657,32 +680,39 @@ class DefaultClient implements Client {
         if (this.isSupported) {
             let nextTask: () => Thenable<any> = async () => {
                 try {
-                    let result: any = await task();
-                    this.pendingRequests--;
-                    return result;
+                    return await task();
                 } catch (err) {
                     console.error(err);
-                    this.pendingRequests--;
                     throw err;
                 }
             };
             
-            console.assert(this.pendingRequests >= 0);
-            if (this.pendingRequests === 0) {
-                this.pendingRequests++;
-                this.pendingTask = nextTask();
-                return this.pendingTask;
-            } else {
+            if (this.pendingTask && !this.pendingTask.Done) {
                 // We don't want the queue to stall because of a rejected promise.
-                this.pendingRequests++;
                 return this.pendingTask.then(nextTask, nextTask);
+            } else {
+                this.pendingTask = undefined;
+                return nextTask();
             }
         } else {
             return Promise.reject("Unsupported client");
         }
     }
 
-    public queueTaskWithTimeout(task: () => Thenable<any>, ms: number, cancelToken?: CancellationTokenSource): Thenable<any> {
+    /**
+     * Queue a task that blocks all future tasks until it completes. This is currently only intended to be used
+     * during language client startup and for custom configuration providers.
+     * @param task The task that blocks all future tasks
+     */
+    private queueBlockingTask(task: () => Thenable<void>): Thenable<void> {
+        if (this.isSupported) {
+            this.pendingTask = new BlockingTask<void>(task, this.pendingTask);
+        } else {
+            return Promise.reject("Unsupported client");
+        }
+    }
+
+    private queueTaskWithTimeout(task: () => Thenable<any>, ms: number, cancelToken?: CancellationTokenSource): Thenable<any> {
         let timer: NodeJS.Timer;
         // Create a promise that rejects in <ms> milliseconds
         let timeout: () => Promise<any> = () => new Promise((resolve, reject) => {
@@ -713,11 +743,16 @@ class DefaultClient implements Client {
         return this.queueTask(request);
     }
 
-    public notifyWhenReady(notify: () => void): Thenable<void> {
-        return this.queueTask(() => new Promise(resolve => {
+    public notifyWhenReady(notify: () => void, blockingTask?: boolean): Thenable<void> {
+        let task: () => Thenable<void> = () => new Promise(resolve => {
             notify();
             resolve();
-        }));
+        });
+        if (blockingTask) {
+            return this.queueBlockingTask(task);
+        } else {
+            return this.queueTask(task);
+        }
     }
 
     /**
@@ -1117,7 +1152,7 @@ class DefaultClient implements Client {
             util.isOptionalArrayOfString(input.configuration.forcedInclude));
     }
 
-    public sendCustomConfigurations(configs: any): void {
+    private sendCustomConfigurations(configs: any, blockingTask?: boolean): void {
         // configs is marked as 'any' because it is untrusted data coming from a 3rd-party. We need to sanitize it before sending it to the language server.
         if (!configs || !(configs instanceof Array)) {
             console.warn("discarding invalid SourceFileConfigurationItems[]: " + configs);
@@ -1155,10 +1190,10 @@ class DefaultClient implements Client {
         let params: CustomConfigurationParams = {
             configurationItems: sanitized
         };
-        this.notifyWhenReady(() => this.languageClient.sendNotification(CustomConfigurationNotification, params));
+        this.notifyWhenReady(() => this.languageClient.sendNotification(CustomConfigurationNotification, params), blockingTask);
     }
 
-    public sendCustomBrowseConfiguration(config: any): Thenable<void> {
+    private sendCustomBrowseConfiguration(config: any): Thenable<void> {
         // config is marked as 'any' because it is untrusted data coming from a 3rd-party. We need to sanitize it before sending it to the language server.
         if (!config || config instanceof Array) {
             console.warn("discarding invalid WorkspaceBrowseConfiguration: " + config);
@@ -1307,11 +1342,8 @@ class NullClient implements Client {
     getCurrentConfigName(): Thenable<string> { return Promise.resolve(""); }
     takeOwnership(document: vscode.TextDocument): void {}
     queueTask<T>(task: () => Thenable<T>): Thenable<T> { return task(); }
-    queueTaskWithTimeout(task: () => Thenable<any>, ms: number, tokenSource?: CancellationTokenSource): Thenable<any> { return task(); }
     requestWhenReady(request: () => Thenable<any>): Thenable<any> { return; }
     notifyWhenReady(notify: () => void): void {}
-    sendCustomConfigurations(configs: any): void {}
-    sendCustomBrowseConfiguration(config: any): Thenable<void> { return Promise.resolve(); }
     requestGoToDeclaration(): Thenable<void> { return Promise.resolve(); }
     requestSwitchHeaderSource(rootPath: string, fileName: string): Thenable<string> { return Promise.resolve(""); }
     requestNavigationList(document: vscode.TextDocument): Thenable<string> { return Promise.resolve(""); }


### PR DESCRIPTION
Only two task types act as "fences" for future tasks.
1. language client startup
2. provide custom configuration

Only serialize tasks while one of these two task types is running