### PR TITLE
Fix cl.exe validation and other minor UI fixes

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -959,9 +959,12 @@ export class CppProperties {
                     }
                 }
             }
-            
+
             if (!pathExists) {
                 let message: string = `Cannot find: ${resolvedCompilerPath}`;
+                compilerPathErrors.push(message);
+            } else if (compilerPathAndArgs.compilerPath === "") {
+                let message: string = `Invalid input, cannot resolve compiler path`;
                 compilerPathErrors.push(message);
             } else if (!util.checkFileExistsSync(resolvedCompilerPath)) {
                 let message: string = `Path is not a file: ${resolvedCompilerPath}`;

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -796,7 +796,12 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
     let additionalArgs: string[];
     let isWindows: boolean = os.platform() === 'win32';
     if (compilerPath) {
-        if (compilerPath.startsWith("\"")) {
+        if (compilerPath === "cl.exe") {
+            // Input is only compiler name, this is only for cl.exe
+            compilerName = compilerPath;
+    
+        } else if (compilerPath.startsWith("\"")) {
+            // Input has quotes around compiler path
             let endQuote: number = compilerPath.substr(1).search("\"") + 1;
             if (endQuote !== -1) {
                 additionalArgs = compilerPath.substr(endQuote + 1).split(" ");
@@ -805,6 +810,7 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
                 compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
             }
         } else {
+            // Input has no quotes but can have a compiler path with spaces and args.
             // Go from right to left checking if a valid path is to the left of a space.
             let spaceStart: number = compilerPath.lastIndexOf(" ");
             if (spaceStart !== -1 && (!isWindows || !compilerPath.endsWith("cl.exe")) && !checkFileExistsSync(compilerPath)) {
@@ -826,7 +832,7 @@ export function extractCompilerPathAndArgs(inputCompilerPath: string): CompilerP
                 }
             }
             // Get compiler name if there are no args but path is valid or a valid path was found with args.
-            if (checkFileExistsSync(compilerPath)) {
+            if (compilerPath === "cl.exe" || checkFileExistsSync(compilerPath)) {
                 compilerName = compilerPath.replace(/^.*(\\|\/|\:)/, '');
             }
         }

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -62,7 +62,7 @@
             margin-right: 6px;
             margin-top: -4px;
             content: '\276E';
-            transform: rotate(90deg);
+            transform: rotate(270deg);
         }
 
         .collapse:after {
@@ -71,7 +71,7 @@
             margin-right: 6px;
             margin-top: -4px;
             content: '\276E';
-            transform: rotate(270deg);
+            transform: rotate(90deg);
         }
 
         .main {

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -189,6 +189,9 @@ class SettingsApp {
         this.vsCodeApi.postMessage({
             command: "knownCompilerSelect"
         });
+
+        // Reset selection to none
+        el.value = "";
     }
     private onChangedCheckbox(id: string): void {
         if (this.updating) {


### PR DESCRIPTION
- Handle input "cl.exe" for compiler path
- Show error message for compiler cannot be resolved on Config UI
- Flip expand/collapse arrow for "Advanced Settings" on Config UI