### PR TITLE
Various settings UI load/save related changes

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -607,7 +607,7 @@ export class CppProperties {
                     if (this.settingsPanel === undefined) {
                         this.settingsPanel = new SettingsPanel();
                         this.settingsPanel.SettingsPanelActivated(() => this.onSettingsPanelActivated());
-                        this.settingsPanel.SettingsPanelStateChanged(() => this.saveConfigurationUI());
+                        this.settingsPanel.ConfigValuesChanged(() => this.saveConfigurationUI());
                         this.disposables.push(this.settingsPanel);
                     }
                     this.settingsPanel.createOrShow(this.configurationJson.configurations[this.currentConfigurationIndex.Value]);

--- a/Extension/src/LanguageServer/settingsPanel.ts
+++ b/Extension/src/LanguageServer/settingsPanel.ts
@@ -25,7 +25,7 @@ export class SettingsPanel {
     private configValues: config.Configuration;
     private isIntelliSenseModeDefined: boolean = false;
     private settingsPanelActivated = new vscode.EventEmitter<void>();
-    private settingsPanelStateChanged = new vscode.EventEmitter<void>();
+    private configValuesChanged = new vscode.EventEmitter<void>();
     private panel: vscode.WebviewPanel;
     private disposable: vscode.Disposable = undefined;
     private disposablesPanel: vscode.Disposable = undefined;
@@ -35,7 +35,8 @@ export class SettingsPanel {
     constructor() {
         this.configValues = { name: undefined };
         this.disposable = vscode.Disposable.from(
-            this.settingsPanelStateChanged,
+            this.settingsPanelActivated,
+            this.configValuesChanged,
             vscode.window.onDidChangeWindowState(this.onWindowStateChanged, this)
         );
     }
@@ -86,8 +87,8 @@ export class SettingsPanel {
         return this.settingsPanelActivated.event;
     }
 
-    public get SettingsPanelStateChanged(): vscode.Event<void> { 
-        return this.settingsPanelStateChanged.event;
+    public get ConfigValuesChanged(): vscode.Event<void> { 
+        return this.configValuesChanged.event;
     }
 
     public getLastValuesFromConfigUI(): config.Configuration {
@@ -191,7 +192,7 @@ export class SettingsPanel {
                 break;
         }
 
-        this.settingsPanelStateChanged.fire();
+        this.configValuesChanged.fire();
     }
 
     private getHtml(): string {

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -79,23 +79,19 @@ class SettingsApp {
         }
     }
 
-    private unescapeConfigString(s: string): string {
-        return s.replace(/\\\\/g, "\\");
-    }
-
     private update(config: any): void {
         this.updating = true;
         try {
-            (<HTMLInputElement>document.getElementById(elementId.activeConfig)).value = this.unescapeConfigString(config.name);
+            (<HTMLInputElement>document.getElementById(elementId.activeConfig)).value = config.name;
 
-            (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ? this.unescapeConfigString(config.compilerPath) : "";
+            (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ? config.compilerPath : "";
             (<HTMLInputElement>document.getElementById(elementId.intelliSenseMode)).value = config.intelliSenseMode ? config.intelliSenseMode : "${default}";
 
             (<HTMLInputElement>document.getElementById(elementId.includePath)).value = 
-                (config.includePath && config.includePath.length > 0) ? this.unescapeConfigString(config.includePath.join("\n")) : "";
+                (config.includePath && config.includePath.length > 0) ? config.includePath.join("\n") : "";
 
             (<HTMLInputElement>document.getElementById(elementId.defines)).value = 
-                (config.defines && config.defines.length > 0 ) ? this.unescapeConfigString(config.defines.join("\n")) : "";
+                (config.defines && config.defines.length > 0 ) ? config.defines.join("\n") : "";
 
             (<HTMLInputElement>document.getElementById(elementId.cStandard)).value = config.cStandard;
             (<HTMLInputElement>document.getElementById(elementId.cppStandard)).value = config.cppStandard;


### PR DESCRIPTION
Integrated parsePropertiesFileAndHandleSquiggles into parsePropertiesFile(true).

Switched from delayed saving to saving immediately as setting change, using a new event.

Removed some escaping logic from parsePropertiesFile(false) not needed for settings UI.

Changed SettingsPanelViewStateChanged to SettingsPanelActivated, only triggered on activation.

Removed previous fix slash escaping fix.
