### PR TITLE
Fix CLI mismatch for downgrading

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -252,7 +252,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                 return path.join(vsCodeExeDir, 'bin', cmdFile);
             } else if (platformInfo.platform === 'darwin') {
                 return path.join(process.execPath, '..', '..', '..', '..', '..',
-                'Resources', 'app', 'bin', 'code');
+                    'Resources', 'app', 'bin', 'code');
             } else {
                 const vsCodeBinName: string = path.basename(process.execPath);
                 try {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -279,7 +279,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                         throw new Error();
                     }
                 } catch (error) {
-                    reject(new Error('Failed to launch VS Code script process for installation with Code version greater than or equal to  1.28.0'));
+                    reject(new Error('Failed to launch VS Code script process for installation'));
                     return;
                 }
                 resolve();
@@ -294,7 +294,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                     throw new Error();
                 }
             } catch (error) {
-                reject(new Error('Failed to launch VS Code script process for installation with Code version less than 1.28.0'));
+                reject(new Error('Failed to launch VS Code script process for installation'));
                 return;
             }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -22,6 +22,7 @@ import { Range } from 'vscode-languageclient';
 import { ChildProcess, spawn, execSync } from 'child_process';
 import * as tmp from 'tmp';
 import { getTargetBuildInfo } from '../githubAPI';
+import { PackageVersion } from '../packageVersion';
 
 let prevCrashFile: string;
 let clients: ClientCollection;
@@ -251,7 +252,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                 return path.join(vsCodeExeDir, 'bin', cmdFile);
             } else if (platformInfo.platform === 'darwin') {
                 return path.join(process.execPath, '..', '..', '..', '..', '..',
-                    'Resources', 'app', 'bin', 'code');
+                'Resources', 'app', 'bin', 'code');
             } else {
                 const vsCodeBinName: string = path.basename(process.execPath);
                 try {
@@ -266,7 +267,25 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
             return Promise.reject(new Error('Failed to find VS Code script'));
         }
 
-        // Install the VSIX
+        // 1.28.0 changes the CLI for making installations
+        let userVersion: PackageVersion = new PackageVersion(vscode.version);
+        let breakingVersion: PackageVersion = new PackageVersion('1.28.0');
+        if (userVersion.isGreaterThan(breakingVersion, 'insider')) {
+            return new Promise<void>((resolve, reject) => {
+                let process: ChildProcess;
+                try {
+                    process = spawn(vsCodeScriptPath, ['--install-extension', vsixLocation, '--force']);
+                    if (process.pid === undefined) {
+                        throw new Error();
+                    }
+                } catch (error) {
+                    reject(new Error('Failed to launch VS Code script process for installation'));
+                    return;
+                }
+                resolve();
+            });
+        }
+
         return new Promise<void>((resolve, reject) => {
             let process: ChildProcess;
             try {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -279,7 +279,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                         throw new Error();
                     }
                 } catch (error) {
-                    reject(new Error('Failed to launch VS Code script process for installation'));
+                    reject(new Error('Failed to launch VS Code script process for installation with Code version greater than or equal to  1.28.0'));
                     return;
                 }
                 resolve();
@@ -294,7 +294,7 @@ async function installVsix(vsixLocation: string, updateChannel: string): Promise
                     throw new Error();
                 }
             } catch (error) {
-                reject(new Error('Failed to launch VS Code script process for installation'));
+                reject(new Error('Failed to launch VS Code script process for installation with Code version less than 1.28.0'));
                 return;
             }
 

--- a/Extension/src/packageVersion.ts
+++ b/Extension/src/packageVersion.ts
@@ -40,9 +40,8 @@ export class PackageVersion {
         }
     }
 
-    public isGreaterThan(other: PackageVersion): boolean {
-        // PackageVersions cannot be compared if either have a suffix that is not 'insiders'
-        if ((this.suffix && !this.suffix.startsWith('insiders')) || (other.suffix && !other.suffix.startsWith('insiders'))) {
+    public isGreaterThan(other: PackageVersion, suffixStr: string = 'insiders'): boolean {
+        if ((this.suffix && !this.suffix.startsWith(suffixStr)) || (other.suffix && !other.suffix.startsWith(suffixStr))) {
             return false;
         }
 


### PR DESCRIPTION
The September update for VS Code added a CLI change that breaks downgrading. Check user's VS Code/-Insiders version then use the appropriate install command