### PR TITLE
re-enable the supported arch check

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -20,7 +20,7 @@ import { PackageManager, PackageManagerError, IPackage } from './packageManager'
 import { PersistentState } from './LanguageServer/persistentState';
 import { getInstallationInformation, InstallationInformation, setInstallationStage, setInstallationType, InstallationType } from './installationInformation';
 import { Logger, getOutputChannelLogger, showOutputChannel } from './logger';
-import { CppTools1 } from './cppTools1';
+import { CppTools1, NullCppTools } from './cppTools1';
 
 const releaseNotesVersion: number = 5;
 const cppTools: CppTools1 = new CppTools1();
@@ -29,9 +29,8 @@ let reloadMessageShown: boolean = false;
 let disposables: vscode.Disposable[] = [];
 
 export async function activate(context: vscode.ExtensionContext): Promise<CppToolsApi & CppToolsExtension> {
-    /*
     let errMsg: string = "";
-    if (process.arch !== 'x32' && process.arch !== 'x64') {
+    if (process.arch !== 'ia32' && process.arch !== 'x64') {
         errMsg = "Architecture " + String(process.arch) + " is not supported. ";
     } else if (process.platform === 'linux' && fs.existsSync('/etc/alpine-release')) {
         errMsg = "Alpine containers are not supported. ";
@@ -39,7 +38,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (errMsg) {
         vscode.window.showErrorMessage(errMsg);
         return new NullCppTools();
-    }*/
+    }
 
     util.setExtensionContext(context);
     initializeTemporaryCommandRegistrar();


### PR DESCRIPTION
ia32 is the correct arch to check here. It represents a standard 32-bit OS.
x32 is a special arch that allows 32-bit bit code to access additional registers generally only available to x64 processes. We are not doing any checks for x32 at this time. The goal of this change is to disable the extension for unsupported 'arm' architectures and Alpine linux.