### PR TITLE
Ensure renamePending gets reset when operation is complete

### DIFF
--- a/Extension/assets/minus-dark.svg
+++ b/Extension/assets/minus-dark.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" y="8" width="6" height="1" fill="#C5C5C5"/>
+<path d="M15 8H1V7H15V8Z" fill="#C5C5C5"/>
 </svg>

--- a/Extension/assets/minus-light.svg
+++ b/Extension/assets/minus-light.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" y="8" width="6" height="1" fill="#424242"/>
+<path d="M15 8H1V7H15V8Z" fill="#424242"/>
 </svg>

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -749,7 +749,7 @@ export class DefaultClient implements Client {
 
                                 if (referencesRequestPending) {
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
-                                    referencesPendingCancellations.push({ reject, callback });
+                                    referencesPendingCancellations.push({ reject: () => { --renameRequestsPending; reject(); }, callback });
                                     if (!cancelling) {
                                         this.client.languageClient.sendNotification(CancelReferencesNotification);
                                         this.client.references.closeRenameUI();

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2157,11 +2157,13 @@ export class DefaultClient implements Client {
     public cancelReferences(): void {
         referencesParams = null;
         renamePending = false;
-        let cancelling: boolean = referencesPendingCancellations.length > 0;
-        referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
-        if (!cancelling) {
-            this.languageClient.sendNotification(CancelReferencesNotification);
-            this.references.closeRenameUI();
+        if (referencesRequestPending || this.references.symbolSearchInProgress) {
+            let cancelling: boolean = referencesPendingCancellations.length > 0;
+            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
+            if (!cancelling) {
+                this.languageClient.sendNotification(CancelReferencesNotification);
+                this.references.closeRenameUI();
+            }
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -660,7 +660,7 @@ export class DefaultClient implements Client {
                                     });
                                 };
 
-                                if (referencesRequestPending || this.client.references.symbolSearchInProgress) {
+                                if (referencesRequestPending || (this.client.references.symbolSearchInProgress && !this.client.references.referencesViewFindPending)) {
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
                                     referencesPendingCancellations.push({ reject, callback });
                                     if (!cancelling) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -660,7 +660,7 @@ export class DefaultClient implements Client {
                                     });
                                 };
 
-                                if (referencesRequestPending) {
+                                if (referencesRequestPending || this.client.references.symbolSearchInProgress) {
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
                                     referencesPendingCancellations.push({ reject, callback });
                                     if (!cancelling) {
@@ -744,7 +744,7 @@ export class DefaultClient implements Client {
                                     });
                                 };
 
-                                if (referencesRequestPending) {
+                                if (referencesRequestPending || this.client.references.symbolSearchInProgress) {
                                     let cancelling: boolean = referencesPendingCancellations.length > 0;
                                     referencesPendingCancellations.push({ reject: () => { --renameRequestsPending; reject(); }, callback });
                                     if (!cancelling) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -707,7 +707,9 @@ export class DefaultClient implements Client {
                                         // The current request is represented by referencesParams.  If a request detects
                                         // referencesParams does not match the object used when creating the request, abort it.
                                         if (params !== referencesParams) {
-                                            --renameRequestsPending;
+                                            if (--renameRequestsPending === 0) {
+                                                renamePending = false;
+                                            }
                                             reject();
                                             return;
                                         }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -286,6 +286,7 @@ let failureMessageShown: boolean = false;
 
 let referencesRequestPending: boolean = false;
 let renamePending: boolean = false;
+let renameRequestsPending: number = 0;
 let referencesParams: RenameParams | FindAllReferencesParams;
 
 interface ReferencesCancellationState {
@@ -693,6 +694,7 @@ export class DefaultClient implements Client {
                             // VS Code will attempt to issue new rename requests while another is still active.
                             // When we receive another rename request, cancel the one that is in progress.
                             renamePending = true;
+                            ++renameRequestsPending;
                             return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
                                 let callback: () => void = () => {
                                     let params: RenameParams = {
@@ -705,6 +707,7 @@ export class DefaultClient implements Client {
                                         // The current request is represented by referencesParams.  If a request detects
                                         // referencesParams does not match the object used when creating the request, abort it.
                                         if (params !== referencesParams) {
+                                            --renameRequestsPending;
                                             reject();
                                             return;
                                         }
@@ -712,6 +715,7 @@ export class DefaultClient implements Client {
                                         this.client.languageClient.sendNotification(RenameNotification, params);
                                         this.client.references.setResultsCallback((final, referencesResult) => {
                                             referencesRequestPending = false;
+                                            --renameRequestsPending;
                                             let workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                                             let cancelling: boolean = referencesPendingCancellations.length > 0;
                                             if (cancelling) {
@@ -724,6 +728,9 @@ export class DefaultClient implements Client {
                                                 referencesPendingCancellations.pop();
                                                 pendingCancel.callback();
                                             } else {
+                                                if (renameRequestsPending === 0) {
+                                                    renamePending = false;
+                                                }
                                                 // If rename UI Was cancelled, we will get a null result
                                                 // If null, return an empty list to avoid Rename failure dialog
                                                 if (referencesResult !== null) {
@@ -2154,8 +2161,8 @@ export class DefaultClient implements Client {
         referencesParams = null;
         renamePending = false;
         let cancelling: boolean = referencesPendingCancellations.length > 0;
+        referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
         if (!cancelling) {
-            referencesPendingCancellations.push({ reject: () => {}, callback: () => {} });
             this.languageClient.sendNotification(CancelReferencesNotification);
             this.references.closeRenameUI();
         }

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -370,9 +370,11 @@ export class ReferencesManager {
                     this.renameView.show(true);
                     this.renameView.setData(referencesResult, this.resultsCallback);
                 }
+            } else {
+                // Do nothing when rename is canceled while searching for references was in progress.
+                this.resultsCallback(true, null);
             }
         } else {
-            // Put results in data model
             this.findAllRefsView.setData(referencesResult, this.referencesCanceled);
 
             // Display data based on command mode: peek references OR find all references

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -126,6 +126,7 @@ export class ReferencesManager {
     private renameView: RenameView;
     private viewsInitialized: boolean = false;
 
+    public symbolSearchInProgress: boolean = false;
     private referencesCurrentProgress: ReportReferencesProgressNotification;
     private referencesPrevProgressIncrement: number;
     private referencesPrevProgressMessage: string;
@@ -344,6 +345,7 @@ export class ReferencesManager {
         }
 
         if (this.client.ReferencesCommandMode === ReferencesCommandMode.Rename) {
+            this.symbolSearchInProgress = false;
             if (!this.referencesCanceled) {
                 // If there are only Confirmed results, complete the rename immediately.
                 let foundUnconfirmed: ReferenceInfo = referencesResult.referenceInfos.find(e => e.type !== ReferenceType.Confirmed);
@@ -382,6 +384,7 @@ export class ReferencesManager {
                 this.currentUpdateProgressTimer = null;
             }
             if (this.client.ReferencesCommandMode !== ReferencesCommandMode.Rename) {
+                this.symbolSearchInProgress = false;
                 this.resultsCallback(referencesResult);
             }
             this.client.setReferencesCommandMode(ReferencesCommandMode.None);
@@ -389,6 +392,7 @@ export class ReferencesManager {
     }
 
     public setResultsCallback(callback: (results: ReferencesResult) => void): void {
+        this.symbolSearchInProgress = true;
         this.resultsCallback = callback;
     }
 

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -355,7 +355,7 @@ export class ReferencesManager {
                 }
             } else {
                 // Do nothing when rename is canceled while searching for references was in progress.
-                this.resultsCallback(true, null);
+                this.resultsCallback(null);
             }
         } else {
             this.findAllRefsView.setData(referencesResult, this.referencesCanceled);


### PR DESCRIPTION
These are the changes I suggested on https://github.com/microsoft/vscode-cpptools/pull/4342

This does not address the condition we've discussed needing to be restored in cancelReferences.  I think that may not actually be needed.  As long as pendingRename is getting properly reset as the (last) rename operation is completed successfully, we shouldn't see unwanted calls to cancelReferences() after a completed rename. 