### PR TITLE
When generating tasks.json, use the editor's tab setting

### DIFF
--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -93,7 +93,7 @@ export class OtherSettings {
         this.resource = resource;
     }
 
-    public get editorTabSize(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("editor", this.resource).get("tabSize"); }
+    public get editorTabSize(): number { return vscode.workspace.getConfiguration("editor", this.resource).get<number>("tabSize"); }
     public get filesAssociations(): any { return vscode.workspace.getConfiguration("files", null).get("associations"); }
     public get filesExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("files", this.resource).get("exclude"); }
     public get searchExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("search", this.resource).get("exclude"); }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -17,6 +17,7 @@ import * as assert from 'assert';
 import * as https from 'https';
 import { ClientRequest, OutgoingHttpHeaders } from 'http';
 import { getBuildTasks } from './LanguageServer/extension';
+import { OtherSettings } from './LanguageServer/settings';
 
 export let extensionContext: vscode.ExtensionContext;
 export function setExtensionContext(context: vscode.ExtensionContext): void {
@@ -88,7 +89,8 @@ export async function ensureBuildTaskExists(taskName: string): Promise<void> {
     }
     
     // TODO: It's dangerous to overwrite this file. We could be wiping out comments.
-    await writeFileText(getTasksJsonPath(), JSON.stringify(rawTasksJson, null, 2));
+    let settings: OtherSettings = new OtherSettings();
+    await writeFileText(getTasksJsonPath(), JSON.stringify(rawTasksJson, null, settings.editorTabSize));
 }
 
 export function fileIsCOrCppSource(file: string): boolean {


### PR DESCRIPTION
We were creating tasks.json with 2 space indents.  Use the editor setting instead.