### PR TITLE
Fix Remote Process Picker 

### DIFF
--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -105,9 +105,10 @@ export class RemoteAttachPicker {
 
     private getRemoteOSAndProcesses(pipeCmd: string): Promise<AttachItem[]> {
         // Commands to get OS and processes
-        const command: string = `sh -c 'uname && if [ $(uname) = "Linux" ] ; then ${PsProcessParser.psLinuxCommand} ; elif [ $(uname) = "Darwin" ] ; ` +
-            `then ${PsProcessParser.psDarwinCommand}; fi'`;
+        const command: string = `sh -c "uname && if [ $(uname) = \\\"Linux\\\" ] ; then ${PsProcessParser.psLinuxCommand} ; elif [ $(uname) = \\\"Darwin\\\" ] ; ` +
+            `then ${PsProcessParser.psDarwinCommand}; fi"`;
 
+        // Must use single quotes around ${command}. Linux systems evaluate $() within double-quotes.
         return execChildProcess(`${pipeCmd} '${command}'`, null, this._channel).then(output => {
             // OS will be on first line
             // Processess will follow if listed


### PR DESCRIPTION
Validated ${command} with shell check. 

Fixes https://github.com/Microsoft/vscode-cpptools/issues/2585 and https://github.com/Microsoft/vscode-cpptools/issues/3150

