### PR TITLE
remove telemetry that is already being blocked

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -16,7 +16,7 @@ import * as vscode from 'vscode';
 import { CppToolsApi, CppToolsExtension } from 'vscode-cpptools';
 import { getTemporaryCommandRegistrarInstance, initializeTemporaryCommandRegistrar } from './commands';
 import { PlatformInformation } from './platform';
-import { PackageManager, PackageManagerError, PackageManagerWebResponseError, IPackage } from './packageManager';
+import { PackageManager, PackageManagerError, IPackage } from './packageManager';
 import { PersistentState } from './LanguageServer/persistentState';
 import { getInstallationInformation, InstallationInformation, setInstallationStage } from './installationInformation';
 import { Logger, getOutputChannelLogger, showOutputChannel } from './logger';

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -192,17 +192,6 @@ function handleError(error: any): void {
     let errorMessage: string;
 
     if (error instanceof PackageManagerError) {
-        // If this is a WebResponse error, log the IP that it resolved from the package URL
-        if (error instanceof PackageManagerWebResponseError) {
-            let webRequestPackageError: PackageManagerWebResponseError = error;
-            if (webRequestPackageError.socket) {
-                let address: any = webRequestPackageError.socket.address();
-                if (address) {
-                    installationInformation.telemetryProperties['error.targetIP'] = address.address + ':' + address.port;
-                }
-            }
-        }
-
         let packageError: PackageManagerError = error;
 
         installationInformation.telemetryProperties['error.methodName'] = packageError.methodName;


### PR DESCRIPTION
I'm not sure when this was added, but it is not being processed by our system as we never approved it, so there's no sense in sending it anymore.

Note: I believe that these were the IP's of the CDNs hosting our binaries so we could track failures to a specific node.