### PR TITLE
Add telemetry for missing language service extension binary

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -402,6 +402,7 @@ class DefaultClient implements Client {
         let serverModule: string = getLanguageServerFileName();
         let exeExists: boolean = fs.existsSync(serverModule);
         if (!exeExists) {
+            telemetry.logLanguageServerEvent("missingBinary");
             throw String('Missing binary at ' + serverModule);
         }
         let serverName: string = this.getName(workspaceFolder);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -402,7 +402,7 @@ class DefaultClient implements Client {
         let serverModule: string = getLanguageServerFileName();
         let exeExists: boolean = fs.existsSync(serverModule);
         if (!exeExists) {
-            telemetry.logLanguageServerEvent("missingBinary");
+            telemetry.logLanguageServerEvent("missingLanguageServerBinary");
             throw String('Missing binary at ' + serverModule);
         }
         let serverName: string = this.getName(workspaceFolder);


### PR DESCRIPTION
So we have a better understanding of how severe the missing binaries issues are, such as https://github.com/microsoft/vscode-cpptools/issues/3610 . We've had other missing binary reports in the past (such as from virus scan deletions).