### PR TITLE
Remove incorrect editor background setting

### DIFF
--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -306,10 +306,6 @@ export class ColorizationSettings {
                         let themeFullPath: string = path.join(extensionPath, themeRelativePath);
                         let defaultStyle: ThemeStyle = new ThemeStyle();
                         let rulesSet: TextMateRule[][] = await this.loadTheme(themeFullPath, defaultStyle);
-                        let editorBackgroundSetting: string = otherSettings.editorBackground;
-                        if (editorBackgroundSetting) {
-                            this.editorBackground = editorBackgroundSetting;
-                        }
                         this.updateStyles(themeName, defaultStyle, rulesSet);
                         return;
                     }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -117,7 +117,6 @@ export class OtherSettings {
     public get filesExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("files", this.resource).get("exclude"); }
     public get searchExclude(): vscode.WorkspaceConfiguration { return vscode.workspace.getConfiguration("search", this.resource).get("exclude"); }
     public get settingsEditor(): string { return vscode.workspace.getConfiguration("workbench.settings").get<string>("editor"); }
-    public get editorBackground(): string { return vscode.workspace.getConfiguration("editor", this.resource).get<string>("background"); }
 
     public get colorTheme(): string { return vscode.workspace.getConfiguration("workbench").get<string>("colorTheme"); }
 


### PR DESCRIPTION
Remove attempt to load editor background override setting.  If a theme assigned a background color to a scope that is the same as it's (default) editor background color, lets assume the intention was that the default background was desired on that scope, rather than apply that background (i.e. if the user overrides the editor background color).

Remove setting used to load editor background override setting.  (No longer used, and was being read from the wrong place).
