### PR TITLE
Grdowns/update channel4

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -321,7 +321,6 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
             });
         }, (error: Error) => {
             // Handle getTargetBuildInfo rejection
-            logFailure(error);
             reject(error);
         });
     });

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -617,3 +617,36 @@ export function downloadFileToDestination(urlStr: string, destinationPath: strin
         request.end();
     });
 }
+
+export function downloadFileToStr(urlStr: string, headers?: OutgoingHttpHeaders): Promise<any> {
+    return new Promise<string>((resolve, reject) => {
+        let parsedUrl: url.Url = url.parse(urlStr);
+        let request: ClientRequest = https.request({
+            host: parsedUrl.host,
+            path: parsedUrl.path,
+            agent: getHttpsProxyAgent(),
+            rejectUnauthorized: vscode.workspace.getConfiguration().get('http.proxyStrictSSL', true),
+            headers: headers
+        }, (response) => {
+            if (response.statusCode === 301 || response.statusCode === 302) { // If redirected
+                // Download from new location
+                let redirectUrl: string;
+                if (typeof response.headers.location === 'string') {
+                    redirectUrl = response.headers.location;
+                } else {
+                    redirectUrl = response.headers.location[0];
+                }
+                return resolve(downloadFileToStr(redirectUrl, headers));
+            }
+            if (response.statusCode !== 200) { // If request is not successful
+                return reject();
+            }
+            let downloadedData: string = '';
+            response.on('data', (data) => { downloadedData += data; });
+            response.on('error', (error) => { reject(); });
+            response.on('end', () => { resolve(downloadedData); });
+        });
+        request.on('error', (error) => { reject(); });
+        request.end();
+    });
+}

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -222,45 +222,29 @@ async function rateLimitExceeded(): Promise<boolean> {
  * @return Information about the released builds of the C/C++ extension.
  */
 async function getReleaseJson(): Promise<Build[]> {
-    return new Promise<Build[]>((resolve, reject) => {
-        // Create temp file to hold JSON
-        tmp.file(async (err, releaseJsonPath, fd, cleanupCallback) => {
-            if (err) {
-                reject(new Error('Failed to create release json file'));
-                return;
-            }
+    if (await rateLimitExceeded()) {
+        throw new Error('Failed to stay within GitHub API rate limit');
+    }
 
-            try {
-                if (await rateLimitExceeded()) {
-                    throw new Error('Failed to stay within GitHub API rate limit');
-                }
-                // Download release JSON
-                const releaseUrl: string = 'https://api.github.com/repos/Microsoft/vscode-cpptools/releases';
-                const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
-                await util.downloadFileToDestination(releaseUrl, releaseJsonPath, header)
-                    .catch(() => { throw new Error('Failed to download release JSON'); });
+    // Download release JSON
+    const releaseUrl: string = 'https://api.github.com/repos/Microsoft/vscode-cpptools/releases';
+    const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
 
-                // Read the release JSON file
-                const fileContent: string = await util.readFileText(releaseJsonPath)
-                    .catch(() => { throw new Error('Failed to read release JSON file'); } );
+    const data: string = await util.downloadFileToStr(releaseUrl, header)
+        .catch(() => { throw new Error('Failed to download release JSON'); });
 
-                // Parse the file
-                let releaseJson: any;
-                try {
-                    releaseJson = JSON.parse(fileContent);
-                } catch (error) {
-                    throw new Error('Failed to parse release JSON');
-                }
+    // Parse the file
+    let releaseJson: any;
+    try {
+        releaseJson = JSON.parse(data);
+    } catch (error) {
+        throw new Error('Failed to parse release JSON');
+    }
 
-                // Type check
-                if (isArrayOfBuilds(releaseJson)) {
-                    resolve(releaseJson);
-                } else {
-                    throw new Error('Release JSON is not of type Build[]');
-                }
-            } catch (error) {
-                reject(error);
-            }
-        });
-    });
+    // Type check
+    if (isArrayOfBuilds(releaseJson)) {
+        return releaseJson;
+    } else {
+        throw new Error('Release JSON is not of type Build[]');
+    }
 }

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -6,7 +6,6 @@
 
 import { PackageVersion } from './packageVersion';
 import * as util from './common';
-import * as tmp from 'tmp';
 import { PlatformInformation } from './platform';
 import { OutgoingHttpHeaders } from 'http';
 

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -196,7 +196,7 @@ function isRateLimit(input: any): input is RateLimit {
 async function getRateLimit(): Promise<RateLimit> {
     try {
         const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
-        let data: string = await util.downloadFileToStr('https://api.github.com/rate_limit', header)
+        const data: string = await util.downloadFileToStr('https://api.github.com/rate_limit', header)
             .catch(() => { throw new Error('Failed to download rate limit JSON'); });
 
         let rateLimit: any;
@@ -217,7 +217,7 @@ async function getRateLimit(): Promise<RateLimit> {
 }
 
 async function rateLimitExceeded(): Promise<boolean> {
-    let rateLimit: RateLimit = await getRateLimit();
+    const rateLimit: RateLimit = await getRateLimit();
     if (rateLimit.rate.remaining <= 0) {
         return Promise.resolve(true);
     } else {

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -186,15 +186,14 @@ interface RateLimit {
 }
 
 function isRate(input: any): input is Rate {
-    return input && input.remaining && typeof(input.remaining) === 'number';
+    return input && input.remaining && util.isNumber(input.remaining);
 }
 
 function isRateLimit(input: any): input is RateLimit {
-    return input && input.rate && isRate(input.rate);
+    return input && isRate(input.rate);
 }
 
 async function getRateLimit(): Promise<RateLimit> {
-    try {
         const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
         const data: string = await util.downloadFileToStr('https://api.github.com/rate_limit', header)
             .catch(() => { throw new Error('Failed to download rate limit JSON'); });
@@ -211,18 +210,11 @@ async function getRateLimit(): Promise<RateLimit> {
         } else {
             throw new Error('Rate limit JSON is not of type RateLimit');
         }
-    } catch (error) {
-        return Promise.reject(error);
-    }
 }
 
 async function rateLimitExceeded(): Promise<boolean> {
     const rateLimit: RateLimit = await getRateLimit();
-    if (rateLimit.rate.remaining <= 0) {
-        return Promise.resolve(true);
-    } else {
-        return Promise.resolve(false);
-    }
+    return rateLimit.rate.remaining <= 0;
 }
 
 /**

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -194,22 +194,22 @@ function isRateLimit(input: any): input is RateLimit {
 }
 
 async function getRateLimit(): Promise<RateLimit> {
-        const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
-        const data: string = await util.downloadFileToStr('https://api.github.com/rate_limit', header)
-            .catch(() => { throw new Error('Failed to download rate limit JSON'); });
+    const header: OutgoingHttpHeaders = { 'User-Agent': 'vscode-cpptools' };
+    const data: string = await util.downloadFileToStr('https://api.github.com/rate_limit', header)
+        .catch(() => { throw new Error('Failed to download rate limit JSON'); });
 
-        let rateLimit: any;
-        try {
-            rateLimit = JSON.parse(data);
-        } catch (error) {
-            throw new Error('Failed to parse rate limit JSON');
-        }
+    let rateLimit: any;
+    try {
+        rateLimit = JSON.parse(data);
+    } catch (error) {
+        throw new Error('Failed to parse rate limit JSON');
+    }
 
-        if (isRateLimit(rateLimit)) {
-            return Promise.resolve(rateLimit);
-        } else {
-            throw new Error('Rate limit JSON is not of type RateLimit');
-        }
+    if (isRateLimit(rateLimit)) {
+        return Promise.resolve(rateLimit);
+    } else {
+        throw new Error('Rate limit JSON is not of type RateLimit');
+    }
 }
 
 async function rateLimitExceeded(): Promise<boolean> {


### PR DESCRIPTION
Remove redundant telemetry on failure
Check GitHub API rate limit prior to attempting to download release 
Update error message for failing to parse release JSON into type Build[]