### PR TITLE
fix rename of HTML element in ConfigUI

### DIFF
--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -74,7 +74,7 @@ class SettingsApp {
     private updateConfig(config: any): void {
         this.updating = true;
         try {
-            (<HTMLInputElement>document.getElementById(elementId.activeConfig)).value = config.name;
+            (<HTMLInputElement>document.getElementById(elementId.configName)).value = config.name;
 
             (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ? config.compilerPath : "";
             (<HTMLInputElement>document.getElementById(elementId.intelliSenseMode)).value = config.intelliSenseMode ? config.intelliSenseMode : "${default}";


### PR DESCRIPTION
Renamed an element from "activeConfig" to "configName" and missed one reference of it.