### PR TITLE
Disable wordBasedSuggestions by default.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1367,10 +1367,10 @@
     },
     "configurationDefaults": {
       "[cpp]": {
-        "editor.autoIndent": false
+        "editor.wordBasedSuggestions": false
       },
       "[c]": {
-        "editor.autoIndent": false
+        "editor.wordBasedSuggestions": false
       }
     },
     "snippets": [


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vscode-cpptools/issues/2943 .