### PR TITLE
Fix issue in which source file selection for header TU's does not occur when reconfiguring custom config provider

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1290,11 +1290,13 @@ export class DefaultClient implements Client {
             return Promise.resolve();
         }
         let provider: CustomConfigurationProvider1 | null = getCustomConfigProviders().get(providerId);
-        if (provider) {
-            if (!provider.isReady) {
-                onFinished();
-                return Promise.reject(`${this.configurationProvider} is not ready`);
-            }
+        if (!provider) {
+            onFinished();
+            return Promise.resolve();
+        }
+        if (!provider.isReady) {
+            onFinished();
+            return Promise.reject(`${this.configurationProvider} is not ready`);
         }
         return this.queueBlockingTask(async () => {
             let tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1191,15 +1191,6 @@ export class DefaultClient implements Client {
             this.trackedDocuments.forEach(document => {
                 this.provideCustomConfiguration(document.uri, null);
             });
-
-            // let tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
-            // let documentUris: vscode.Uri[] = [];
-            // this.trackedDocuments.forEach(document => documentUris.push(document.uri));
-
-            // let task: () => Thenable<SourceFileConfigurationItem[]> = () => {
-            //     return currentProvider.provideConfigurations(documentUris, tokenSource.token);
-            // };
-            // this.queueTaskWithTimeout(task, configProviderTimeout, tokenSource).then(configs => this.sendCustomConfigurations(configs), () => {});
         });
     }
 
@@ -1474,33 +1465,6 @@ export class DefaultClient implements Client {
             return Promise.reject(localize("unsupported.client", "Unsupported client"));
         }
     }
-
-    // private queueTaskWithTimeout(task: () => Thenable<any>, ms: number, cancelToken?: vscode.CancellationTokenSource): Thenable<any> {
-    //     let timer: NodeJS.Timer;
-    //     // Create a promise that rejects in <ms> milliseconds
-    //     let timeout: () => Promise<any> = () => new Promise((resolve, reject) => {
-    //         timer = global.setTimeout(() => {
-    //             clearTimeout(timer);
-    //             if (cancelToken) {
-    //                 cancelToken.cancel();
-    //             }
-    //             reject(localize("timed.out", "Timed out in {0}ms.", ms));
-    //         }, ms);
-    //     });
-
-    //     // Returns a race between our timeout and the passed in promise
-    //     return this.queueTask(() => {
-    //         return Promise.race([task(), timeout()]).then(
-    //             (result: any) => {
-    //                 clearTimeout(timer);
-    //                 return result;
-    //             },
-    //             (error: any) => {
-    //                 clearTimeout(timer);
-    //                 throw error;
-    //             });
-    //     });
-    // }
 
     private callTaskWithTimeout(task: () => Thenable<any>, ms: number, cancelToken?: vscode.CancellationTokenSource): Thenable<any> {
         let timer: NodeJS.Timer;


### PR DESCRIPTION
Also fixes an issue in which settings are not refreshed after a configuration provider has changed.

Also updated provideCustomConfiguration to use this.configurationProvider instead of looking it up again based on the setting..

queueTaskWithTimeout was removed to avoid an error, as it's no longer called.

This (and a corresponding PR against the native processes) addresses https://github.com/microsoft/vscode-cpptools/issues/4649 .  They should also address https://github.com/microsoft/vscode-cpptools/issues/3985