### PR TITLE
Add debugHeap toggle and turn off by default

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1230,7 +1230,7 @@
               },
               "enableDebugHeap": {
                 "type": "boolean",
-                "description": "If false, the process will be launched with debug heaps disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+                "description": "If false, the process will be launched with debug heap disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
                 "default": false
               },
               "logging": {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1228,6 +1228,11 @@
                   "<source-path>": "<target-path>"
                 }
               },
+              "enableDebugHeap": {
+                "type": "boolean",
+                "description": "If false, the process will be launched with debug heaps disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+                "default": false
+              },
               "logging": {
                 "type": "object",
                 "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -179,10 +179,23 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
 	 */
     resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
         if (config) {
-            // Fail if cppvsdbg type is running on non-Windows
-            if (config.type === 'cppvsdbg' && os.platform() !== 'win32') {
-                vscode.window.showErrorMessage("Debugger of type: 'cppvsdbg' is only available on Windows. Use type: 'cppdbg' on the current OS platform.");
-                return undefined;
+            if (config.type === 'cppvsdbg') {
+                // Fail if cppvsdbg type is running on non-Windows
+                if (os.platform() !== 'win32') {
+                    vscode.window.showErrorMessage("Debugger of type: 'cppvsdbg' is only available on Windows. Use type: 'cppdbg' on the current OS platform.");
+                    return undefined;
+                }
+
+                // Disable debug heap by default, enable if 'enableDebugHeap' is set.
+                if (!config.enableDebugHeap) {
+                    const disableDebugHeapEnvSetting : any = {"name" : "_NO_DEBUG_HEAP", "value" : "1"};
+
+                    if (config.environment && util.isArray(config.environment)) {
+                        config.environment.push(disableDebugHeapEnvSetting);
+                    } else {
+                        config.environment = [disableDebugHeapEnvSetting];
+                    }
+                }
             }
 
             // Modify WSL config for OpenDebugAD7

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -461,6 +461,11 @@
             "<source-path>": "<target-path>"
           }
         },
+        "enableDebugHeap": {
+          "type": "boolean",
+          "description": "If false, the process will be launched with debug heaps disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+          "default": false
+        },
         "logging": {
           "type": "object",
           "description": "Optional flags to determine what types of messages should be logged to the Debug Console.",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -463,7 +463,7 @@
         },
         "enableDebugHeap": {
           "type": "boolean",
-          "description": "If false, the process will be launched with debug heaps disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+          "description": "If false, the process will be launched with debug heap disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
           "default": false
         },
         "logging": {


### PR DESCRIPTION
This PR adds a launch.json setting to enable debugHeap if users are
intersted in using it. By default, debug heap will be disabled.

@gregg-miskelly