### PR TITLE
Fix Insider channel not auto-downgrading after an Insider vsix is unpublished.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.26.3-insiders2: December 18, 2019
 ### Bug Fixes
 * Fix IntelliSense regression crashes. [#4754](https://github.com/microsoft/vscode-cpptools/issues/4754)
-* Fix Insider channel not auto-downgrading after an Insider vsix is unpublished. [#4760](https://github.com/microsoft/vscode-cpptools/issues/4760)
+* Fix Insiders channel not auto-downgrading after an Insiders vsix is unpublished. [#4760](https://github.com/microsoft/vscode-cpptools/issues/4760)
 
 ## Version 0.26.3-insiders: December 16, 2019
 ### Bug Fixes

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 0.26.3-insiders2: December 18, 2019
+### Bug Fixes
+* Fix IntelliSense regression crashes. [#4754](https://github.com/microsoft/vscode-cpptools/issues/4754)
+* Fix Insider channel not auto-downgrading after an Insider vsix is unpublished. [#4760](https://github.com/microsoft/vscode-cpptools/issues/4760)
+
 ## Version 0.26.3-insiders: December 16, 2019
 ### Bug Fixes
 * Fix clang-cl detection for system includes and defines.

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -142,7 +142,7 @@ export async function getTargetBuildInfo(updateChannel: string): Promise<BuildIn
             // Allows testing pre-releases without accidentally downgrading to the latest version
             const userVersion: PackageVersion = new PackageVersion(util.packageJson.version);
             const latestVersion: PackageVersion = new PackageVersion(builds[0].name);
-            if (!testingInsidersVsixInstall && (userVersion.isGreaterThan(latestVersion) || (userVersion.suffix && userVersion.suffix !== 'insiders'))) {
+            if (!testingInsidersVsixInstall && ((userVersion.suffix && userVersion.suffix !== 'insiders') || (userVersion.isEqual(latestVersion)))) {
                 return undefined;
             }
 
@@ -179,7 +179,7 @@ function getTargetBuild(builds: Build[], userVersion: PackageVersion, updateChan
     let needsUpdate: (installed: PackageVersion, target: PackageVersion) => boolean;
     let useBuild: (build: Build) => boolean;
     if (updateChannel === 'Insiders') {
-        needsUpdate = (installed: PackageVersion, target: PackageVersion) => testingInsidersVsixInstall || target.isGreaterThan(installed);
+        needsUpdate = (installed: PackageVersion, target: PackageVersion) => testingInsidersVsixInstall || (!target.isEqual(installed));
         useBuild = (build: Build): boolean => true;
     } else if (updateChannel === 'Default') {
         needsUpdate = function(installed: PackageVersion, target: PackageVersion): boolean { return installed.isGreaterThan(target); };

--- a/Extension/src/packageVersion.ts
+++ b/Extension/src/packageVersion.ts
@@ -40,6 +40,11 @@ export class PackageVersion {
         }
     }
 
+    public isEqual(other: PackageVersion): boolean {
+        return this.major === other.major && this.minor === other.minor && this.patch === other.patch &&
+            this.suffix === other.suffix && this.suffixVersion === other.suffixVersion;
+    }
+
     public isGreaterThan(other: PackageVersion, suffixStr: string = 'insiders'): boolean {
         if ((this.suffix && !this.suffix.startsWith(suffixStr)) || (other.suffix && !other.suffix.startsWith(suffixStr))) {
             return false;


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/4760

For testing pre-release builds, we'd need to either not use the Insiders channel or set autoUpdate to false (or it would keep downgrading).