### PR TITLE
Address issue with trailing backslashes in config path not squiggled

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -764,30 +764,7 @@ export class CppProperties {
             if (handleSquiggles) {
                 // Replace all \<escape character> with \\<character>, except for \"
                 // Otherwise, the JSON.parse result will have the \<escape character> missing.
-                let newResults: string = "";
-                let lastWasBackslash: Boolean = false;
-                let lastBackslashWasEscaped: Boolean = false;
-                for (let i: number = 0; i < readResults.length; i++) {
-                    if (readResults[i] === '\\') {
-                        if (lastWasBackslash) {
-                            newResults += "\\";
-                            lastBackslashWasEscaped = !lastBackslashWasEscaped;
-                        }
-                        else {
-                            lastBackslashWasEscaped = false;
-                        }
-                        newResults += "\\";
-                        lastWasBackslash = true;
-                    } else {
-                        if (lastWasBackslash && (lastBackslashWasEscaped || (readResults[i] !== '"'))) {
-                            newResults += "\\";
-                        }
-                        lastWasBackslash = false;
-                        lastBackslashWasEscaped  = false;
-                        newResults += readResults[i];
-                    }
-                }
-                readResults = newResults;
+                readResults = util.escapeForSquiggles(readResults);
             }
             // Try to use the same configuration as before the change.
             let newJson: ConfigurationJson = JSON.parse(readResults);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -768,8 +768,7 @@ export class CppProperties {
                         }
                         newResults += "\\";
                         lastWasBackslash = true;
-                    }
-                    else {
+                    } else {
                         if (lastWasBackslash && (lastBackslashWasEscaped || (readResults[i] !== '"'))) {
                             newResults += "\\";
                         }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -802,8 +802,7 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
     return { compilerPath, additionalArgs };
 }
 
-export function escapeForSquiggles(s: string): string
-{
+export function escapeForSquiggles(s: string): string {
     // Replace all \<escape character> with \\<character>, except for \"
     // Otherwise, the JSON.parse result will have the \<escape character> missing.
     let newResults: string = "";

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -801,3 +801,35 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
     }
     return { compilerPath, additionalArgs };
 }
+
+export function escapeForSquiggles(s: string): string
+{
+    // Replace all \<escape character> with \\<character>, except for \"
+    // Otherwise, the JSON.parse result will have the \<escape character> missing.
+    let newResults: string = "";
+    let lastWasBackslash: Boolean = false;
+    let lastBackslashWasEscaped: Boolean = false;
+    for (let i: number = 0; i < s.length; i++) {
+        if (s[i] === '\\') {
+            if (lastWasBackslash) {
+                newResults += "\\";
+                lastBackslashWasEscaped = !lastBackslashWasEscaped;
+            } else {
+                lastBackslashWasEscaped = false;
+            }
+            newResults += "\\";
+            lastWasBackslash = true;
+        } else {
+            if (lastWasBackslash && (lastBackslashWasEscaped || (s[i] !== '"'))) {
+                newResults += "\\";
+            }
+            lastWasBackslash = false;
+            lastBackslashWasEscaped  = false;
+            newResults += s[i];
+        }
+    }
+    if (lastWasBackslash) {
+        newResults += "\\";
+    }
+    return newResults;
+}

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as assert from "assert";
-import {  resolveVariables } from "../../src/common";
+import { resolveVariables, escapeForSquiggles } from "../../src/common";
 
 suite("Common Utility validation", () => {
     suite("resolveVariables", () => {
@@ -198,6 +198,25 @@ suite("Common Utility validation", () => {
                 .shouldLookupSymbol("Root");
         });
 
+        test("escapeForSquiggles:", () => {
+            let testEscapeForSquigglesScenario: any = (input: string, expectedOutput: string) => {
+                let result: string = escapeForSquiggles(input);
+                if (result !== expectedOutput) {
+                    throw new Error(`escapeForSquiggles failure: for \"${input}\", \"${result}\" !== \"${expectedOutput}\"`);
+                }
+            };
+
+            testEscapeForSquigglesScenario("\\", "\\\\"); // single backslash
+            testEscapeForSquigglesScenario("\\\"", "\\\""); // escaped quote
+            testEscapeForSquigglesScenario("\\\t", "\\\\\t"); // escaped non-quote
+            testEscapeForSquigglesScenario("\\\\\"", "\\\\\\\\\""); // escaped backslash, unescaped quote
+            testEscapeForSquigglesScenario("\\\\\t", "\\\\\\\\\t"); // escaped backslash, unescaped non-quote
+            testEscapeForSquigglesScenario("\\t", "\\\\t"); // escaped non-quote
+            testEscapeForSquigglesScenario("\\\\\\t", "\\\\\\\\\\\\t"); // escaped backslash, unescaped non-quote
+            testEscapeForSquigglesScenario("\"\"", "\"\""); // empty quoted string
+            testEscapeForSquigglesScenario("\"\\\\\"", "\"\\\\\\\\\""); // quoted string containing escaped backslash
+        });
+
         interface ResolveTestFlowEnvironment {
             withEnvironment(additionalEnvironment: {[key: string]: string | string[]}): ResolveTestFlowAssert;
             shouldLookupSymbol: (key: string) => void;
@@ -229,6 +248,5 @@ suite("Common Utility validation", () => {
                 }
             };
         }
-
     });
 });


### PR DESCRIPTION
The prior approach using a RegEx was identifying a backslash followed by a quote as an escaped quote, even if that backslash was itself escaped.  Unclear how to solve that with RegEx.  Replaced with manual parsing.