### PR TITLE
Find refs UI: fix collapse state for file reference

### DIFF
--- a/Extension/src/LanguageServer/referencesTreeDataProvider.ts
+++ b/Extension/src/LanguageServer/referencesTreeDataProvider.ts
@@ -81,15 +81,16 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
         switch (element.node) {
             case NodeType.referenceType:
                 const label: string = getReferenceTagString(element.referenceType, this.referencesModel.isCanceled, true);
-                let result: vscode.TreeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
+                let resultRefType: vscode.TreeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
                 if (this.referencesModel.isRename) {
-                    result.contextValue = "candidateReferenceType";
+                    resultRefType.contextValue = "candidateReferenceType";
                 }
-                return result;
+                return resultRefType;
 
             case NodeType.file:
             case NodeType.fileWithPendingRef:
-                let resultFile: vscode.TreeItem = new vscode.TreeItem(element.fileUri, vscode.TreeItemCollapsibleState.Expanded);
+                let resultFile: vscode.TreeItem = new vscode.TreeItem(element.fileUri);
+                resultFile.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
                 resultFile.iconPath = vscode.ThemeIcon.File;
                 resultFile.description = true;
                 if (this.referencesModel.isRename) {
@@ -104,6 +105,7 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
                     };
                     let tag: string = getReferenceTagString(ReferenceType.ConfirmationInProgress, this.referencesModel.isCanceled);
                     resultFile.tooltip = `[${tag}]\n${element.filename}`;
+                    resultFile.collapsibleState = vscode.TreeItemCollapsibleState.None;
                 }
 
                 return resultFile;


### PR DESCRIPTION
**Issue:**
"Other references results" view will cause VS Code to crash if it tries to display file references during previewing results.

**Fix:**
For TreeItems that are file references (`NodeType.fileWithPendingRef`) set the `collapsibleState` to `TreeItemCollapsibleState.None` so that it will not try to get children references when there are none.