### PR TITLE
Fix `launch.json` creation when using non-English display languages.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Bug Fixes
 * Fix querying of non-ENU compilers. [#2874](https://github.com/microsoft/vscode-cpptools/issues/2874)
-* Fix IntelliSense error with `constexpr char* s[] = { "" }`. [#2939](https://github.com/microsoft/vscode-cpptools/issues/2939)
+* Fix IntelliSense error with `constexpr const char* s[] = { "" }`. [#2939](https://github.com/microsoft/vscode-cpptools/issues/2939)
 * Add support for C++20 designated initializers for cl and gcc. [#3491](https://github.com/Microsoft/vscode-cpptools/issues/3491)
 * Fix `Find All References` not confirming references of method overrides in an inheritance hierarchy. [#4078](https://github.com/microsoft/vscode-cpptools/issues/4078)
 * Fix missing references on the last line. [#4150](https://github.com/microsoft/vscode-cpptools/issues/4150)

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 0.26.1: October 24, 2019
+### Bug Fixes
+* Fix `launch.json` creation when using non-English display languages. [#4464](https://github.com/microsoft/vscode-cpptools/issues/4464)
+* Fix CHS translation. [#4422](https://github.com/microsoft/vscode-cpptools/issues/4422)
+
 ## Version 0.26.0: October 15, 2019
 ### New Features
 * Add localization support (translated text) via `Configure Display Language`. [#7](https://github.com/microsoft/vscode-cpptools/issues/7)
@@ -17,6 +22,8 @@
 
 ### Bug Fixes
 * Fix querying of non-ENU compilers. [#2874](https://github.com/microsoft/vscode-cpptools/issues/2874)
+* Fix IntelliSense error with `constexpr char* s[] = { "" }`. [#2939](https://github.com/microsoft/vscode-cpptools/issues/2939)
+* Add support for C++20 designated initializers for cl and gcc. [#3491](https://github.com/Microsoft/vscode-cpptools/issues/3491)
 * Fix `Find All References` not confirming references of method overrides in an inheritance hierarchy. [#4078](https://github.com/microsoft/vscode-cpptools/issues/4078)
 * Fix missing references on the last line. [#4150](https://github.com/microsoft/vscode-cpptools/issues/4150)
 * Fix `Go to Definition` on implicit default constructors. [#4162](https://github.com/microsoft/vscode-cpptools/issues/4162)

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,9 +1,10 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Version 0.26.1: October 24, 2019
+## Version 0.26.1: October 28, 2019
 ### Bug Fixes
 * Fix `launch.json` creation when using non-English display languages. [#4464](https://github.com/microsoft/vscode-cpptools/issues/4464)
 * Fix CHS translation. [#4422](https://github.com/microsoft/vscode-cpptools/issues/4422)
+* Fix debugging hang when Windows 10 Beta Unicode (UTF-8) support is enabled. [#1527](https://github.com/microsoft/vscode-cpptools/issues/1527)
 
 ## Version 0.26.0: October 15, 2019
 ### New Features

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -41,7 +41,7 @@ export class QuickPickConfigurationProvider implements vscode.DebugConfiguration
 
     async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         const configs: vscode.DebugConfiguration[] = await this.underlyingProvider.provideDebugConfigurations(folder, token);
-        const defaultConfig: vscode.DebugConfiguration = configs.find(config => isDebugLaunchStr(config.name));
+        const defaultConfig: vscode.DebugConfiguration = configs.find(config => isDebugLaunchStr(config.name) && config.request === "launch");
         console.assert(defaultConfig);
         const editor: vscode.TextEditor = vscode.window.activeTextEditor;
         if (!editor || !util.fileIsCOrCppSource(editor.document.fileName) || configs.length <= 1) {
@@ -105,7 +105,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
             return Promise.resolve(this.provider.getInitialConfigurations(this.type));
         }
         const defaultConfig: vscode.DebugConfiguration = this.provider.getInitialConfigurations(this.type).find(config => {
-            return isDebugLaunchStr(config.name);
+            return isDebugLaunchStr(config.name) && config.request === "launch";
         });
         console.assert(defaultConfig, "Could not find default debug configuration.");
 

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -24,7 +24,7 @@ nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFo
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 function isDebugLaunchStr(str: string): boolean {
-    return str === "(gdb) Launch" || str === "(lldb) Launch" || str === "(Windows) Launch";
+    return str.startsWith("(gdb) ") || str.startsWith("(lldb) ") || str.startsWith("(Windows) ");
 }
 
 /*
@@ -114,7 +114,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
 
         // Filter out build tasks that don't match the currently selectede debug configuration type.
         buildTasks = buildTasks.filter((task: vscode.Task) => {
-            if (defaultConfig.name === "(Windows) Launch") {
+            if (defaultConfig.name.startsWith("(Windows) ")) {
                 if (task.name.startsWith("cl.exe")) {
                     return true;
                 }

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -112,7 +112,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
         const platformInfo: PlatformInformation = await PlatformInformation.GetPlatformInformation();
         const platform: string = platformInfo.platform;
 
-        // Filter out build tasks that don't match the currently selectede debug configuration type.
+        // Filter out build tasks that don't match the currently selected debug configuration type.
         buildTasks = buildTasks.filter((task: vscode.Task) => {
             if (defaultConfig.name.startsWith("(Windows) ")) {
                 if (task.name.startsWith("cl.exe")) {


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/4464 .