### PR TITLE
Disable AutoPCH for older Macs.

### DIFF
--- a/Extension/package-lock.json
+++ b/Extension/package-lock.json
@@ -16,9 +16,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz",
-      "integrity": "sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==",
+      "version": "8.10.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.43.tgz",
+      "integrity": "sha512-5m5W13HR2k3cu88mpzlnPBBv5+GyMHtj4F0P83RG4mqoC0AYVYHVMHfF3SgwKNtqEZiZQASMxU92QsLEekKcnw==",
       "dev": true
     },
     "agent-base": {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1435,7 +1435,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",
-    "@types/node": "^8.10.40",
+    "@types/node": "^8.10.43",
     "async-child-process": "^1.1.1",
     "await-notify": "^1.0.1",
     "child-process": "^1.0.2",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -386,7 +386,7 @@ class DefaultClient implements Client {
             const releaseParts: string[] = os.release().split(".");
             if (releaseParts.length >= 1) {
                 // AutoPCH doesn't work for older Mac OS's.
-                intelliSenseCacheDisabled = parseInt(releaseParts[0]) < 18;
+                intelliSenseCacheDisabled = parseInt(releaseParts[0]) < 17;
             }
         }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -30,6 +30,7 @@ import { getTestHook, TestHook } from '../testHook';
 import { getCustomConfigProviders, CustomConfigurationProviderCollection, CustomConfigurationProvider1 } from '../LanguageServer/customProviders';
 import { ABTestSettings, getABTestSettings } from '../abTesting';
 import * as fs from 'fs';
+import * as os from 'os';
 
 let ui: UI;
 const configProviderTimeout: number = 2000;
@@ -379,6 +380,16 @@ class DefaultClient implements Client {
         }
 
         let abTestSettings: ABTestSettings = getABTestSettings();
+        
+        let intelliSenseCacheDisabled: boolean = false;
+        if (os.platform() === "darwin") {
+            const releaseParts: string[] = os.release().split(".");
+            if (releaseParts.length >= 1) {
+                // AutoPCH doesn't work for older Mac OS's.
+                intelliSenseCacheDisabled = parseInt(releaseParts[0]) < 18;
+            }
+        }
+
         let clientOptions: LanguageClientOptions = {
             documentSelector: [
                 { scheme: 'file', language: 'cpp' },
@@ -402,6 +413,7 @@ class DefaultClient implements Client {
                 tab_size: other.editorTabSize,
                 intelliSenseEngine: settings.intelliSenseEngine,
                 intelliSenseEngineFallback: settings.intelliSenseEngineFallback,
+                intelliSenseCacheDisabled: intelliSenseCacheDisabled,
                 intelliSenseCachePath : settings.intelliSenseCachePath,
                 intelliSenseCacheSize : settings.intelliSenseCacheSize,
                 autocomplete: settings.autoComplete,


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vscode-cpptools/issues/3256 . Requires a language server change as well.