### PR TITLE
Decrease F5 workflow time w/ VSCode

### DIFF
--- a/Extension/.vscode/tasks.json
+++ b/Extension/.vscode/tasks.json
@@ -64,9 +64,6 @@
                 "run",
                 "compileDev"
             ],
-            "dependsOn": [
-                "TypeScript Compile"
-            ],
             "problemMatcher": "$tsc-watch"
         },
         {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1459,14 +1459,15 @@
   },
   "scripts": {
     "compile": "npm run vscode:prepublish",
-    "compileDev": "node ./tools/prepublish.js && webpack --mode development",
+    "compileDev": "npm run prepublishjs && webpack --mode development",
     "generateOptionsSchema": "gulp generateOptionsSchema",
     "postinstall": "node ./node_modules/vscode/bin/install",
+    "prepublishjs": "node ./tools/prepublish.js",
     "pretest": "tsc -p test.tsconfig.json",
     "pr-check": "gulp pr-check",
     "tslint": "gulp tslint",
     "unitTests": "gulp unitTests",
-    "vscode:prepublish": "node ./tools/prepublish.js && webpack --mode production",
+    "vscode:prepublish": "npm run prepublishjs && webpack --mode production",
     "watch": "webpack --watch --mode development"
   },
   "devDependencies": {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1459,7 +1459,7 @@
   },
   "scripts": {
     "compile": "npm run vscode:prepublish",
-    "compileDev": "webpack --mode development",
+    "compileDev": "node ./tools/prepublish.js && webpack --mode development",
     "generateOptionsSchema": "gulp generateOptionsSchema",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "tsc -p test.tsconfig.json",


### PR DESCRIPTION
webpack is being called twice. Once with --mode production and then
rewritten with --mode development. This causes long delays. 

Adjusting tasks and launch so it is only called once. 