### PR TITLE
Update Select Configurations command to offer Edit Configs JSON option

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -436,6 +436,10 @@ export class CppProperties {
 
     public select(index: number): Configuration {
         if (index === this.configurationJson.configurations.length) {
+            this.handleConfigurationEditUICommand(vscode.window.showTextDocument);
+            return;
+        }
+        if (index === this.configurationJson.configurations.length + 1) {
             this.handleConfigurationEditJSONCommand(vscode.window.showTextDocument);
             return;
         }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -436,7 +436,7 @@ export class CppProperties {
 
     public select(index: number): Configuration {
         if (index === this.configurationJson.configurations.length) {
-            this.handleConfigurationEditCommand(vscode.window.showTextDocument);
+            this.handleConfigurationEditJSONCommand(vscode.window.showTextDocument);
             return;
         }
 

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -171,7 +171,7 @@ export class UI {
         for (let i: number = 0; i < configurationNames.length; i++) {
             items.push({ label: configurationNames[i], description: "", index: i });
         }
-        items.push({ label: "Edit Configurations...", description: "", index: configurationNames.length });
+        items.push({ label: "Edit Configurations (JSON)", description: "", index: configurationNames.length });
 
         return vscode.window.showQuickPick(items, options)
             .then(selection => (selection) ? selection.index : -1);

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -171,7 +171,8 @@ export class UI {
         for (let i: number = 0; i < configurationNames.length; i++) {
             items.push({ label: configurationNames[i], description: "", index: i });
         }
-        items.push({ label: "Edit Configurations (JSON)", description: "", index: configurationNames.length });
+        items.push({ label: "Edit Configurations (UI)", description: "", index: configurationNames.length });
+        items.push({ label: "Edit Configurations (JSON)", description: "", index: configurationNames.length + 1 });
 
         return vscode.window.showQuickPick(items, options)
             .then(selection => (selection) ? selection.index : -1);


### PR DESCRIPTION
The "Select Configuration..." command will display a list of configurations to choose between, or an option to "Edit Configurations...".

Settings UI uses this Select Configurations command to allow the user to change which configuration is currently being edited.

Because the user is likely to select the option to edit configurations when the configuration they want to select is not on the list, and because settings UI does not yet allow new configurations to be added, we should offer "Edit Configurations (JSON)" in the selection list instead.
