### PR TITLE
Fix integration tests timeouts and events

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1762,7 +1762,7 @@
     "mkdirp": "^0.5.1",
     "plist": "^3.0.1",
     "tmp": "^0.1.0",
-    "vscode-cpptools": "^3.0.1",
+    "vscode-cpptools": "^3.1.0",
     "vscode-debugadapter": "^1.35.0",
     "vscode-debugprotocol": "^1.35.0",
     "vscode-extension-telemetry": "^0.1.2",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1677,7 +1677,6 @@ export class DefaultClient implements Client {
 
     private updateStatus(notificationBody: ReportStatusNotificationBody): void {
         let message: string = notificationBody.status;
-        console.log("---------- IntelliSense Status: " + message);
         util.setProgress(util.getProgressExecutableSuccess());
         let testHook: TestHook = getTestHook();
         if (message.endsWith("Indexing...")) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1677,7 +1677,6 @@ export class DefaultClient implements Client {
 
     private updateStatus(notificationBody: ReportStatusNotificationBody): void {
         let message: string = notificationBody.status;
-        console.log("------------------ status: " + message);
         util.setProgress(util.getProgressExecutableSuccess());
         let testHook: TestHook = getTestHook();
         if (message.endsWith("Indexing...")) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1677,6 +1677,7 @@ export class DefaultClient implements Client {
 
     private updateStatus(notificationBody: ReportStatusNotificationBody): void {
         let message: string = notificationBody.status;
+        console.log("------------------ status: " + message);
         util.setProgress(util.getProgressExecutableSuccess());
         let testHook: TestHook = getTestHook();
         if (message.endsWith("Indexing...")) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1677,6 +1677,7 @@ export class DefaultClient implements Client {
 
     private updateStatus(notificationBody: ReportStatusNotificationBody): void {
         let message: string = notificationBody.status;
+        console.log("---------- IntelliSense Status: " + message);
         util.setProgress(util.getProgressExecutableSuccess());
         let testHook: TestHook = getTestHook();
         if (message.endsWith("Indexing...")) {

--- a/Extension/src/testHook.ts
+++ b/Extension/src/testHook.ts
@@ -4,25 +4,33 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { CppToolsTestHook, IntelliSenseStatus } from 'vscode-cpptools/out/testApi';
+import { CppToolsTestHook, Status, IntelliSenseStatus } from 'vscode-cpptools/out/testApi';
 import * as vscode from 'vscode';
 
 export class TestHook implements CppToolsTestHook {
-    private statusChangedEvent: vscode.EventEmitter<IntelliSenseStatus> = new vscode.EventEmitter<IntelliSenseStatus>();
+    private intelliSenseStatusChangedEvent: vscode.EventEmitter<IntelliSenseStatus> = new vscode.EventEmitter<IntelliSenseStatus>();
+    private statusChangedEvent: vscode.EventEmitter<Status> = new vscode.EventEmitter<Status>();
 
-    public get StatusChanged(): vscode.Event<IntelliSenseStatus> {
+    // The StatusChanged event is deprecated in CppToolsTestHook API.
+    public get StatusChanged(): vscode.Event<Status> {
         return this.statusChangedEvent.event;
     }
 
+    public get IntelliSenseStatusChanged(): vscode.Event<IntelliSenseStatus> {
+        return this.intelliSenseStatusChangedEvent.event;
+    }
+
     public get valid(): boolean {
-        return !!this.statusChangedEvent;
+        return !!this.intelliSenseStatusChangedEvent;
     }
 
     public updateStatus(status: IntelliSenseStatus): void {
-        this.statusChangedEvent.fire(status);
+        this.intelliSenseStatusChangedEvent.fire(status);
     }
 
     public dispose(): void {
+        this.intelliSenseStatusChangedEvent.dispose();
+        this.intelliSenseStatusChangedEvent = null;
         this.statusChangedEvent.dispose();
         this.statusChangedEvent = null;
     }

--- a/Extension/src/testHook.ts
+++ b/Extension/src/testHook.ts
@@ -4,13 +4,13 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { CppToolsTestHook, Status } from 'vscode-cpptools/out/testApi';
+import { CppToolsTestHook, IntelliSenseStatus } from 'vscode-cpptools/out/testApi';
 import * as vscode from 'vscode';
 
 export class TestHook implements CppToolsTestHook {
-    private statusChangedEvent: vscode.EventEmitter<Status> = new vscode.EventEmitter<Status>();
+    private statusChangedEvent: vscode.EventEmitter<IntelliSenseStatus> = new vscode.EventEmitter<IntelliSenseStatus>();
 
-    public get StatusChanged(): vscode.Event<Status> {
+    public get StatusChanged(): vscode.Event<IntelliSenseStatus> {
         return this.statusChangedEvent.event;
     }
 
@@ -18,7 +18,7 @@ export class TestHook implements CppToolsTestHook {
         return !!this.statusChangedEvent;
     }
 
-    public updateStatus(status: Status): void {
+    public updateStatus(status: IntelliSenseStatus): void {
         this.statusChangedEvent.fire(status);
     }
 

--- a/Extension/test/integrationTests/languageServer/index.ts
+++ b/Extension/test/integrationTests/languageServer/index.ts
@@ -28,7 +28,7 @@ testRunner.configure({
     ui: 'tdd', 		// the TDD UI is being used in *.test.ts (suite, test, etc.)
     useColors: true, // colored output from test results
     fullStackTrace: true,
-    timeout: 60000
+    timeout: 90000
 });
 
 const logFolder: string = path.join(__dirname, ".logs");

--- a/Extension/test/integrationTests/languageServer/index.ts
+++ b/Extension/test/integrationTests/languageServer/index.ts
@@ -28,7 +28,7 @@ testRunner.configure({
     ui: 'tdd', 		// the TDD UI is being used in *.test.ts (suite, test, etc.)
     useColors: true, // colored output from test results
     fullStackTrace: true,
-    timeout: 90000
+    timeout: 100000
 });
 
 const logFolder: string = path.join(__dirname, ".logs");

--- a/Extension/test/integrationTests/languageServer/index.ts
+++ b/Extension/test/integrationTests/languageServer/index.ts
@@ -28,7 +28,7 @@ testRunner.configure({
     ui: 'tdd', 		// the TDD UI is being used in *.test.ts (suite, test, etc.)
     useColors: true, // colored output from test results
     fullStackTrace: true,
-    timeout: 100000
+    timeout: 120000
 });
 
 const logFolder: string = path.join(__dirname, ".logs");

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -195,7 +195,6 @@ suite("extensibility tests v3", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            console.log("-------------- waiting for status change ------- v3");
             disposables.push(testHook.StatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main3.cpp" && result.status === apit.Status.IntelliSenseReady) {
@@ -289,7 +288,6 @@ suite("extensibility tests v2", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            console.log("-------------- waiting for status change ------- v2");
             disposables.push(testHook.StatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main2.cpp" && result.status === apit.Status.IntelliSenseReady) {
@@ -368,7 +366,6 @@ suite("extensibility tests v1", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            console.log("-------------- waiting for status change ------- v1 ");
             disposables.push(testHook.StatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main1.cpp" && result.status === apit.Status.IntelliSenseReady) {
@@ -443,7 +440,6 @@ suite("extensibility tests v0", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            console.log("-------------- waiting for status change ------- v0 ");
             disposables.push(testHook.StatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main.cpp" && result.status === apit.Status.IntelliSenseReady) {

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -363,7 +363,7 @@ suite("extensibility tests v1", function(): void {
         let uri: vscode.Uri = vscode.Uri.file(path);
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
-        let testResult: any = new Promise<void>((resolve) => {
+        let testResult: any = new Promise<void>((resolve, reject) => {
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -371,8 +371,8 @@ suite("extensibility tests v1", function(): void {
                     resolve();
                 }
             }));
-            // This check usually takes more than 60000 ms. remove timeout to verify if status actually changes.
-            //setTimeout(() => { reject(new Error("timeout")); }, defaultTimeout);
+            // increase timeout for this test
+            setTimeout(() => { reject(new Error("timeout")); }, 10000);
         });
         disposables.push(testHook);
 

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -101,7 +101,7 @@ async function changeCppProperties(cppProperties: config.ConfigurationJson, disp
         }));
 
         // Can't trust the file watcher, so we need to allocate additional time for the backup watcher to fire.
-        setTimeout(() => { reject(new Error("timeout")); }, 4000);
+        setTimeout(() => { reject(new Error("Get ActiveConfigChanged event: timeout")); }, 8000);
     });
     await util.writeFileText(cppPropertiesPath(), JSON.stringify(cppProperties));
     let contents: string = await util.readFileText(cppPropertiesPath());

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,7 +13,7 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 6000;
+const defaultTimeout: number = 100000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,7 +13,7 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 100000;
+const defaultTimeout: number = 120000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -195,7 +195,7 @@ suite("extensibility tests v3", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            disposables.push(testHook.StatusChanged(result => {
+            disposables.push(testHook.IntelliSenseStatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main3.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -288,7 +288,7 @@ suite("extensibility tests v2", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            disposables.push(testHook.StatusChanged(result => {
+            disposables.push(testHook.IntelliSenseStatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main2.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -366,7 +366,7 @@ suite("extensibility tests v1", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            disposables.push(testHook.StatusChanged(result => {
+            disposables.push(testHook.IntelliSenseStatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main1.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -440,7 +440,7 @@ suite("extensibility tests v0", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
-            disposables.push(testHook.StatusChanged(result => {
+            disposables.push(testHook.IntelliSenseStatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -363,7 +363,7 @@ suite("extensibility tests v1", function(): void {
         let uri: vscode.Uri = vscode.Uri.file(path);
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
-        let testResult: any = new Promise<void>((resolve, reject) => {
+        let testResult: any = new Promise<void>((resolve) => {
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -371,7 +371,8 @@ suite("extensibility tests v1", function(): void {
                     resolve();
                 }
             }));
-            setTimeout(() => { reject(new Error("timeout")); }, defaultTimeout);
+            // This check usually takes more than 60000 ms. remove timeout to verify if status actually changes.
+            //setTimeout(() => { reject(new Error("timeout")); }, defaultTimeout);
         });
         disposables.push(testHook);
 

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,7 +13,7 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 100000; //60000;
+const defaultTimeout: number = 90000; //60000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -10,16 +10,12 @@ import * as util from '../../../src/common';
 import * as api from 'vscode-cpptools';
 import * as apit from 'vscode-cpptools/out/testApi';
 import * as config from '../../../src/LanguageServer/configurations';
-import { getActiveClient } from '../../../src/LanguageServer/extension';
-import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
 const defaultTimeout: number = 100000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {
         let extension: vscode.Extension<any> = vscode.extensions.getExtension("ms-vscode.cpptools");
-        util.setExtensionPath(extension.extensionPath);
-        //initializeTemporaryCommandRegistrar();
         if (!extension.isActive) {
            await extension.activate();
         }
@@ -106,7 +102,9 @@ async function changeCppProperties(cppProperties: config.ConfigurationJson, disp
     await util.writeFileText(cppPropertiesPath(), JSON.stringify(cppProperties));
     let contents: string = await util.readFileText(cppPropertiesPath());
     console.log("    wrote c_cpp_properties.json: " + contents);
-    return new Promise(r => setTimeout(r, 1));
+
+    // Sleep for 4000ms for file watcher
+    return new Promise(r => setTimeout(r, 4000));
 }
 
 /******************************************************************************/

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,7 +13,7 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 60000;
+const defaultTimeout: number = 100000; //60000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {
@@ -372,7 +372,7 @@ suite("extensibility tests v1", function(): void {
                 }
             }));
             // increase timeout for this test
-            setTimeout(() => { reject(new Error("timeout")); }, 10000);
+            setTimeout(() => { reject(new Error("timeout")); }, defaultTimeout);
         });
         disposables.push(testHook);
 

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,15 +13,15 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 120000;
+const defaultTimeout: number = 6000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {
         let extension: vscode.Extension<any> = vscode.extensions.getExtension("ms-vscode.cpptools");
         util.setExtensionPath(extension.extensionPath);
-        initializeTemporaryCommandRegistrar();
+        //initializeTemporaryCommandRegistrar();
         if (!extension.isActive) {
-            await extension.activate();
+           await extension.activate();
         }
     });
 
@@ -93,20 +93,20 @@ function cppPropertiesPath(): string {
 }
 
 async function changeCppProperties(cppProperties: config.ConfigurationJson, disposables: vscode.Disposable[]): Promise<void> {
-    let promise: Promise<void> = new Promise<void>((resolve, reject) => {
-        disposables.push(getActiveClient().ActiveConfigChanged(name => {
-            if (name === cppProperties.configurations[0].name) {
-                resolve();
-            }
-        }));
+    // let promise: Promise<void> = new Promise<void>((resolve, reject) => {
+    //     disposables.push(getActiveClient().ActiveConfigChanged(name => {
+    //         if (name === cppProperties.configurations[0].name) {
+    //             resolve();
+    //         }
+    //     }));
 
-        // Can't trust the file watcher, so we need to allocate additional time for the backup watcher to fire.
-        setTimeout(() => { reject(new Error("Get ActiveConfigChanged event: timeout")); }, 8000);
-    });
+    //     // Can't trust the file watcher, so we need to allocate additional time for the backup watcher to fire.
+    //     setTimeout(() => { reject(new Error("Get ActiveConfigChanged event: timeout")); }, 8000);
+    // });
     await util.writeFileText(cppPropertiesPath(), JSON.stringify(cppProperties));
     let contents: string = await util.readFileText(cppPropertiesPath());
     console.log("    wrote c_cpp_properties.json: " + contents);
-    return promise;
+    return new Promise(r => setTimeout(r, 1));
 }
 
 /******************************************************************************/
@@ -188,7 +188,7 @@ suite("extensibility tests v3", function(): void {
         disposables.forEach(d => d.dispose());
     });
 
-    test("Check provider", async () => {
+    test("Check provider - main3.cpp", async () => {
         // Open a c++ file to start the language server.
         let path: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/main3.cpp";
         let uri: vscode.Uri = vscode.Uri.file(path);
@@ -281,7 +281,7 @@ suite("extensibility tests v2", function(): void {
         disposables.forEach(d => d.dispose());
     });
 
-    test("Check provider", async () => {
+    test("Check provider - main2.cpp", async () => {
         // Open a c++ file to start the language server.
         let path: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/main2.cpp";
         let uri: vscode.Uri = vscode.Uri.file(path);
@@ -359,7 +359,7 @@ suite("extensibility tests v1", function(): void {
         disposables.forEach(d => d.dispose());
     });
 
-    test("Check provider", async () => {
+    test("Check provider - main1.cpp", async () => {
         // Open a c++ file to start the language server.
         let path: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/main1.cpp";
         let uri: vscode.Uri = vscode.Uri.file(path);
@@ -433,7 +433,7 @@ suite("extensibility tests v0", function(): void {
         await util.deleteFile(cppPropertiesPath());
     });
 
-    test("Check provider", async () => {
+    test("Check provider - main.cpp", async () => {
         // Open a C++ file to start the language server.
         let path: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/main.cpp";
         let uri: vscode.Uri = vscode.Uri.file(path);

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -17,7 +17,7 @@ suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {
         let extension: vscode.Extension<any> = vscode.extensions.getExtension("ms-vscode.cpptools");
         if (!extension.isActive) {
-           await extension.activate();
+            await extension.activate();
         }
     });
 
@@ -89,16 +89,6 @@ function cppPropertiesPath(): string {
 }
 
 async function changeCppProperties(cppProperties: config.ConfigurationJson, disposables: vscode.Disposable[]): Promise<void> {
-    // let promise: Promise<void> = new Promise<void>((resolve, reject) => {
-    //     disposables.push(getActiveClient().ActiveConfigChanged(name => {
-    //         if (name === cppProperties.configurations[0].name) {
-    //             resolve();
-    //         }
-    //     }));
-
-    //     // Can't trust the file watcher, so we need to allocate additional time for the backup watcher to fire.
-    //     setTimeout(() => { reject(new Error("Get ActiveConfigChanged event: timeout")); }, 8000);
-    // });
     await util.writeFileText(cppPropertiesPath(), JSON.stringify(cppProperties));
     let contents: string = await util.readFileText(cppPropertiesPath());
     console.log("    wrote c_cpp_properties.json: " + contents);

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -13,7 +13,7 @@ import * as config from '../../../src/LanguageServer/configurations';
 import { getActiveClient } from '../../../src/LanguageServer/extension';
 import { initializeTemporaryCommandRegistrar } from '../../../src/commands';
 
-const defaultTimeout: number = 90000; //60000;
+const defaultTimeout: number = 100000;
 
 suite("multiline comment setting tests", function(): void {
     suiteSetup(async function(): Promise<void> {
@@ -196,8 +196,9 @@ suite("extensibility tests v3", function(): void {
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
             console.log("-------------- waiting for status change ------- v3");
-            disposables.push(testHook.StatusChanged(status => {
-                if (status === apit.Status.IntelliSenseReady) {
+            disposables.push(testHook.StatusChanged(result => {
+                result = result as apit.IntelliSenseStatus;
+                if (result.filename === "main3.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
                     assert.deepEqual(lastResult, expected);
                     assert.deepEqual(lastBrowseResult, defaultFolderBrowseConfig);
@@ -289,8 +290,9 @@ suite("extensibility tests v2", function(): void {
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
             console.log("-------------- waiting for status change ------- v2");
-            disposables.push(testHook.StatusChanged(status => {
-                if (status === apit.Status.IntelliSenseReady) {
+            disposables.push(testHook.StatusChanged(result => {
+                result = result as apit.IntelliSenseStatus;
+                if (result.filename === "main2.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
                     assert.deepEqual(lastResult, expected);
                     assert.deepEqual(lastBrowseResult, defaultBrowseConfig);
@@ -367,8 +369,9 @@ suite("extensibility tests v1", function(): void {
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
             console.log("-------------- waiting for status change ------- v1 ");
-            disposables.push(testHook.StatusChanged(status => {
-                if (status === apit.Status.IntelliSenseReady) {
+            disposables.push(testHook.StatusChanged(result => {
+                result = result as apit.IntelliSenseStatus;
+                if (result.filename === "main1.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
                     assert.deepEqual(lastResult, expected);
                     resolve();
@@ -441,8 +444,9 @@ suite("extensibility tests v0", function(): void {
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
             console.log("-------------- waiting for status change ------- v0 ");
-            disposables.push(testHook.StatusChanged(status => {
-                if (status === apit.Status.IntelliSenseReady) {
+            disposables.push(testHook.StatusChanged(result => {
+                result = result as apit.IntelliSenseStatus;
+                if (result.filename === "main.cpp" && result.status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
                     assert.deepEqual(lastResult, expected);
                     resolve();

--- a/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
+++ b/Extension/test/integrationTests/languageServer/languageServer.integration.test.ts
@@ -195,6 +195,7 @@ suite("extensibility tests v3", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
+            console.log("-------------- waiting for status change ------- v3");
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -287,6 +288,7 @@ suite("extensibility tests v2", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
+            console.log("-------------- waiting for status change ------- v2");
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -364,6 +366,7 @@ suite("extensibility tests v1", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
+            console.log("-------------- waiting for status change ------- v1 ");
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
@@ -371,7 +374,6 @@ suite("extensibility tests v1", function(): void {
                     resolve();
                 }
             }));
-            // increase timeout for this test
             setTimeout(() => { reject(new Error("timeout")); }, defaultTimeout);
         });
         disposables.push(testHook);
@@ -438,6 +440,7 @@ suite("extensibility tests v0", function(): void {
 
         let testHook: apit.CppToolsTestHook = cpptools.getTestHook();
         let testResult: any = new Promise<void>((resolve, reject) => {
+            console.log("-------------- waiting for status change ------- v0 ");
             disposables.push(testHook.StatusChanged(status => {
                 if (status === apit.Status.IntelliSenseReady) {
                     let expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -5160,10 +5160,10 @@ vrsource-tslint-rules@^6.0.0:
   resolved "https://registry.yarnpkg.com/vrsource-tslint-rules/-/vrsource-tslint-rules-6.0.0.tgz#a4e25e8f3fdd487684174f423c090c35d60f37a9"
   integrity sha512-pmcnJdIVziZTk1V0Cqehmh3gIabBRkBYXkv9vx+1CZDNEa41kNGUBFwQLzw21erYOd2QnD8jJeZhBGqnlT1HWw==
 
-vscode-cpptools@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-3.0.1.tgz#35ea986a48ac14eda85f3989ba5eedc64886c0c2"
-  integrity sha512-KAbwWhG36Ahnug9frcCOvWI3dUb3mzWeTqB6NQjIkzAazRTJWT/PiZ7gxpY/+jQIUylbbiU9ezWmzIIm8nP+TQ==
+vscode-cpptools@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-3.1.0.tgz#fbc0e493e81a05baf01702ea8b9467c39fba257d"
+  integrity sha512-z4W/A1TQMEtqTEWNY3Hb4HJcJ2J3HeaLHp3TyqCotoRkLU8ovH4jmDb5tNTyh3DgIiaAAnDalO03A4wm5IvNBg==
 
 vscode-debugadapter@^1.35.0:
   version "1.37.1"


### PR DESCRIPTION
**Issues:**

1. Updating IntelliSense may take more than the test timeout value on macOS. 
2. The returned IntelliSense status for tests may not be synchronized with the document that is being tested. For example, a document `ABC.cpp` was opened, and then a second document `123.cpp` is opened and the test is waiting to verify IntelliSense status of `123.cpp`, but receives the status for `ABC.cpp` and uses this status to verify `123.cpp` which results in an incorrect verification.
3. Extra instance of extension gets created when checking for cppProperty changes in tests, that is when `getActiveClient()` is called in test code.

**Fix:**
1. Increase the timeout value of test to account for the slow IntelliSense update time on macOS.
2. Update the testHook API to include the name of the active document to the IntelliSense status (see pull request (https://github.com/microsoft/vscode-cpptools-api/pull/23). This will allow correct verification of the IntelliSense status for an active document that is in test.
3. Remove code creates extra instance of extension. This code is not needed to check for cppProperty changes, but sleep timer is needed for file watcher.

