### PR TITLE
Temporarily revert documentation until changes to feature ship

### DIFF
--- a/Documentation/LanguageServer/colorization.md
+++ b/Documentation/LanguageServer/colorization.md
@@ -1,4 +1,3 @@
-
 # VS Code C/C++ Extension - Enhanced Colorization
 
 The VS Code C/C++ extension now supports semantic colorization, when IntelliSense is enabled.  Enhanced colorization can be enabled using the enhancedColorization setting:
@@ -19,32 +18,32 @@ Colors are associated with [TextMate scopes](https://macromates.com/manual/en/la
 
 | Token         | Scope         |
 | ------------- |:-------------:|
-| Class Template | entity.name.type.class.templated |
+| Class Template | entity.name.class.template |
 | Enumerator | variable.other.enummember |
 | Event  (C++/CLI) | variable.other.event |
 | Function | entity.name.function |
-| Function Template | entity.name.function.templated |
-| Generic Type (C++/CLI) | entity.name.type.class.generic |
+| Function Template | entity.name.function.template |
+| Generic Type (C++/CLI) | entity.name.class.generic |
 | Global Variable | variable.other.global |
 | Label | entity.name.label |
 | Local Variable | variable.other.local |
 | Macro | entity.name.function.preprocessor |
-| Member Field  | variable.other.property |
+| Member Field  | variable.other.member |
 | Member Function | entity.name.function.member |
-| Namespace | entity.name.namespace |
+| Member Operator | keyword.operator.member |
+| Namespace | entity.name.type.namespace |
 | New / Delete | keyword.operator.new |
-| Operator Overload Function | entity.name.function.operator |
-| Operator Overload Member | entity.name.function.operator.member |
+| Operator Function | entity.name.function.operator |
 | Parameter | variable.parameter |
-| Property (C++/CLI) | variable.other.property.cli |
-| Reference Type (C++/CLI) | entity.name.type.class.reference |
-| Static Member Field | variable.other.property.static |
+| Property (C++/CLI) | variable.other.property |
+| Reference Type (C++/CLI) | entity.name.class.reference |
+| Static Member Field | variable.other.member.static |
 | Static Member Function | entity.name.function.member.static |
-| Type | entity.name.type.class |
-| User-Defined Literal - Number | entity.name.operator.custom-literal.number |
-| User-Defined Literal - Raw | entity.name.operator.custom-literal |
-| User-Defined Literal - String | entity.name.operator.custom-literal.string |
-| Value Type (C++/CLI) | entity.name.type.class.value |
+| Type | entity.name.type |
+| User-Defined Literal - Number | entity.name.user-defined-literal.number |
+| User-Defined Literal - Raw | entity.name.user-defined-literal |
+| User-Defined Literal - String | entity.name.user-defined-literal.string |
+| Value Type (C++/CLI) | entity.name.class.value |
 
 Many of the tokens recognized by IntelliSense do not directly map to existing scopes in the VS Code's default C/C++ TextMate grammar, so are likely not colored by existing VS Code themes.
 
@@ -55,7 +54,7 @@ Colors can also be overridden globally, in settings:
     "editor.tokenColorCustomizations": {
         "textMateRules": [
             {
-                "scope": "entity.name.type.class",
+                "scope": "entity.name.type",
                 "settings": {
                     "foreground": "#FF0000",
                     "fontStyle": "italic bold underline"
@@ -70,7 +69,7 @@ Or, overridden on a per-theme basis:
         "[Visual Studio Dark]": {
             "textMateRules": [
                 {
-                    "scope": "entity.name.type.class",
+                    "scope": "entity.name.type",
                     "settings": {
                         "foreground": "#FF0000",
                         "fontStyle": "italic bold underline"
@@ -171,19 +170,19 @@ Use the following to augment the Visual Studio Dark theme to match what Visual S
                     }
                 },
                 {
-                    "scope": "entity.name.type.class",
+                    "scope": "entity.name.type",
                     "settings": {
                         "foreground": "#4EC9B0"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.reference",
+                    "scope": "entity.name.class.reference",
                     "settings": {
                         "foreground": "#4EC9B0"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.value",
+                    "scope": "entity.name.class.value",
                     "settings": {
                         "foreground": "#4EC9B0"
                     }
@@ -201,7 +200,7 @@ Use the following to augment the Visual Studio Dark theme to match what Visual S
                     }
                 },
                 {
-                    "scope": "variable.other.property",
+                    "scope": "variable.other.member",
                     "settings": {
                         "foreground": "#DADADA"
                     }
@@ -213,7 +212,7 @@ Use the following to augment the Visual Studio Dark theme to match what Visual S
                     }
                 },
                 {
-                    "scope": "variable.other.property.static",
+                    "scope": "variable.other.member.static",
                     "settings": {
                         "foreground": "#C8C8C8"
                     }
@@ -225,19 +224,19 @@ Use the following to augment the Visual Studio Dark theme to match what Visual S
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.templated",
+                    "scope": "entity.name.class.template",
                     "settings": {
                         "foreground": "#4EC9B0"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.generic",
+                    "scope": "entity.name.class.generic",
                     "settings": {
                         "foreground": "#4EC9B0"
                     }
                 },
                 {
-                    "scope": "entity.name.function.templated",
+                    "scope": "entity.name.function.template",
                     "settings": {
                         "foreground": "#C8C8C8"
                     }
@@ -255,19 +254,19 @@ Use the following to augment the Visual Studio Dark theme to match what Visual S
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal",
+                    "scope": "entity.name.user-defined-literal",
                     "settings": {
                         "foreground": "#DADADA"
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal.string",
+                    "scope": "entity.name.user-defined-literal.string",
                     "settings": {
                         "foreground": "#D69D85"
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal.number",
+                    "scope": "entity.name.user-defined-literal.number",
                     "settings": {
                         "foreground": "#B5CEA8"
                     }
@@ -386,19 +385,19 @@ Use the following to augment the Visual Studio Light theme to match what Visual 
                     }
                 },
                 {
-                    "scope": "entity.name.type.class",
+                    "scope": "entity.name.type",
                     "settings": {
                         "foreground": "#2B91AF"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.reference",
+                    "scope": "entity.name.class.reference",
                     "settings": {
                         "foreground": "#2B91AF"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.value",
+                    "scope": "entity.name.class.value",
                     "settings": {
                         "foreground": "#2B91AF"
                     }
@@ -416,7 +415,7 @@ Use the following to augment the Visual Studio Light theme to match what Visual 
                     }
                 },
                 {
-                    "scope": "variable.other.property",
+                    "scope": "variable.other.member",
                     "settings": {
                         "foreground": "#000000"
                     }
@@ -428,7 +427,7 @@ Use the following to augment the Visual Studio Light theme to match what Visual 
                     }
                 },
                 {
-                    "scope": "variable.other.property.static",
+                    "scope": "variable.other.member.static",
                     "settings": {
                         "foreground": "#000000"
                     }
@@ -440,19 +439,19 @@ Use the following to augment the Visual Studio Light theme to match what Visual 
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.templated",
+                    "scope": "entity.name.class.template",
                     "settings": {
                         "foreground": "#2B91AF"
                     }
                 },
                 {
-                    "scope": "entity.name.type.class.generic",
+                    "scope": "entity.name.class.generic",
                     "settings": {
                         "foreground": "#2B91AF"
                     }
                 },
                 {
-                    "scope": "entity.name.function.templated",
+                    "scope": "entity.name.function.template",
                     "settings": {
                         "foreground": "#000000"
                     }
@@ -470,19 +469,19 @@ Use the following to augment the Visual Studio Light theme to match what Visual 
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal",
+                    "scope": "entity.name.user-defined-literal",
                     "settings": {
                         "foreground": "#000000"
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal.string",
+                    "scope": "entity.name.user-defined-literal.string",
                     "settings": {
                         "foreground": "#A31515"
                     }
                 },
                 {
-                    "scope": "entity.name.operator.custom-literal.number",
+                    "scope": "entity.name.user-defined-literal.number",
                     "settings": {
                         "foreground": "#000000"
                     }


### PR DESCRIPTION
Restores previous contents.  Will need to update again after shipping, so document link provides current documentation for released version.
