### PR TITLE
Fix bug with Insider installation.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 * Fix IntelliSense regression crashes. [#4754](https://github.com/microsoft/vscode-cpptools/issues/4754)
 * Fix Insiders channel not auto-downgrading after an Insiders vsix is unpublished. [#4760](https://github.com/microsoft/vscode-cpptools/issues/4760)
+* Fix Insiders channel not working on remote targets. [#3874](https://github.com/microsoft/vscode-cpptools/issues/3874)
 
 ## Version 0.26.3-insiders: December 16, 2019
 ### Bug Fixes

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -633,7 +633,7 @@ function installVsix(vsixLocation: string): Thenable<void> {
 
     // 1.33.0 introduces workbench.extensions.installExtension.  1.32.3 was immediately prior.
     let lastVersionWithoutInstallExtensionCommand: PackageVersion = new PackageVersion('1.32.3');
-    if (userVersion.isGreaterThan(lastVersionWithoutInstallExtensionCommand)) {
+    if (userVersion.isGreaterThan(lastVersionWithoutInstallExtensionCommand, "insider")) {
         return vscode.commands.executeCommand('workbench.extensions.installExtension', vscode.Uri.file(vsixLocation));
     }
 
@@ -672,7 +672,7 @@ function installVsix(vsixLocation: string): Thenable<void> {
 
         // 1.28.0 changes the CLI for making installations.  1.27.2 was immediately prior.
         let oldVersion: PackageVersion = new PackageVersion('1.27.2');
-        if (userVersion.isGreaterThan(oldVersion)) {
+        if (userVersion.isGreaterThan(oldVersion, "insider")) {
             return new Promise<void>((resolve, reject) => {
                 let process: ChildProcess;
                 try {


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/3874 .
This was also causing my previous "downgrade" fix to fail: [#4760](https://github.com/microsoft/vscode-cpptools/issues/4760)