### PR TITLE
Grdowns/update channel fix

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -262,8 +262,13 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
 
         // Install the VSIX
         return new Promise<void>((resolve, reject) => {
-            let process: ChildProcess = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation], {shell: true});
-            if (process.pid === undefined) {
+            let process: ChildProcess;
+            try {
+                process = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation], {shell: true});
+                if (process.pid === undefined) {
+                    throw new Error;
+                }
+            } catch (error) {
                 reject(new Error('Failed to launch VS Code script process for installation'));
                 return;
             }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -344,7 +344,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
         });
     });
     await p.catch((error: Error) => {
-        // Handle .then following getTargetBuildInfo rejection'
+        // Handle .then following getTargetBuildInfo rejection
         if (error.message.indexOf('/') !== -1 || error.message.indexOf('\\') !== -1) {
             error.message = "Potential PII hidden";
         }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -344,7 +344,10 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
         });
     });
     await p.catch((error: Error) => {
-        // Handle .then following getTargetBuildInfo rejection
+        // Handle .then following getTargetBuildInfo rejection'
+        if (error.message.indexOf('/') != -1 || error.message.indexOf('\\') != -1) {
+            error.message = "Potential PII hidden";
+        }
         telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
         throw error;
     });

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -266,7 +266,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
             try {
                 process = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation], {shell: true});
                 if (process.pid === undefined) {
-                    throw new Error;
+                    throw new Error();
                 }
             } catch (error) {
                 reject(new Error('Failed to launch VS Code script process for installation'));
@@ -345,7 +345,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
     });
     await p.catch((error: Error) => {
         // Handle .then following getTargetBuildInfo rejection'
-        if (error.message.indexOf('/') != -1 || error.message.indexOf('\\') != -1) {
+        if (error.message.indexOf('/') !== -1 || error.message.indexOf('\\') !== -1) {
             error.message = "Potential PII hidden";
         }
         telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -262,7 +262,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
 
         // Install the VSIX
         return new Promise<void>((resolve, reject) => {
-            let process: ChildProcess = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation]);
+            let process: ChildProcess = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation], {shell: true});
             if (process.pid === undefined) {
                 reject(new Error('Failed to launch VS Code script process for installation'));
                 return;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -242,10 +242,10 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                     cmdFile = 'code.cmd';
                 }
                 const vsCodeExeDir: string = path.dirname(process.execPath);
-                return '"' + path.join(vsCodeExeDir, 'bin', cmdFile) + '"';
+                return path.join(vsCodeExeDir, 'bin', cmdFile);
             } else if (platformInfo.platform === 'darwin') {
-                return '"' + path.join(process.execPath, '..', '..', '..', '..', '..',
-                    'Resources', 'app', 'bin', 'code') + '"';
+                return path.join(process.execPath, '..', '..', '..', '..', '..',
+                    'Resources', 'app', 'bin', 'code');
             } else {
                 const vsCodeBinName: string = path.basename(process.execPath);
                 try {
@@ -264,7 +264,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
         return new Promise<void>((resolve, reject) => {
             let process: ChildProcess;
             try {
-                process = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation], {shell: true});
+                process = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation]);
                 if (process.pid === undefined) {
                     throw new Error;
                 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -301,10 +301,6 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
  * @param updateChannel The user's updateChannel setting.
  */
 async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
-    // Helper fn to avoid code duplication
-    let logFailure: (error: Error) => void = (error: Error) => {
-        telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
-    };
     // Wrap in new Promise to allow tmp.file callback to successfully resolve/reject
     // as tmp.file does not do anything with the callback functions return value
     const p: Promise<void> = new Promise<void>((resolve, reject) => {
@@ -349,7 +345,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
     });
     await p.catch((error: Error) => {
         // Handle .then following getTargetBuildInfo rejection
-        logFailure(error);
+        telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
         throw error;
     });
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -349,7 +349,6 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
             error.message = "Potential PII hidden";
         }
         telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
-        throw error;
     });
 }
 

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -101,7 +101,9 @@ function vsixNameForPlatform(info: PlatformInformation): string {
             default: {
                 switch (platformInfo.architecture) {
                     case 'x86_64': return 'cpptools-linux.vsix';
-                    default: return 'cpptools-linux32.vsix';
+                    case 'x86':
+                    case 'i386':
+                    case 'i686': return 'cpptools-linux32.vsix';
                 }
             }
         }

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -100,8 +100,8 @@ function vsixNameForPlatform(info: PlatformInformation): string {
             case 'darwin': return 'cpptools-osx.vsix';
             default: {
                 switch (platformInfo.architecture) {
-                    case 'x86': return 'cpptools-linux32.vsix';
                     case 'x86_64': return 'cpptools-linux.vsix';
+                    default: return 'cpptools-linux32.vsix';
                 }
             }
         }


### PR DESCRIPTION
Removed surrounding quotes on calls to spawn on Windows and Mac
Add try/catch around spawn to override any possible exceptions
Default vsixname to cpptools-linux32.vsix
Move logFailure inline
Remove potential PII from error message to be on the safe side