### PR TITLE
Fix issue with files in the database getting unnecessarily removed on startup with a configuration provider

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1223,7 +1223,7 @@ export class DefaultClient implements Client {
             // Resume parsing on either resolve or reject, only if parsing was not resumed due to timeout
             let hasCompleted: boolean = false;
             task().then(async config => {
-                await this.sendCustomBrowseConfiguration(config, requestingProvider.extensionId);
+                await this.sendCustomBrowseConfiguration(config, currentProvider.extensionId);
                 if (!hasCompleted) {
                     hasCompleted = true;
                     if (currentProvider.version >= Version.v2) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1223,7 +1223,7 @@ export class DefaultClient implements Client {
             // Resume parsing on either resolve or reject, only if parsing was not resumed due to timeout
             let hasCompleted: boolean = false;
             task().then(async config => {
-                await this.sendCustomBrowseConfiguration(config);
+                await this.sendCustomBrowseConfiguration(config, requestingProvider.extensionId);
                 if (!hasCompleted) {
                     hasCompleted = true;
                     if (currentProvider.version >= Version.v2) {
@@ -1243,7 +1243,7 @@ export class DefaultClient implements Client {
             global.setTimeout(async () => {
                 if (!hasCompleted) {
                     hasCompleted = true;
-                    await this.sendCustomBrowseConfiguration(null, true);
+                    await this.sendCustomBrowseConfiguration(null, null, true);
                     if (currentProvider.version >= Version.v2) {
                         console.warn("Configuration Provider timed out in {0}ms.", configProviderTimeout);
                         this.resumeParsing();
@@ -1810,7 +1810,7 @@ export class DefaultClient implements Client {
     }
 
     private promptCompileCommands(params: CompileCommandsPaths) : void {
-        if (this.configuration.CurrentConfiguration.compileCommands !== undefined && this.configuration.CurrentConfiguration.configurationProvider !== undefined) {
+        if (this.configuration.CurrentConfiguration.compileCommands !== undefined || this.configuration.CurrentConfiguration.configurationProvider !== undefined) {
             return;
         }
 
@@ -1918,6 +1918,8 @@ export class DefaultClient implements Client {
         this.notifyWhenReady(() => this.languageClient.sendNotification(ResumeParsingNotification));
     }
 
+    private doneInitialCustomBrowseConfigurationCheck: Boolean = false;
+
     private onConfigurationsChanged(configurations: configs.Configuration[]): void {
         let params: FolderSettingsParams = {
             configurations: configurations,
@@ -1931,14 +1933,27 @@ export class DefaultClient implements Client {
             c.compilerArgs = compilerPathAndArgs.additionalArgs;
         });
         this.notifyWhenReady(() => {
+            let lastCustomBrowseConfigurationProviderId: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastCustomBrowseConfigurationProviderId", null, this.RootPath);
+            if (!this.doneInitialCustomBrowseConfigurationCheck) {
+                // Send the last custom browse configuration we received from this provider.
+                // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
+                // Should only execute on launch, for the initial delivery of configurations
+                if (lastCustomBrowseConfigurationProviderId.Value == configurations[params.currentConfiguration].configurationProvider) {
+                    let lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration> = new PersistentFolderState<WorkspaceBrowseConfiguration>("CPP.lastCustomBrowseConfiguration", null, this.RootPath);
+                    if (lastCustomBrowseConfiguration.Value) {
+                        this.sendCustomBrowseConfiguration(lastCustomBrowseConfiguration.Value, lastCustomBrowseConfigurationProviderId.Value);
+                    }
+                }
+                this.doneInitialCustomBrowseConfigurationCheck = true;
+            }
             this.languageClient.sendNotification(ChangeFolderSettingsNotification, params);
             this.model.activeConfigName.Value = configurations[params.currentConfiguration].name;
         }).then(() => {
             let newProvider: string = this.configuration.CurrentConfigurationProvider;
             if (!isSameProviderExtensionId(newProvider, this.configurationProvider)) {
                 this.configurationProvider = newProvider;
-                this.updateCustomConfigurations();
                 this.updateCustomBrowseConfiguration();
+                this.updateCustomConfigurations();
             }
         });
     }
@@ -2030,8 +2045,9 @@ export class DefaultClient implements Client {
         }
     }
 
-    private sendCustomBrowseConfiguration(config: any, timeoutOccured?: boolean): Thenable<void> {
+    private sendCustomBrowseConfiguration(config: any, providerId: string, timeoutOccured?: boolean): Thenable<void> {
         let lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration> = new PersistentFolderState<WorkspaceBrowseConfiguration>("CPP.lastCustomBrowseConfiguration", null, this.RootPath);
+        let lastCustomBrowseConfigurationProviderId: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastCustomBrowseConfigurationProviderId", null, this.RootPath);
         let sanitized: util.Mutable<WorkspaceBrowseConfiguration>;
 
         // This while (true) is here just so we can break out early if the config is set on error
@@ -2081,6 +2097,7 @@ export class DefaultClient implements Client {
             }
 
             lastCustomBrowseConfiguration.Value = sanitized;
+            lastCustomBrowseConfigurationProviderId.Value = providerId;
             break;
         }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1938,7 +1938,7 @@ export class DefaultClient implements Client {
                 // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
                 // Should only execute on launch, for the initial delivery of configurations
                 let lastCustomBrowseConfigurationProviderId: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastCustomBrowseConfigurationProviderId", null, this.RootPath);
-                if (lastCustomBrowseConfigurationProviderId.Value == configurations[params.currentConfiguration].configurationProvider) {
+                if (lastCustomBrowseConfigurationProviderId.Value === configurations[params.currentConfiguration].configurationProvider) {
                     let lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration> = new PersistentFolderState<WorkspaceBrowseConfiguration>("CPP.lastCustomBrowseConfiguration", null, this.RootPath);
                     if (lastCustomBrowseConfiguration.Value) {
                         this.sendCustomBrowseConfiguration(lastCustomBrowseConfiguration.Value, lastCustomBrowseConfigurationProviderId.Value);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1933,11 +1933,11 @@ export class DefaultClient implements Client {
             c.compilerArgs = compilerPathAndArgs.additionalArgs;
         });
         this.notifyWhenReady(() => {
-            let lastCustomBrowseConfigurationProviderId: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastCustomBrowseConfigurationProviderId", null, this.RootPath);
             if (!this.doneInitialCustomBrowseConfigurationCheck) {
                 // Send the last custom browse configuration we received from this provider.
                 // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
                 // Should only execute on launch, for the initial delivery of configurations
+                let lastCustomBrowseConfigurationProviderId: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastCustomBrowseConfigurationProviderId", null, this.RootPath);
                 if (lastCustomBrowseConfigurationProviderId.Value == configurations[params.currentConfiguration].configurationProvider) {
                     let lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration> = new PersistentFolderState<WorkspaceBrowseConfiguration>("CPP.lastCustomBrowseConfiguration", null, this.RootPath);
                     if (lastCustomBrowseConfiguration.Value) {


### PR DESCRIPTION
Addressed #4802
Also addresses the issue in which the prompt to configure compile commands is displayed despite already using compile commands, or using a custom config provider: https://github.com/microsoft/vscode-cpptools/issues/3972
