### PR TITLE
Fix rename cancel and subsequent renames

### DIFF
--- a/Extension/assets/minus-dark.svg
+++ b/Extension/assets/minus-dark.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" y="8" width="6" height="1" fill="#C5C5C5"/>
+<path d="M15 8H1V7H15V8Z" fill="#C5C5C5"/>
 </svg>

--- a/Extension/assets/minus-light.svg
+++ b/Extension/assets/minus-light.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" y="8" width="6" height="1" fill="#424242"/>
+<path d="M15 8H1V7H15V8Z" fill="#424242"/>
 </svg>

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2155,13 +2155,11 @@ export class DefaultClient implements Client {
     public cancelReferences(): void {
         referencesParams = null;
         renamePending = false;
-        if (referencesRequestPending) {
-            let cancelling: boolean = referencesPendingCancellations.length > 0;
-            if (!cancelling) {
-                referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
-                this.languageClient.sendNotification(CancelReferencesNotification);
-                this.references.closeRenameUI();
-            }
+        let cancelling: boolean = referencesPendingCancellations.length > 0;
+        if (!cancelling) {
+            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
+            this.languageClient.sendNotification(CancelReferencesNotification);
+            this.references.closeRenameUI();
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -712,7 +712,6 @@ export class DefaultClient implements Client {
                                         this.client.languageClient.sendNotification(RenameNotification, params);
                                         this.client.references.setResultsCallback((final, referencesResult) => {
                                             referencesRequestPending = false;
-                                            renamePending = false;
                                             let workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                                             let cancelling: boolean = referencesPendingCancellations.length > 0;
                                             if (cancelling) {
@@ -2155,11 +2154,13 @@ export class DefaultClient implements Client {
     public cancelReferences(): void {
         referencesParams = null;
         renamePending = false;
-        let cancelling: boolean = referencesPendingCancellations.length > 0;
-        if (!cancelling) {
-            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
-            this.languageClient.sendNotification(CancelReferencesNotification);
-            this.references.closeRenameUI();
+        if (referencesRequestPending) {
+            let cancelling: boolean = referencesPendingCancellations.length > 0;
+            if (!cancelling) {
+                referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
+                this.languageClient.sendNotification(CancelReferencesNotification);
+                this.references.closeRenameUI();
+            }
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -712,6 +712,7 @@ export class DefaultClient implements Client {
                                         this.client.languageClient.sendNotification(RenameNotification, params);
                                         this.client.references.setResultsCallback((final, referencesResult) => {
                                             referencesRequestPending = false;
+                                            renamePending = false;
                                             let workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                                             let cancelling: boolean = referencesPendingCancellations.length > 0;
                                             if (cancelling) {
@@ -744,6 +745,7 @@ export class DefaultClient implements Client {
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
                                     referencesPendingCancellations.push({ reject, callback });
                                     if (!cancelling) {
+                                        renamePending = false;
                                         this.client.languageClient.sendNotification(CancelReferencesNotification);
                                         this.client.references.closeRenameUI();
                                     }
@@ -2153,11 +2155,13 @@ export class DefaultClient implements Client {
     public cancelReferences(): void {
         referencesParams = null;
         renamePending = false;
-        let cancelling: boolean = referencesPendingCancellations.length > 0;
-        if (!cancelling) {
-            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
-            this.languageClient.sendNotification(CancelReferencesNotification);
-            this.references.closeRenameUI();
+        if (referencesRequestPending) {
+            let cancelling: boolean = referencesPendingCancellations.length > 0;
+            if (!cancelling) {
+                referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
+                this.languageClient.sendNotification(CancelReferencesNotification);
+                this.references.closeRenameUI();
+            }
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -286,6 +286,7 @@ let failureMessageShown: boolean = false;
 
 let referencesRequestPending: boolean = false;
 let renamePending: boolean = false;
+let renameRequestsPending: number = 0;
 let referencesParams: RenameParams | FindAllReferencesParams;
 
 interface ReferencesCancellationState {
@@ -693,6 +694,7 @@ export class DefaultClient implements Client {
                             // VS Code will attempt to issue new rename requests while another is still active.
                             // When we receive another rename request, cancel the one that is in progress.
                             renamePending = true;
+                            ++renameRequestsPending;
                             return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
                                 let callback: () => void = () => {
                                     let params: RenameParams = {
@@ -705,6 +707,7 @@ export class DefaultClient implements Client {
                                         // The current request is represented by referencesParams.  If a request detects
                                         // referencesParams does not match the object used when creating the request, abort it.
                                         if (params !== referencesParams) {
+                                            --renameRequestsPending;
                                             reject();
                                             return;
                                         }
@@ -712,6 +715,7 @@ export class DefaultClient implements Client {
                                         this.client.languageClient.sendNotification(RenameNotification, params);
                                         this.client.references.setResultsCallback((final, referencesResult) => {
                                             referencesRequestPending = false;
+                                            --renameRequestsPending;
                                             let workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                                             let cancelling: boolean = referencesPendingCancellations.length > 0;
                                             if (cancelling) {
@@ -724,6 +728,9 @@ export class DefaultClient implements Client {
                                                 referencesPendingCancellations.pop();
                                                 pendingCancel.callback();
                                             } else {
+                                                if (renameRequestsPending === 0) {
+                                                    renamePending = false;
+                                                }
                                                 // If rename UI Was cancelled, we will get a null result
                                                 // If null, return an empty list to avoid Rename failure dialog
                                                 if (referencesResult !== null) {
@@ -741,10 +748,9 @@ export class DefaultClient implements Client {
                                 };
 
                                 if (referencesRequestPending) {
+                                    referencesPendingCancellations.push({ reject: () => { --renameRequestsPending; reject(); }, callback });
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
-                                    referencesPendingCancellations.push({ reject, callback });
                                     if (!cancelling) {
-                                        renamePending = false;
                                         this.client.languageClient.sendNotification(CancelReferencesNotification);
                                         this.client.references.closeRenameUI();
                                     }
@@ -2154,10 +2160,10 @@ export class DefaultClient implements Client {
     public cancelReferences(): void {
         referencesParams = null;
         renamePending = false;
-        if (referencesRequestPending) {
+        if (referencesRequestPending || this.references.symbolSearchInProgress) {
+            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
             let cancelling: boolean = referencesPendingCancellations.length > 0;
             if (!cancelling) {
-                referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
                 this.languageClient.sendNotification(CancelReferencesNotification);
                 this.references.closeRenameUI();
             }

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -370,9 +370,11 @@ export class ReferencesManager {
                     this.renameView.show(true);
                     this.renameView.setData(referencesResult, this.resultsCallback);
                 }
+            } else {
+                // Do nothing when rename is canceled while searching for references was in progress.
+                this.resultsCallback(true, null);
             }
         } else {
-            // Put results in data model
             this.findAllRefsView.setData(referencesResult, this.referencesCanceled);
 
             // Display data based on command mode: peek references OR find all references

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -126,6 +126,7 @@ export class ReferencesManager {
     private renameView: RenameView;
     private viewsInitialized: boolean = false;
 
+    public symbolSearchInProgress: boolean = false;
     private referencesCurrentProgress: ReportReferencesProgressNotification;
     private referencesPrevProgressIncrement: number;
     private referencesPrevProgressMessage: string;
@@ -323,9 +324,11 @@ export class ReferencesManager {
                 if (this.client.ReferencesCommandMode === ReferencesCommandMode.Peek) {
                     telemetry.logLanguageServerEvent("peekReferences");
                 }
+                this.symbolSearchInProgress = true;
                 this.handleProgressStarted(notificationBody.referencesProgress);
                 break;
             case ReferencesProgress.Finished:
+                this.symbolSearchInProgress = false;
                 this.referencesCurrentProgress = notificationBody;
                 clearInterval(this.referencesDelayProgress);
                 if (this.currentUpdateProgressTimer) {


### PR DESCRIPTION
**Issue 1:**
When doing subsequent renames, as a set of two, the second rename does nothing.

Repro steps:
1. do rename
2. commit rename --> operation completes
3. do another rename
4. commit rename --> nothing happens
5. do another rename 
6. commit rename --> operation completes
7. do another rename
8. commit rename --> nothing happens

Solution:
When the first rename completes, the client gets onDidChangeTextDocument(...) callback, which will cause a cancel on a rename operation if there is one in pending. However, the flag `renamePending` does not get reset when the first rename completes, therefore any second rename will get canceled. Solution is to set `renamePending` to false whenever the current rename session is completed.

**Issue 2:**
Canceling rename while searching for references is in progress does not cancel the blue progress bar on editor to stop.

Solution:
In `processResults(...)`, handle state of when `this.referencesCanceled` is true for `this.client.ReferencesCommandMode === ReferencesCommandMode.Rename`. That is ensure `resultsCallback` is called to complete the rename operation.

**Misc:**
Update "remove" icon from https://github.com/microsoft/vscode-icons/blob/master/icons/light/dash.svg to https://github.com/microsoft/vscode-icons/blob/master/icons/light/remove.svg