### PR TITLE
Support both provider ID's for cmake-tools

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -26,7 +26,7 @@ import * as logger from '../logger';
 import { updateLanguageConfigurations, registerCommands } from './extension';
 import { SettingsTracker, getTracker } from './settingsTracker';
 import { getTestHook, TestHook } from '../testHook';
-import { getCustomConfigProviders, CustomConfigurationProviderCollection, CustomConfigurationProvider1 } from '../LanguageServer/customProviders';
+import { getCustomConfigProviders, CustomConfigurationProviderCollection, CustomConfigurationProvider1, isSameProviderExtensionId } from '../LanguageServer/customProviders';
 import { ABTestSettings, getABTestSettings } from '../abTesting';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -1167,7 +1167,7 @@ export class DefaultClient implements Client {
                     },
                     () => ask.Value = false);
                 }
-            } else if (selectedProvider === provider.extensionId) {
+            } else if (isSameProviderExtensionId(selectedProvider, provider.extensionId)) {
                 onRegistered();
                 telemetry.logLanguageServerEvent("customConfigurationProvider", { "providerId": provider.extensionId });
             } else if (selectedProvider === provider.name) {
@@ -1316,6 +1316,15 @@ export class DefaultClient implements Client {
 
             const notReadyMessage: string = `${providerName} is not ready`;
             let provider: CustomConfigurationProvider1 | null = providers.get(providerId);
+            if (!provider) {
+                // Consider old and new names for cmake-tools as equivilent
+                if (providerId === "ms-vscode.cmake-tools") {
+                    providerId = "vector-of-bool.cmake-tools";
+                } else if (providerId === "vector-of-bool.cmake-tools") {
+                    providerId = "ms-vscode.cmake-tools";
+                }
+                provider = providers.get(providerId);
+            }
             if (provider) {
                 if (!provider.isReady) {
                     return Promise.reject(notReadyMessage);
@@ -1974,7 +1983,7 @@ export class DefaultClient implements Client {
             this.model.activeConfigName.Value = configurations[params.currentConfiguration].name;
         }).then(() => {
             let newProvider: string = this.configuration.CurrentConfigurationProvider;
-            if (this.configurationProvider !== newProvider) {
+            if (!isSameProviderExtensionId(newProvider, this.configurationProvider)) {
                 this.configurationProvider = newProvider;
                 this.updateCustomConfigurations();
                 this.updateCustomBrowseConfiguration();

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1316,15 +1316,6 @@ export class DefaultClient implements Client {
 
             const notReadyMessage: string = `${providerName} is not ready`;
             let provider: CustomConfigurationProvider1 | null = providers.get(providerId);
-            if (!provider) {
-                // Consider old and new names for cmake-tools as equivilent
-                if (providerId === "ms-vscode.cmake-tools") {
-                    providerId = "vector-of-bool.cmake-tools";
-                } else if (providerId === "vector-of-bool.cmake-tools") {
-                    providerId = "ms-vscode.cmake-tools";
-                }
-                provider = providers.get(providerId);
-            }
             if (provider) {
                 if (!provider.isReady) {
                     return Promise.reject(notReadyMessage);

--- a/Extension/src/LanguageServer/customProviders.ts
+++ b/Extension/src/LanguageServer/customProviders.ts
@@ -17,6 +17,9 @@ export interface CustomConfigurationProvider1 extends CustomConfigurationProvide
     readonly version: Version;
 }
 
+const oldCmakeToolsExtensionId: string = "vector-of-bool.cmake-tools";
+const newCmakeToolsExtensionId: string = "ms-vscode.cmake-tools";
+
 /**
  * Wraps the incoming CustomConfigurationProvider so that we can treat all of them as if they were the same version (e.g. latest)
  */
@@ -187,11 +190,11 @@ export class CustomConfigurationProviderCollection {
         }
 
         if (typeof provider === "string") {
-            // Consider old and new names for cmake-tools as equivilent
-            if (provider === "ms-vscode.cmake-tools") {
-                id = "vector-of-bool.cmake-tools";
-            } else if (provider === "vector-of-bool.cmake-tools") {
-                id = "ms-vscode.cmake-tools";
+            // Consider old and new names for cmake-tools as equivalent
+            if (provider === newCmakeToolsExtensionId) {
+                id = oldCmakeToolsExtensionId;
+            } else if (provider === oldCmakeToolsExtensionId) {
+                id = newCmakeToolsExtensionId;
             }
             if (this.providers.has(id)) {
                 return this.providers.get(id);
@@ -248,9 +251,9 @@ export function isSameProviderExtensionId(settingExtensionId: string, providerEx
     if (settingExtensionId === providerExtensionId) {
         return true;
     }
-    // Consider old and new names for cmake-tools as equivilent
-    if ((settingExtensionId === "ms-vscode.cmake-tools" && providerExtensionId === "vector-of-bool.cmake-tools")
-        || (settingExtensionId === "vector-of-bool.cmake-tools" && providerExtensionId === "ms-vscode.cmake-tools")) {
+    // Consider old and new names for cmake-tools as equivalent
+    if ((settingExtensionId === newCmakeToolsExtensionId && providerExtensionId === oldCmakeToolsExtensionId)
+        || (settingExtensionId === oldCmakeToolsExtensionId && providerExtensionId === newCmakeToolsExtensionId)) {
         return true;
     }
     return false;

--- a/Extension/src/LanguageServer/customProviders.ts
+++ b/Extension/src/LanguageServer/customProviders.ts
@@ -185,6 +185,18 @@ export class CustomConfigurationProviderCollection {
         if (this.providers.has(id)) {
             return this.providers.get(id);
         }
+
+        if (typeof provider === "string") {
+            // Consider old and new names for cmake-tools as equivilent
+            if (provider === "ms-vscode.cmake-tools") {
+                id = "vector-of-bool.cmake-tools";
+            } else if (provider === "vector-of-bool.cmake-tools") {
+                id = "ms-vscode.cmake-tools";
+            }
+            if (this.providers.has(id)) {
+                return this.providers.get(id);
+            }
+        }
         return null;
     }
 

--- a/Extension/src/LanguageServer/customProviders.ts
+++ b/Extension/src/LanguageServer/customProviders.ts
@@ -231,3 +231,15 @@ let providerCollection: CustomConfigurationProviderCollection = new CustomConfig
 export function getCustomConfigProviders(): CustomConfigurationProviderCollection {
     return providerCollection;
 }
+
+export function isSameProviderExtensionId(settingExtensionId: string, providerExtensionId: string): boolean {
+    if (settingExtensionId === providerExtensionId) {
+        return true;
+    }
+    // Consider old and new names for cmake-tools as equivilent
+    if ((settingExtensionId === "ms-vscode.cmake-tools" && providerExtensionId === "vector-of-bool.cmake-tools")
+        || (settingExtensionId === "vector-of-bool.cmake-tools" && providerExtensionId === "ms-vscode.cmake-tools")) {
+        return true;
+    }
+    return false;
+}

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { Client } from './client';
 import { ReferencesCommandMode, referencesCommandModeToString } from './references';
-import { getCustomConfigProviders, CustomConfigurationProviderCollection } from './customProviders';
+import { getCustomConfigProviders, CustomConfigurationProviderCollection, isSameProviderExtensionId } from './customProviders';
 import * as nls from 'vscode-nls';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -195,7 +195,7 @@ export class UI {
         let items: KeyedQuickPickItem[] = [];
         providers.forEach(provider => {
             let label: string = provider.name;
-            if (provider.extensionId === currentProvider) {
+            if (isSameProviderExtensionId(currentProvider, provider.extensionId)) {
                 label += ` (${localize("active", "active")})`;
             }
             items.push({ label: label, description: "", key: provider.extensionId });

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -572,7 +572,7 @@
 
         <div class="section">
             <div class="section-title" data-loc-id="configuration.provider">Configuration provider</div>
-            <div class="section-text" data-loc-id="configuration.provider.description">The ID of a VS Code extension that can provide IntelliSense configuration information for source files. For example, use the VS Code extension ID <code>vector-of-bool.cmake-tools</code> to provide configuration information from the CMake Tools extension.</div>
+            <div class="section-text" data-loc-id="configuration.provider.description">The ID of a VS Code extension that can provide IntelliSense configuration information for source files. For example, use the VS Code extension ID <code>ms-vscode.cmake-tools</code> to provide configuration information from the CMake Tools extension.</div>
             <div>
                 <input name="inputValue" id="configurationProvider" style="width: 290px"></input>
             </div>


### PR DESCRIPTION
Made both extension ID's compare equal.  Should be forwards compatible to use of new extension ID until updated in cmake-tools, and backwards compatible to use of the old extension ID after updated in cmake-tools.

Addresses: https://github.com/microsoft/vscode-cpptools/issues/4586 