### PR TITLE
This message wasn't being sent by the language server

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1155,7 +1155,7 @@ class DefaultClient implements Client {
             util.setProgress(util.getProgressParseRootSuccess());
         } else if (message.endsWith("No Squiggles")) {
             util.setIntelliSenseProgress(util.getProgressIntelliSenseNoSquiggles());
-        } else if (message.endsWith("IntelliSense Fallback")) {
+        } else if (message.endsWith("Unresolved Headers")) {
             let showIntelliSenseFallbackMessage: PersistentState<boolean> = new PersistentState<boolean>("CPP.showIntelliSenseFallbackMessage", true);
             if (showIntelliSenseFallbackMessage.Value) {
                 ui.showConfigureIncludePathMessage(() => {
@@ -1170,8 +1170,8 @@ class DefaultClient implements Client {
                             case configJSON:
                                 vscode.commands.getCommands(true).then((commands: string[]) => {
                                     if (commands.indexOf("workbench.action.problems.focus") >= 0) {
-                                         vscode.commands.executeCommand("workbench.action.problems.focus");
-                                   }
+                                        vscode.commands.executeCommand("workbench.action.problems.focus");
+                                    }
                                 });
                                 this.handleConfigurationEditJSONCommand();
                                 telemetry.logLanguageServerEvent("SettingsCommand", { "toast": "json" }, null);
@@ -1180,7 +1180,7 @@ class DefaultClient implements Client {
                                 vscode.commands.getCommands(true).then((commands: string[]) => {
                                     if (commands.indexOf("workbench.action.problems.focus") >= 0) {
                                         vscode.commands.executeCommand("workbench.action.problems.focus");
-                                }
+                                    }
                                 });
                                 this.handleConfigurationEditUICommand();
                                 telemetry.logLanguageServerEvent("SettingsCommand", { "toast": "ui" }, null);


### PR DESCRIPTION
The message has been renamed to encompass two scenarios: fallback and disabling squiggles when headers don't resolve.  The message itself is not user-facing.  See the corresponding PR on the language server side for context.