### PR TITLE
Attempt to fix download failure.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -335,8 +335,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
                             .catch(() => { throw new Error('Failed to download VSIX package'); });
                     } catch (error) {
                         // Try again with the proxySupport to "off".
-                        let currentProxySupport = config.inspect<string>('http.proxySupport').globalValue;
-                        if (currentProxySupport !== originalProxySupport) {
+                        if (originalProxySupport !== config.inspect<string>('http.proxySupport').globalValue) {
                             config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
                             reject(error); // Changing the proxySupport didn't help.
                             return;
@@ -348,8 +347,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
                         reject(error);
                         return;
                     }
-                    let currentProxySupport = config.inspect<string>('http.proxySupport').globalValue;
-                    if (currentProxySupport !== originalProxySupport) {
+                    if (originalProxySupport !== config.inspect<string>('http.proxySupport').globalValue) {
                         config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
                     }
                     break;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -349,6 +349,7 @@ async function checkAndApplyUpdate(updateChannel: string): Promise<void> {
                     }
                     if (originalProxySupport !== config.inspect<string>('http.proxySupport').globalValue) {
                         config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
+                        telemetry.logLanguageServerEvent('installVsix', { 'error': "Success with http.proxySupport off", 'success': 'true' });
                     }
                     break;
                 }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -625,16 +625,6 @@ export function downloadFileToDestination(urlStr: string, destinationPath: strin
                 return resolve(downloadFileToDestination(redirectUrl, destinationPath, headers));
             }
             if (response.statusCode !== 200) { // If request is not successful
-                // Try again with proxySupport "off".
-                let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-                if (config.get('http.proxySupport') !== "off") {
-                    let workspaceValue = config.inspect('http.proxySupport').workspaceValue;
-                    config.update('http.proxySupport', "off", false); // Save the existing workspace setting.
-                    return resolve(downloadFileToDestination(urlStr, destinationPath, headers).then((result) => {
-                        config.update('http.proxySupport', workspaceValue, false); // Restore the workspace setting.
-                        return result;
-                    }));
-                }
                 return reject();
             }
             // Write file using downloaded data


### PR DESCRIPTION
This explains why we have 1000 users with "Failed to download VSIX" results.

The current users of VS Code Insiders won't be able to auto-upgrade to 0.21.0-insiders until they get this fix in the non-Insiders release.