### PR TITLE
Update IntelliSense mode and compiler compatibility validation

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -392,13 +392,13 @@ export class CppProperties {
         if (configuration.compilerPath === undefined ||
             configuration.compilerPath === "" ||
             configuration.compilerPath === "${default}" ||
-            configuration.intelliSenseMode === undefined || 
-            configuration.intelliSenseMode === "" || 
+            configuration.intelliSenseMode === undefined ||
+            configuration.intelliSenseMode === "" ||
             configuration.intelliSenseMode === "${default}") {
             return true;
         }
         let compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(configuration.compilerPath);
-        return compilerPathAndArgs.compilerPath.endsWith("cl.exe") === (configuration.intelliSenseMode === "msvc-x64");
+        return (compilerPathAndArgs.compilerName === "cl.exe") === (configuration.intelliSenseMode === "msvc-x64");
     }
 
     public addToIncludePathCommand(path: string): void {
@@ -920,7 +920,7 @@ export class CppProperties {
         let compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(resolvedCompilerPath);
         if (resolvedCompilerPath &&
             // Don't error cl.exe paths because it could be for an older preview build.
-            !(isWindows && compilerPathAndArgs.compilerPath.endsWith("cl.exe"))) {
+            !(isWindows && compilerPathAndArgs.compilerName === "cl.exe")) {
             resolvedCompilerPath = resolvedCompilerPath.trim();
 
             // Error when the compiler's path has spaces without quotes but args are used.
@@ -1139,7 +1139,7 @@ export class CppProperties {
                 if (isCompilerPath) {
                     resolvedPath = resolvedPath.trim();
                     let compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(resolvedPath);
-                    if (isWindows && compilerPathAndArgs.compilerPath.endsWith("cl.exe")) {
+                    if (isWindows && compilerPathAndArgs.compilerName === "cl.exe") {
                         continue; // Don't squiggle invalid cl.exe paths because it could be for an older preview build.
                     }
                     // Squiggle when the compiler's path has spaces without quotes but args are used.

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -808,8 +808,11 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
                     additionalArgs = compilerPath.substr(spaceStart + 1).split(" ");
                     additionalArgs = additionalArgs.filter((arg: string) => { return arg.trim().length !== 0; }); // Remove empty args.
                     compilerPath = potentialCompilerPath;
-                    compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
                 }
+            }
+            // Get compiler name if there are no args but path is valid or a valid path was found with args.
+            if (checkFileExistsSync(compilerPath)) {
+                compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
             }
         }
     }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -771,11 +771,13 @@ export function downloadFileToStr(urlStr: string, headers?: OutgoingHttpHeaders)
 
 export interface CompilerPathAndArgs {
     compilerPath: string;
+    compilerName: string;
     additionalArgs: string[];
 }
 
 export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerPathAndArgs {
     let compilerPath: string = inputCompilerPath;
+    let compilerName: string = "";
     let additionalArgs: string[];
     let isWindows: boolean = os.platform() === 'win32';
     if (compilerPath) {
@@ -785,6 +787,7 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
                 additionalArgs = compilerPath.substr(endQuote + 1).split(" ");
                 additionalArgs = additionalArgs.filter((arg: string) => { return arg.trim().length !== 0; }); // Remove empty args.
                 compilerPath = compilerPath.substr(1, endQuote - 1);
+                compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
             }
         } else {
             // Go from right to left checking if a valid path is to the left of a space.
@@ -805,11 +808,12 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
                     additionalArgs = compilerPath.substr(spaceStart + 1).split(" ");
                     additionalArgs = additionalArgs.filter((arg: string) => { return arg.trim().length !== 0; }); // Remove empty args.
                     compilerPath = potentialCompilerPath;
+                    compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
                 }
             }
         }
     }
-    return { compilerPath, additionalArgs };
+    return { compilerPath, compilerName, additionalArgs };
 }
 
 export function escapeForSquiggles(s: string): string {


### PR DESCRIPTION
Get the full compiler name, if successful in getting compiler path and extracting any arguments. Then use full compiler name to checked against IntelliSense mode compatibility.

Fix for #3637 (intelliSenseMode clang-x64 in incompatible with compilerPath).