### PR TITLE
Fix issue in SchemaProvider that could occur if schema is in a subdirectory

### DIFF
--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -433,6 +433,7 @@ const generateLocalizedJsonSchemaFiles = () => {
             // Entire file is scanned and modified, then serialized for that language.
             // Even if no translations are available, we still write new files to dist/schema/...
             let keyPrefix = relativePath + ".";
+            keyPrefix = keyPrefix.replace(/\\/g, "/");
             let descriptionCallback = (path, value, parent) => {
                 if (stringTable[keyPrefix + path]) {
                     parent.description = stringTable[keyPrefix + path];

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1515,7 +1515,7 @@
     "jsonValidation": [
       {
         "fileMatch": "c_cpp_properties.json",
-        "url": "cpptools-schema://c_cpp_properties.schema.json"
+        "url": "cpptools-schema:///c_cpp_properties.schema.json"
       }
     ],
     "menus": {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -471,7 +471,7 @@ function realActivation(): void {
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json
     class SchemaProvider implements vscode.TextDocumentContentProvider {
         public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-            let fileName: string = uri.authority;
+            let fileName: string = uri.authority + uri.fsPath;
             let locale: string = util.getLocaleId();
             let localizedFilePath: string = util.getExtensionFilePath(path.join("dist/schema/", locale, fileName));
             return util.checkFileExists(localizedFilePath).then((fileExists) => {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -471,7 +471,7 @@ function realActivation(): void {
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json
     class SchemaProvider implements vscode.TextDocumentContentProvider {
         public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-            let fileName: string = uri.authority + uri.fsPath;
+            let fileName: string = uri.fsPath;
             let locale: string = util.getLocaleId();
             let localizedFilePath: string = util.getExtensionFilePath(path.join("dist/schema/", locale, fileName));
             return util.checkFileExists(localizedFilePath).then((fileExists) => {


### PR DESCRIPTION
Applying a recent fix from cmake-tools to similar code in cpptools.

Not actually causing any issues, as our schemas are not within subdirectories.
