### PR TITLE
Command translation enabled, added italian locale for command titles.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -472,88 +472,88 @@
     "commands": [
       {
         "command": "C_Cpp.ConfigurationSelect",
-        "title": "Select a Configuration...",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.configurationSelect.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ConfigurationProviderSelect",
-        "title": "Change Configuration Provider...",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.configurationProviderSelect.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ConfigurationEdit",
-        "title": "Edit Configurations...",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.configurationEdit.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.GoToDeclaration",
-        "title": "Go to Declaration",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.goToDeclaration.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.PeekDeclaration",
-        "title": "Peek Declaration",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.peekDeclaration.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.SwitchHeaderSource",
-        "title": "Switch Header/Source",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.switchHeaderSource.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.Navigate",
-        "title": "Navigate...",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.navigate.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ToggleSnippets",
-        "title": "Toggle Snippets",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.toggleSnippets.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ToggleErrorSquiggles",
-        "title": "Toggle Error Squiggles",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.toggleErrorSquiggles.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ToggleIncludeFallback",
-        "title": "Toggle IntelliSense Engine Fallback on Include Errors",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.toggleIncludeFallback.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ToggleDimInactiveRegions",
-        "title": "Toggle Inactive Region Colorization",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.toggleDimInactiveRegions.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ShowReleaseNotes",
-        "title": "Show Release Notes",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.showReleaseNotes.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ResetDatabase",
-        "title": "Reset IntelliSense Database",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.resetDatabase.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.PauseParsing",
-        "title": "Pause Parsing",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.pauseParsing.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ResumeParsing",
-        "title": "Resume Parsing",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.resumeParsing.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.ShowParsingCommands",
-        "title": "Show Parsing Commands",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.showParsingCommands.title%",
+        "category": "C/C++"
       },
       {
         "command": "C_Cpp.TakeSurvey",
-        "title": "Take Survey",
-        "category": "C/Cpp"
+        "title": "%c_cpp.command.takeSurvey.title%",
+        "category": "C/C++"
       }
     ],
     "keybindings": [

--- a/Extension/package.nls.it.json
+++ b/Extension/package.nls.it.json
@@ -1,0 +1,19 @@
+{
+    "c_cpp.command.configurationSelect.title": "Scegli una configurazione...",
+    "c_cpp.command.configurationProviderSelect.title": "Cambia provider configurazioni...",
+    "c_cpp.command.configurationEdit.title": "Modifica configurazioni...",
+    "c_cpp.command.goToDeclaration.title": "Vai a dichiarazione",
+    "c_cpp.command.peekDeclaration.title": "Visualizza dichiarazione",
+    "c_cpp.command.switchHeaderSource.title": "Visualizza Header/Sorgente",
+    "c_cpp.command.navigate.title": "Naviga...",
+    "c_cpp.command.toggleSnippets.title": "Attiva/Disattiva frammenti di codice",
+    "c_cpp.command.toggleErrorSquiggles.title": "Attiva/Disattiva sottolineamento errori",
+    "c_cpp.command.toggleIncludeFallback.title": "Attiva/Disattiva motore di fallback IntelliSense negli errori di inclusione",
+    "c_cpp.command.toggleDimInactiveRegions.title": "Attiva/Disattiva colorazione regioni inattive",
+    "c_cpp.command.showReleaseNotes.title": "Mostra note di rilascio",
+    "c_cpp.command.resetDatabase.title": "Reimposta il database di IntelliSense",
+    "c_cpp.command.pauseParsing.title": "Metti in pausa l'analisi del codice",
+    "c_cpp.command.resumeParsing.title": "Riprendi l'analisi del codice",
+    "c_cpp.command.showParsingCommands.title": "Mostra comandi per l'analisi del codice",
+    "c_cpp.command.takeSurvey.title": "Partecipa al Sondaggio"
+}

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -1,0 +1,19 @@
+{
+    "c_cpp.command.configurationSelect.title": "Select a configuration...",
+    "c_cpp.command.configurationProviderSelect.title": "Change configuration provider...",
+    "c_cpp.command.configurationEdit.title": "Edit configurations...",
+    "c_cpp.command.goToDeclaration.title": "Go to declaration",
+    "c_cpp.command.peekDeclaration.title": "Peek declaration",
+    "c_cpp.command.switchHeaderSource.title": "Switch Header/Source",
+    "c_cpp.command.navigate.title": "Navigate...",
+    "c_cpp.command.toggleSnippets.title": "Toggle snippets",
+    "c_cpp.command.toggleErrorSquiggles.title": "Toggle error squiggles",
+    "c_cpp.command.toggleIncludeFallback.title": "Toggle IntelliSense engine fallback on include errors",
+    "c_cpp.command.toggleDimInactiveRegions.title": "Toggle inactive region colorization",
+    "c_cpp.command.showReleaseNotes.title": "Show release notes",
+    "c_cpp.command.resetDatabase.title": "Reset IntelliSense database",
+    "c_cpp.command.pauseParsing.title": "Pause parsing",
+    "c_cpp.command.resumeParsing.title": "Resume parsing",
+    "c_cpp.command.showParsingCommands.title": "Show parsing commands",
+    "c_cpp.command.takeSurvey.title": "Take survey"
+}


### PR DESCRIPTION
Moved english commands translation to package.nls.json, added commands translation for italian locale and modified package.json to use localization files.

Preview:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/11614285/46893534-8d2d9080-ce71-11e8-8054-51bbdc411f62.gif)