### PR TITLE
Add call to notifyWhenReady, to prevent crash

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -640,7 +640,7 @@ class DefaultClient implements Client {
         let params: QueryTranslationUnitSourceParams = {
             uri: document.uri.toString()
         };
-        let response: QueryTranslationUnitSourceResult = await this.languageClient.sendRequest(QueryTranslationUnitSourceRequest, params);
+        let response: QueryTranslationUnitSourceResult = await this.requestWhenReady(() => this.languageClient.sendRequest(QueryTranslationUnitSourceRequest, params));
         if (response.configDisposition === QueryTranslationUnitSourceConfigDisposition.ConfigNotNeeded) {
             return Promise.resolve();
         }

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -23,12 +23,10 @@ export function createProtocolFilter(me: Client, clients: ClientCollection): Mid
         didOpen: (document, sendMessage) => {
             if (clients.checkOwnership(me, document)) {
                 me.TrackedDocuments.add(document);
-                me.notifyWhenReady(() => {
-                    me.provideCustomConfiguration(document).then(() => {
-                        sendMessage(document);
-                    }, () => {
-                        sendMessage(document);
-                    });
+                me.provideCustomConfiguration(document).then(() => {
+                    sendMessage(document);
+                }, () => {
+                    sendMessage(document);
                 });
             }
         },

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -23,10 +23,12 @@ export function createProtocolFilter(me: Client, clients: ClientCollection): Mid
         didOpen: (document, sendMessage) => {
             if (clients.checkOwnership(me, document)) {
                 me.TrackedDocuments.add(document);
-                me.provideCustomConfiguration(document).then(() => {
-                    sendMessage(document);
-                }, () => {
-                    sendMessage(document);
+                me.notifyWhenReady(() => {
+                    me.provideCustomConfiguration(document).then(() => {
+                        sendMessage(document);
+                    }, () => {
+                        sendMessage(document);
+                    });
                 });
             }
         },


### PR DESCRIPTION
Addresses an issue with a prior change, which added use of languageClient when it may not yet be available.