### PR TITLE
Validate dependencies for lldb-mi

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1920,11 +1920,25 @@
       ]
     },
     {
-      "description": "LLDB 3.8.0 (OS X)",
+      "description": "LLDB-MI (macOS Mojave and higher)",
+      "url": "https://go.microsoft.com/fwlink/?linkid=2116759",
+      "platforms": [
+        "darwin"
+      ],
+      "versionRegex": "10\\.(1[0-3]|[0-9])(\\..*)*$",
+      "matchVersion": false,
+      "binaries": [
+        "./debugAdapters/lldb-mi/bin/lldb-mi"
+      ]
+    },
+    {
+      "description": "LLDB 3.8.0 (macOS High Sierra and lower)",
       "url": "https://go.microsoft.com/fwlink/?LinkID=817244",
       "platforms": [
         "darwin"
       ],
+      "versionRegex": "10\\.(1[0-3]|[0-9])(\\..*)*$",
+      "matchVersion": true,
       "binaries": [
         "./debugAdapters/lldb/bin/debugserver",
         "./debugAdapters/lldb/bin/lldb-mi",


### PR DESCRIPTION
If a user does not provide a custom lldb-mi on macOS running in LLDB
mode. We check to see if the XCode/XCode CLI LLDB.framework dependencies
exist.