### PR TITLE
Enable ${command:cpptools.activeConfigName} in tasks #1524

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -584,7 +584,7 @@ export function registerCommands(): void {
     disposables.push(vscode.commands.registerCommand('C_Cpp.ResumeParsing', onResumeParsing));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ShowParsingCommands', onShowParsingCommands));
     disposables.push(vscode.commands.registerCommand('C_Cpp.TakeSurvey', onTakeSurvey));
-    disposables.push(vscode.commands.registerCommand('cpptools.activeConfig', onGetActiveConfig));
+    disposables.push(vscode.commands.registerCommand('cpptools.activeConfigName', onGetActiveConfigName));
     getTemporaryCommandRegistrarInstance().executeDelayedCommands();
 }
 
@@ -766,7 +766,7 @@ function onTakeSurvey(): void {
     vscode.commands.executeCommand('vscode.open', uri);
 }
 
-function onGetActiveConfig(): Thenable<string> {
+function onGetActiveConfigName(): Thenable<string> {
     return clients.ActiveClient.getCurrentConfigName();
 }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -584,6 +584,7 @@ export function registerCommands(): void {
     disposables.push(vscode.commands.registerCommand('C_Cpp.ResumeParsing', onResumeParsing));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ShowParsingCommands', onShowParsingCommands));
     disposables.push(vscode.commands.registerCommand('C_Cpp.TakeSurvey', onTakeSurvey));
+    disposables.push(vscode.commands.registerCommand('cpptools.activeConfig', onGetActiveConfig));
     getTemporaryCommandRegistrarInstance().executeDelayedCommands();
 }
 
@@ -763,6 +764,10 @@ function onTakeSurvey(): void {
     telemetry.logLanguageServerEvent("onTakeSurvey");
     let uri: vscode.Uri = vscode.Uri.parse(`https://www.research.net/r/VBVV6C6?o=${os.platform()}&m=${vscode.env.machineId}`);
     vscode.commands.executeCommand('vscode.open', uri);
+}
+
+function onGetActiveConfig(): Thenable<string> {
+    return clients.ActiveClient.getCurrentConfigName();
 }
 
 function reportMacCrashes(): void {


### PR DESCRIPTION
Allow for tasks to query the active configuration as requested in issue #1524 