### PR TITLE
Follow-up change to default cache path

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -295,11 +295,9 @@ export function isOptionalArrayOfString(input: any): input is string[]|undefined
 export function resolveCachePath(input: string, additionalEnvironment: {[key: string]: string | string[]}): string {
     let resolvedPath: string = "";
     if (!input) {
-        // Return default path if no path is specified.
+        // If no path is set, return empty string to language service process, where it will set the default path as
         // Windows: %LocalAppData%/Microsoft/vscode-cpptools/
         // Linux and Mac: ~/.vscode-cpptools/
-        resolvedPath = (process.platform === 'win32') ?
-            (process.env.LOCALAPPDATA + "/Microsoft/vscode-cpptools/") : (process.env.HOME + "/.vscode-cpptools/");
         return resolvedPath;
     }
 


### PR DESCRIPTION
Return empty string to language service process if no path is set.