### PR TITLE
Fix no compiler found when compilerPath isn't set.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -311,7 +311,7 @@ export async function getBuildTasks(returnCompilerPath: boolean): Promise<vscode
         knownCompilerPaths = knownCompilers.map<string>(info => info.path);
     }
 
-    if (!knownCompilerPaths || !userCompilerPath) {
+    if (!knownCompilerPaths && !userCompilerPath) {
         // Don't prompt a message yet until we can make a data-based decision.
         telemetry.logLanguageServerEvent('noCompilerFound');
         // Display a message prompting the user to install compilers if none were found.


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/4834