### PR TITLE
Change clang_format_path back to resource scope.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -73,7 +73,7 @@
           ],
           "default": null,
           "description": "The full path of the clang-format executable.",
-          "scope": "machine"
+          "scope": "resource"
         },
         "C_Cpp.clang_format_style": {
           "type": "string",


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/3937
Revert change from PR https://github.com/microsoft/vscode-cpptools/pull/3810/files .