### PR TITLE
Fire the old event statusChangedEvent in testHook API

### DIFF
--- a/Extension/src/testHook.ts
+++ b/Extension/src/testHook.ts
@@ -21,11 +21,12 @@ export class TestHook implements CppToolsTestHook {
     }
 
     public get valid(): boolean {
-        return !!this.intelliSenseStatusChangedEvent;
+        return !!this.intelliSenseStatusChangedEvent && !!this.statusChangedEvent;
     }
 
     public updateStatus(status: IntelliSenseStatus): void {
         this.intelliSenseStatusChangedEvent.fire(status);
+        this.statusChangedEvent.fire(status.status);
     }
 
     public dispose(): void {


### PR DESCRIPTION
Add back firing the event statusChangedEvent in testHook API in case there was a dependency on it.