### PR TITLE
enable breakpoints set in cu and cuh files

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1516,6 +1516,9 @@
       },
       {
         "language": "cpp"
+      },
+      {
+        "language": "cuda"
       }
     ],
     "jsonValidation": [


### PR DESCRIPTION
This PR adds a `"language": "cuda"` entry to package.json breakpoints list to allow setting breakpoints for the `vscode-cpptools` plugin in `.cu` and `.cuh` files.

This new entry shouldn't have any effect on regular users, but should enable breakpoints in `.cu` and `.cuh` files for users with the [`vscode-cudacpp`](https://marketplace.visualstudio.com/items?itemName=kriegalex.vscode-cudacpp) plugin installed. That plugin contributes a CUDA language definition (with `"languageId": "cuda"`), and handles some of the cuda-specific syntax like the `<<< >>>` kernel launch parameters.

This PR opts for the minimum changes necessary to get these two plugins working together. An alternate approach is to include the `vscode-cudacpp` CUDA language definitions in `vscode-cpptools` itself, which would enable `vscode-cpptools` to support CUDA out of the box.

In my testing, debugging CUDA is largely already supported by adding the following to any `"type": "cppdbg"` launch.json debugging configuration:
```
"MIMode": "gdb",
"miDebuggerPath": "/usr/local/cuda/bin/cuda-gdb",
```
