### PR TITLE
Fix local test deployment

### DIFF
--- a/Extension/.vscode/launch.json
+++ b/Extension/.vscode/launch.json
@@ -60,7 +60,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/test/**/*.js"
 			],
-			"preLaunchTask": "TypeScript Compile"
+			"preLaunchTask": "Pretest"
 		},
 		{
 			"name": "Node Attach",

--- a/Extension/.vscode/tasks.json
+++ b/Extension/.vscode/tasks.json
@@ -51,7 +51,7 @@
                 ]
             },
             "dependsOn": [
-                "TypeScript Compile"
+                "Compile Dev"
             ]
         },
         {
@@ -77,7 +77,7 @@
                 "pretest"
             ],
             "dependsOn": [
-                "TypeScript Compile"
+                "Compile Dev"
             ],
             "problemMatcher": "$tsc-watch"
         }


### PR DESCRIPTION
Fixed issue with "Launch Tests" target not working.

Switched tests to using a development build instead of production, as tests don't need localized strings.
