### PR TITLE
Ensure clearCustomConfigurations() is called when changing the configurationProvider

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1206,7 +1206,7 @@ class DefaultClient implements Client {
         }).then(() => {
             let newProvider: string = this.configuration.CurrentConfigurationProvider;
             if (this.configurationProvider !== newProvider) {
-                if (this.configurationProvider !== undefined) {
+                if (this.configurationProvider) {
                     this.clearCustomConfigurations();
                 }
                 this.configurationProvider = newProvider;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1206,6 +1206,9 @@ class DefaultClient implements Client {
         }).then(() => {
             let newProvider: string = this.configuration.CurrentConfigurationProvider;
             if (this.configurationProvider !== newProvider) {
+                if (this.configurationProvider !== undefined) {
+                    this.clearCustomConfigurations();
+                }
                 this.configurationProvider = newProvider;
                 this.updateCustomConfigurations();
                 this.updateCustomBrowseConfiguration();


### PR DESCRIPTION
Clears custom configurations when the configurationProvider is changed.