### PR TITLE
Fix issue with extension context not being set before initializeTemporaryCommandRegistrar

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -29,8 +29,8 @@ let reloadMessageShown: boolean = false;
 let disposables: vscode.Disposable[] = [];
 
 export async function activate(context: vscode.ExtensionContext): Promise<CppToolsApi & CppToolsExtension> {
-    initializeTemporaryCommandRegistrar();
     util.setExtensionContext(context);
+    initializeTemporaryCommandRegistrar();
     Telemetry.activate();
     util.setProgress(0);
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/3615