### PR TITLE
Handle comma-delimited scopes in JSON themes

### DIFF
--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -245,13 +245,6 @@ export class ColorizationSettings {
                 themeContent = plist.parse(themeContentText);
                 if (themeContent) {
                     textMateRules = themeContent.settings;
-
-                    // Convert comma delimited scopes into an array, to match the json format
-                    textMateRules.forEach(e => {
-                        if (e.scope && e.scope.includes(',')) {
-                            e.scope = e.scope.split(',').map((s: string) => s.trim());
-                        }
-                    });
                 }
             } else {
                 themeContent = jsonc.parse(themeContentText);
@@ -270,6 +263,13 @@ export class ColorizationSettings {
             }
 
             if (textMateRules) {
+                // Convert comma delimited scopes into an array
+                textMateRules.forEach(e => {
+                    if (e.scope && e.scope.includes(',')) {
+                        e.scope = e.scope.split(',').map((s: string) => s.trim());
+                    }
+                });
+
                 let scopelessSetting: any = textMateRules.find(e => e.settings && !e.scope);
                 if (scopelessSetting) {
                     if (scopelessSetting.settings.background) {


### PR DESCRIPTION
It looks like some JSON themes use a single comma-delimited scope to specify multiple scopes, rather than an array.  This should address the issue seen with many of the themes mentioned in https://github.com/microsoft/vscode-cpptools/issues/3780  .  We were already handling comma-delimited scopes in XML themes.  