### PR TITLE
incorrect warning messages

### DIFF
--- a/Extension/src/cppTools.ts
+++ b/Extension/src/cppTools.ts
@@ -77,7 +77,7 @@ export class CppTools implements CppToolsTestApi {
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'notifyReady' ignored");
         } else {
-            console.warn(false, "provider should be registered before signaling it's ready to provide configurations");
+            console.warn("provider should be registered before signaling it's ready to provide configurations");
         }
     }
 
@@ -86,12 +86,14 @@ export class CppTools implements CppToolsTestApi {
         let p: CustomConfigurationProvider1 = providers.get(provider);
 
         if (p) {
-            console.warn(p.isReady, "didChangeCustomConfiguration was invoked before notifyReady");
+            if (!p.isReady) {
+                console.warn("didChangeCustomConfiguration was invoked before notifyReady");
+            }
             LanguageServer.getClients().forEach(client => client.updateCustomConfigurations(p));
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomConfiguration' ignored");
         } else {
-            console.warn(false, "provider should be registered before sending config change messages");
+            console.warn("provider should be registered before sending config change messages");
         }
     }
 
@@ -104,7 +106,7 @@ export class CppTools implements CppToolsTestApi {
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomBrowseConfiguration' ignored");
         } else {
-            console.warn(false, "provider should be registered before sending config change messages");
+            console.warn("provider should be registered before sending config change messages");
         }
     }
 


### PR DESCRIPTION
My last change switched some `console.assert` messages to `console.warn` but forgot to remove the condition. This resulted in bogus warnings for config providers.