### PR TITLE
Work around vscode not treating .C files as C++

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -263,6 +263,7 @@ export interface Client {
     handleAddToIncludePathCommand(path: string): void;
     onInterval(): void;
     dispose(): Thenable<void>;
+    addFileAssociations(fileAssociations: string, is_c: boolean): void;
 }
 
 export function createClient(allClients: ClientCollection, workspaceFolder?: vscode.WorkspaceFolder): Client {
@@ -947,7 +948,11 @@ class DefaultClient implements Client {
 
         // TODO: Move this code to a different place?
         if (cppSettings.autoAddFileAssociations && payload.navigation.startsWith("<def")) {
-            this.addFileAssociations(payload.navigation.substr(4));
+            let fileAssociations: string = payload.navigation.substr(4);
+            let is_c: boolean = fileAssociations.startsWith("c");
+            // Skip over rest of header: c>; or >;
+            fileAssociations = fileAssociations.substr(is_c ? 3 : 2);
+            this.addFileAssociations(fileAssociations, is_c);
             return;
         }
 
@@ -961,41 +966,41 @@ class DefaultClient implements Client {
         this.model.navigationLocation.Value = currentNavigation;
     }
 
-    private addFileAssociations(fileAssociations: string): void {
+    public addFileAssociations(fileAssociations: string, is_c: boolean): void {
         let settings: OtherSettings = new OtherSettings(this.RootUri);
         let assocs: any = settings.filesAssociations;
-        let is_c: boolean = fileAssociations.startsWith("c");
 
-        // Skip over rest of header: c>; or >;
-        fileAssociations = fileAssociations.substr(is_c ? 3 : 2);
         let filesAndPaths: string[] = fileAssociations.split(";");
         let foundNewAssociation: boolean = false;
-        for (let i: number = 0; i < filesAndPaths.length - 1; ++i) {
+        for (let i: number = 0; i < filesAndPaths.length; ++i) {
             let fileAndPath: string[] = filesAndPaths[i].split("@");
-            let file: string = fileAndPath[0];
-            let filePath: string = fileAndPath[1];
-            if ((file in assocs) || (("**/" + file) in assocs)) {
-                continue; // File already has an association.
-            }
-            let j: number = file.lastIndexOf('.');
-            if (j !== -1) {
-                let ext: string = file.substr(j);
-                if ((("*" + ext) in assocs) || (("**/*" + ext) in assocs)) {
-                    continue; // Extension already has an association.
+            // Skip empty or malformed
+            if (fileAndPath.length == 2) { 
+                let file: string = fileAndPath[0];
+                let filePath: string = fileAndPath[1];
+                if ((file in assocs) || (("**/" + file) in assocs)) {
+                    continue; // File already has an association.
                 }
-            }
-            let foundGlobMatch: boolean = false;
-            for (let assoc in assocs) {
-                if (minimatch(filePath, assoc)) {
-                    foundGlobMatch = true;
-                    break; // Assoc matched a glob pattern.
+                let j: number = file.lastIndexOf('.');
+                if (j !== -1) {
+                    let ext: string = file.substr(j);
+                    if ((("*" + ext) in assocs) || (("**/*" + ext) in assocs)) {
+                        continue; // Extension already has an association.
+                    }
                 }
+                let foundGlobMatch: boolean = false;
+                for (let assoc in assocs) {
+                    if (minimatch(filePath, assoc)) {
+                        foundGlobMatch = true;
+                        break; // Assoc matched a glob pattern.
+                    }
+                }
+                if (foundGlobMatch) {
+                    continue;
+                }
+                assocs[file] = is_c ? "c" : "cpp";
+                foundNewAssociation = true;
             }
-            if (foundGlobMatch) {
-                continue;
-            }
-            assocs[file] = is_c ? "c" : "cpp";
-            foundNewAssociation = true;
         }
         if (foundNewAssociation) {
             settings.filesAssociations = assocs;
@@ -1496,4 +1501,5 @@ class NullClient implements Client {
         this.stringEvent.dispose();
         return Promise.resolve();
     }
+    addFileAssociations(fileAssociations: string, is_c: boolean): void {}
 }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -975,7 +975,7 @@ class DefaultClient implements Client {
         for (let i: number = 0; i < filesAndPaths.length; ++i) {
             let fileAndPath: string[] = filesAndPaths[i].split("@");
             // Skip empty or malformed
-            if (fileAndPath.length == 2) { 
+            if (fileAndPath.length === 2) {
                 let file: string = fileAndPath[0];
                 let filePath: string = fileAndPath[1];
                 if ((file in assocs) || (("**/" + file) in assocs)) {

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
+import * as path from 'path';
 import { Middleware } from 'vscode-languageclient';
 import { ClientCollection } from './clientCollection';
 import { Client } from './client';
@@ -26,7 +27,7 @@ export function createProtocolFilter(me: Client, clients: ClientCollection): Mid
 
                 // Work around vscode treating ".C" as c, by adding this file name to file associations as cpp
                 if (document.uri.path.endsWith(".C")) {
-                    let fileName: string = document.uri.fsPath.split('\\').pop().split('/').pop();
+                    let fileName: string = path.basename(document.uri.fsPath);
                     let mappingString: string = fileName + "@" + document.uri.fsPath;
                     me.addFileAssociations(mappingString, false);
                 }

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -23,6 +23,14 @@ export function createProtocolFilter(me: Client, clients: ClientCollection): Mid
         didOpen: (document, sendMessage) => {
             if (clients.checkOwnership(me, document)) {
                 me.TrackedDocuments.add(document);
+
+                // Work around vscode treating ".C" as c, by adding this file name to file associations as cpp
+                if (document.uri.path.endsWith(".C")) {
+                    let fileName: string = document.uri.fsPath.split('\\').pop().split('/').pop();
+                    let mappingString: string = fileName + "@" + document.uri.fsPath;
+                    me.addFileAssociations(mappingString, false);
+                }
+
                 me.provideCustomConfiguration(document).then(() => {
                     sendMessage(document);
                 }, () => {


### PR DESCRIPTION
".C" is associated with C++ by GNU, and Intel.

https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html
http://www.physics.udel.edu/~bnikolic/QTTG/shared/docs/intel_c_user_and_reference_guide.pdf

This works around the issue by adding file associations for any encountered .C file, by name.

This addresses part of: https://github.com/Microsoft/vscode-cpptools/issues/2558
