### PR TITLE
Address issue with TU not being created for file already open when activated

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -572,7 +572,6 @@ function onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
                 if (clients.checkOwnership(client, editor.document)) {
                     if (!client.TrackedDocuments.has(editor.document)) {
                         // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
-                        client.TrackedDocuments.add(editor.document);
                         // Work around vscode treating ".C" as c, by adding this file name to file associations as cpp
                         if (editor.document.uri.path.endsWith(".C") && editor.document.languageId === "c") {
                             let cppSettings: CppSettings = new CppSettings(client.RootUri);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -571,8 +571,8 @@ function onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
             if (client) {
                 if (clients.checkOwnership(client, editor.document)) {
                     if (!client.TrackedDocuments.has(editor.document)) {
-                        client.TrackedDocuments.add(editor.document);
                         // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
+                        client.TrackedDocuments.add(editor.document);
                         // Work around vscode treating ".C" as c, by adding this file name to file associations as cpp
                         if (editor.document.uri.path.endsWith(".C") && editor.document.languageId === "c") {
                             let cppSettings: CppSettings = new CppSettings(client.RootUri);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -571,6 +571,7 @@ function onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
             if (client) {
                 if (clients.checkOwnership(client, editor.document)) {
                     if (!client.TrackedDocuments.has(editor.document)) {
+                        client.TrackedDocuments.add(editor.document);
                         // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
                         // Work around vscode treating ".C" as c, by adding this file name to file associations as cpp
                         if (editor.document.uri.path.endsWith(".C") && editor.document.languageId === "c") {

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -26,7 +26,7 @@ export function createProtocolFilter(me: Client, clients: ClientCollection): Mid
         didOpen: (document, sendMessage) => {
             let editor: vscode.TextEditor = vscode.window.visibleTextEditors.find(e => e.document === document);
             if (editor) {
-                // If the file was is visible editor when we were activated, we will not get a call to
+                // If the file was visible editor when we were activated, we will not get a call to
                 // onDidChangeVisibleTextEditors, so immediately open any file that is visible when we receive didOpen.
                 // Otherwise, we defer opening the file until it's actually visible.
                 if (clients.checkOwnership(me, document)) {


### PR DESCRIPTION
Basically, this restores the original didOpen handling if the file is already visible, in which case we won't necessarily receive a call to onDidChangeVisibleTextEditors().