### PR TITLE
Fix regex to allow non-recursive includePath

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Pull Request
+* Allow the workspace root to be a non-recursive includePath. [#3121](https://github.com/Microsoft/vscode-cpptools/issues/3121)
+
 ## Version 0.22.0-insiders February 5, 2019
 * Fix signature help active parameter selection when parameter names are missing or subsets of each other. [#2952](https://github.com/Microsoft/vscode-cpptools/issues/2952)
 * Render macro hover expansions as C/C++. [#3075](https://github.com/Microsoft/vscode-cpptools/issues/3075)

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,11 +1,10 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Pull Request
-* Allow the workspace root to be a non-recursive includePath. [#3121](https://github.com/Microsoft/vscode-cpptools/issues/3121)
-
 ## Version 0.22.0-insiders February 5, 2019
 * Fix signature help active parameter selection when parameter names are missing or subsets of each other. [#2952](https://github.com/Microsoft/vscode-cpptools/issues/2952)
 * Render macro hover expansions as C/C++. [#3075](https://github.com/Microsoft/vscode-cpptools/issues/3075)
+* Allow * in includePath to apply to browse.path when browse.path is not specified. [#3121](https://github.com/Microsoft/vscode-cpptools/issues/3121)
+  * Tucker Kern (@mill1000) [PR #3122](https://github.com/Microsoft/vscode-cpptools/pull/3122)
 
 ## Version 0.21.0 January 23, 2019
 ### New Features

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -481,7 +481,7 @@ export class CppProperties {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (-1 === configuration.includePath.findIndex((value: string, index: number) => {
-                        return !!value.match(/^\$\{(workspaceRoot|workspaceFolder)\}(\\|\\\*\*|\/|\/\*\*)?$/g);
+                        return !!value.match(/^\$\{(workspaceRoot|workspaceFolder)\}(\\\*{0,2}|\/\*{0,2})?$/g);
                     })) {
                         configuration.browse.path.push("${workspaceFolder}");
                     }


### PR DESCRIPTION
Allow non-recursive ${workspaceRoot} or ${workspaceFoldeR} in includePath when constructing the browse.path from the includePath. Solves #3121.