### PR TITLE
Remove unused script

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1709,7 +1709,6 @@
     "translations-export": "node ./tools/prepublish.js && gulp generate-native-strings && gulp translations-export",
     "translations-generate": "node ./tools/prepublish.js && gulp translations-generate",
     "translations-import": "node ./tools/prepublish.js && gulp translations-import",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "prepublishjs": "node ./tools/prepublish.js",
     "pretest": "node ./tools/prepublish.js && tsc -p test.tsconfig.json",
     "pr-check": "node ./tools/prepublish.js && gulp pr-check",


### PR DESCRIPTION
With this present, "yarn install --production" was failing.

With this change, we can use "yarn install --production" to remove our dev dependencies from node_modules before packaging the vsix.
