### PR TITLE
Dismiss progress indicator when in Rename UI.  Add error dialog when no symbol is found.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -786,7 +786,7 @@ export class DefaultClient implements Client {
                                                         vscode.window.showErrorMessage(localize("unable.to.locate.selected.symbol", "A definition for the selected symbol could not be located."));
                                                     }
                                                     resolve(workspaceEdit);
-                                                } else {
+                                                } else if (workspaceEdit.size > 0) {
                                                     vscode.workspace.applyEdit(workspaceEdit);
                                                 }
                                             }

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -420,6 +420,8 @@ export class ReferencesManager {
                 if (!foundUnconfirmed) {
                     this.resultsCallback(referencesResult, true);
                 } else {
+                    // Passing a null result and doResult of true to resultsCallback will cause
+                    // the RenameProvider to resolve the promise, which causes the progress bar to be dismissed.
                     this.resultsCallback(null, true);
                     this.renameView.setData(referencesResult, this.groupByFile.Value, (result: ReferencesResult) => {
                         this.referencesCanceled = false;

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -420,9 +420,10 @@ export class ReferencesManager {
                 if (!foundUnconfirmed) {
                     this.resultsCallback(referencesResult, true);
                 } else {
+                    this.resultsCallback(null, true);
                     this.renameView.setData(referencesResult, this.groupByFile.Value, (result: ReferencesResult) => {
                         this.referencesCanceled = false;
-                        this.resultsCallback(result, true);
+                        this.resultsCallback(result, false);
                     });
                     this.renameView.show(true);
                 }


### PR DESCRIPTION
This addresses: 

https://github.com/microsoft/vscode-cpptools/issues/4510
https://github.com/microsoft/vscode-cpptools/issues/4504
