### PR TITLE
Avoid applying edits to cached colorization tokens until needed

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -583,14 +583,15 @@ class DefaultClient implements Client {
     private editVersion: number = 0;
 
     public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
+        // Increment editVersion for every call to onDidChangeTextDocument, regardless of whether the file is handled
+        this.editVersion++;
         if (textDocumentChangeEvent.document.uri.scheme === "file") {
             if (textDocumentChangeEvent.document.languageId === "cpp" || textDocumentChangeEvent.document.languageId === "c") {
-                this.editVersion++;
                 try {
                     let colorizationState: ColorizationState = this.getColorizationState(textDocumentChangeEvent.document.uri.toString());
 
                     // Adjust colorization ranges after this edit.  (i.e. if a line was added, push decorations after it down one line)
-                    colorizationState.updateAfterEdits(textDocumentChangeEvent.contentChanges, this.editVersion);
+                    colorizationState.addEdits(textDocumentChangeEvent.contentChanges, this.editVersion);
                 } catch (e) {
                     // Ensure an exception does not prevent pass-through to native handler, or editVersion could become inconsistent
                     console.log(e.toString());

--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -71,6 +71,7 @@ class ThemeStyle {
 export class ColorizationSettings {
     private uri: vscode.Uri;
     private pendingTask: util.BlockingTask<any>;
+    private editorBackground: string;
 
     public themeStyleCMap: ThemeStyle[] = [];
     public themeStyleCppMap: ThemeStyle[] = [];
@@ -98,7 +99,7 @@ export class ColorizationSettings {
         if (textMateRuleSettings.foreground) {
             baseStyle.foreground = textMateRuleSettings.foreground;
         }
-        if (textMateRuleSettings.background) {
+        if (textMateRuleSettings.background && textMateRuleSettings.background !== this.editorBackground) {
             baseStyle.background = textMateRuleSettings.background;
         }
         // Any (even empty) string for fontStyle removes inherited value
@@ -251,7 +252,7 @@ export class ColorizationSettings {
                             e.scope = e.scope.split(',').map((s: string) => s.trim());
                         }
                     });
-                }
+                } 
             } else {
                 themeContent = jsonc.parse(themeContentText);
                 if (themeContent) {
@@ -261,12 +262,19 @@ export class ColorizationSettings {
                         let includedThemePath: string = path.join(path.dirname(themePath), themeContent.include);
                         rules = await this.loadTheme(includedThemePath, defaultStyle);
                     }
+
+                    if (themeContent.colors && themeContent.colors["editor.background"]) {
+                        this.editorBackground = themeContent.colors["editor.background"];
+                    }
                 }
             }
 
             if (textMateRules) {
                 let scopelessSetting: any = textMateRules.find(e => e.settings && !e.scope);
                 if (scopelessSetting) {
+                    if (scopelessSetting.background) {
+                        this.editorBackground = scopelessSetting.background;
+                    }
                     this.updateStyleFromTextMateRuleSettings(defaultStyle, scopelessSetting.settings);
                 }
                 rules.push(textMateRules);
@@ -298,6 +306,10 @@ export class ColorizationSettings {
                         let themeFullPath: string = path.join(extensionPath, themeRelativePath);
                         let defaultStyle: ThemeStyle = new ThemeStyle();
                         let rulesSet: TextMateRule[][] = await this.loadTheme(themeFullPath, defaultStyle);
+                        let editorBackgroundSetting: string = otherSettings.editorBackground;
+                        if (editorBackgroundSetting) {
+                            this.editorBackground = editorBackgroundSetting;
+                        }
                         this.updateStyles(themeName, defaultStyle, rulesSet);
                         return;
                     }
@@ -390,8 +402,10 @@ export class ColorizationState {
     private inactiveDecoration: vscode.TextEditorDecorationType = null;
     private inactiveRanges: vscode.Range[] = [];
     private versionedEdits: VersionedEdits[] = [];
-    private lastSyntacticVersion: number = 0;
-    private lastSemanticVersion: number = 0;
+    private currentSyntacticVersion: number = 0;
+    private lastReceivedSyntacticVersion: number = 0;
+    private currentSemanticVersion: number = 0;
+    private lastReceivedSemanticVersion: number = 0;
 
     public constructor(uri: vscode.Uri, colorizationSettings: ColorizationSettings) {
         this.uri = uri;
@@ -472,6 +486,7 @@ export class ColorizationState {
     }
 
     public refresh(e: vscode.TextEditor): void {
+        this.applyEdits();
         let f: () => void = async () => {
             this.refreshInner(e);
         };
@@ -480,6 +495,7 @@ export class ColorizationState {
 
     public onSettingsChanged(uri: vscode.Uri): void {
         let f: () => void = async () => {
+            this.applyEdits();
             this.disposeColorizationDecorations();
             let isCpp: boolean = util.isEditorFileCpp(uri.toString());
             this.createColorizationDecorations(isCpp);
@@ -609,14 +625,8 @@ export class ColorizationState {
         return ranges;
     }
 
-    public updateAfterEdits(changes: vscode.TextDocumentContentChangeEvent[], editVersion: number): void {
-        for (let i: number = 0; i < this.syntacticRanges.length; i++) {
-            this.syntacticRanges[i] = this.fixRanges(this.syntacticRanges[i], changes);
-        }
-        for (let i: number = 0; i < this.semanticRanges.length; i++) {
-            this.semanticRanges[i] = this.fixRanges(this.semanticRanges[i], changes);
-        }
-        this.inactiveRanges = this.fixRanges(this.inactiveRanges, changes);
+    // Add edits to be applied when/if cached tokens need to be reapplied.
+    public addEdits(changes: vscode.TextDocumentContentChangeEvent[], editVersion: number): void {
         let edits: VersionedEdits = {
             editVersion: editVersion,
             changes: changes
@@ -624,8 +634,28 @@ export class ColorizationState {
         this.versionedEdits.push(edits);
     }
 
+    // Apply any pending edits to the currently cached tokens
+    private applyEdits() : void {
+        this.versionedEdits.forEach((edit) => {
+            if (edit.editVersion > this.currentSyntacticVersion) {
+                for (let i: number = 0; i < TokenKind.Count; i++) {
+                    this.syntacticRanges[i] = this.fixRanges(this.syntacticRanges[i], edit.changes);
+                }
+                this.currentSyntacticVersion = edit.editVersion;
+            }
+            if (edit.editVersion > this.currentSemanticVersion) {
+                for (let i: number = 0; i < TokenKind.Count; i++) {
+                    this.semanticRanges[i] = this.fixRanges(this.semanticRanges[i], edit.changes);
+                }
+                this.inactiveRanges = this.fixRanges(this.inactiveRanges, edit.changes);
+                this.currentSemanticVersion = edit.editVersion;
+            }
+        });
+    }
+
+    // Remove any edits from the list if we will never receive tokens that old.
     private purgeOldVersionedEdits(): void {
-        let minVersion: number = Math.min(this.lastSemanticVersion, this.lastSyntacticVersion);
+        let minVersion: number = Math.min(this.lastReceivedSemanticVersion, this.lastReceivedSyntacticVersion);
         let index: number = this.versionedEdits.findIndex((edit) => edit.editVersion > minVersion);
         if (index === -1) {
             this.versionedEdits = [];
@@ -633,20 +663,12 @@ export class ColorizationState {
             this.versionedEdits = this.versionedEdits.slice(index);
         }
     }
-    
-    private updateColorizationRanges(uri: string, syntacticRanges: vscode.Range[][], semanticRanges: vscode.Range[][], inactiveRanges: vscode.Range[]): void {
-        if (inactiveRanges) {
-            this.inactiveRanges = inactiveRanges;
-        }
-        for (let i: number = 0; i < TokenKind.Count; i++) {
-            if (syntacticRanges) {
-                this.syntacticRanges[i] = syntacticRanges[i];
-            }
-            if (semanticRanges) {
-                this.semanticRanges[i] = semanticRanges[i];
-            }
-        }
+
+    private updateColorizationRanges(uri: string): void {
         let f: () => void = async () => {
+            this.applyEdits();
+            this.purgeOldVersionedEdits();
+
             // The only way to un-apply decorators is to dispose them.
             // If we dispose old decorators before applying new decorators, we see a flicker on Mac,
             // likely due to a race with UI updates.  Here we set aside the existing decorators to be
@@ -682,29 +704,21 @@ export class ColorizationState {
     }
 
     public updateSyntactic(uri: string, syntacticRanges: vscode.Range[][], editVersion: number): void {
-        this.versionedEdits.forEach((edit) => {
-            if (edit.editVersion > editVersion) {
-                for (let i: number = 0; i < TokenKind.Count; i++) {
-                    syntacticRanges[i] = this.fixRanges(syntacticRanges[i], edit.changes);
-                }
-            }
-        });
-        this.updateColorizationRanges(uri, syntacticRanges, null, null);
-        this.lastSyntacticVersion = editVersion;
-        this.purgeOldVersionedEdits();
+        for (let i: number = 0; i < TokenKind.Count; i++) {
+            this.syntacticRanges[i] = syntacticRanges[i];
+        }
+        this.currentSyntacticVersion = editVersion;
+        this.lastReceivedSyntacticVersion = editVersion;
+        this.updateColorizationRanges(uri);
     }
 
     public updateSemantic(uri: string, semanticRanges: vscode.Range[][], inactiveRanges: vscode.Range[], editVersion: number): void {
-        this.versionedEdits.forEach((edit) => {
-            if (edit.editVersion > editVersion) {
-                for (let i: number = 0; i < TokenKind.Count; i++) {
-                    semanticRanges[i] = this.fixRanges(semanticRanges[i], edit.changes);
-                }
-                inactiveRanges = this.fixRanges(inactiveRanges, edit.changes);
-            }
-        });
-        this.updateColorizationRanges(uri, null, semanticRanges, inactiveRanges);
-        this.lastSemanticVersion = editVersion;
-        this.purgeOldVersionedEdits();
+       this.inactiveRanges = inactiveRanges;
+        for (let i: number = 0; i < TokenKind.Count; i++) {
+            this.semanticRanges[i] = semanticRanges[i];
+        }
+        this.currentSemanticVersion = editVersion;
+        this.lastReceivedSemanticVersion = editVersion;
+        this.updateColorizationRanges(uri);
     }
 }

--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -272,8 +272,8 @@ export class ColorizationSettings {
             if (textMateRules) {
                 let scopelessSetting: any = textMateRules.find(e => e.settings && !e.scope);
                 if (scopelessSetting) {
-                    if (scopelessSetting.background) {
-                        this.editorBackground = scopelessSetting.background;
+                    if (scopelessSetting.settings.background) {
+                        this.editorBackground = scopelessSetting.settings.background;
                     }
                     this.updateStyleFromTextMateRuleSettings(defaultStyle, scopelessSetting.settings);
                 }

--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -252,7 +252,7 @@ export class ColorizationSettings {
                             e.scope = e.scope.split(',').map((s: string) => s.trim());
                         }
                     });
-                } 
+                }
             } else {
                 themeContent = jsonc.parse(themeContentText);
                 if (themeContent) {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -117,6 +117,7 @@ export class OtherSettings {
     public get filesExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("files", this.resource).get("exclude"); }
     public get searchExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("search", this.resource).get("exclude"); }
     public get settingsEditor(): string { return vscode.workspace.getConfiguration("workbench.settings").get<string>("editor"); }
+    public get editorBackground(): string { return vscode.workspace.getConfiguration("editor", this.resource).get<string>("background"); }
 
     public get colorTheme(): string { return vscode.workspace.getConfiguration("workbench").get<string>("colorTheme"); }
 


### PR DESCRIPTION
Avoid applying edits to cached tokens unless/until they need to be reapplied.  (Similar fix applied to native side)

Avoid setting background color of decoration if same as editor background, to avoid selection highlighting issue.

Ensure editVersion is always increment per onDidChangeTextDocument, to ensure in sync with native side.  (Has corresponding change on native side)
