### PR TITLE
Fix issue with disabled compiler path in config UI if none detected

### DIFF
--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -480,7 +480,7 @@
         <!-- input compilerPath -->
         <div class="section-note" data-loc-id="specify.a.compiler">Specify a compiler path or select a detected compiler path from the drop-down list.</div>
             <div class="select-editable">
-                <span id="noCompilerPathsDetected" class="error" style="display: none" data-loc-id="no.compiler.paths.detected">(No compiler paths detected)</span>
+                <span id="noCompilerPathsDetected" style="display: none" data-loc-id="no.compiler.paths.detected">(No compiler paths detected)</span>
                 <select id="knownCompilers" style="width: 810px; display: none"></select>
                 <input name="inputValue" id="compilerPath" style="width: 777px; display: none" type="text"/>
             </div>

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -489,8 +489,8 @@
     </div>
 
     <div class="section">
-        <div class="section-title">Compiler arguments</div>
-        <div class="section-text" data-loc-id="compiler.arguments">Compiler arguments to modify the includes or defines used, e.g. <code>-nostdinc++</code>, <code>-m32</code>, etc.</div>
+        <div class="section-title" data-loc-id="compiler.arguments">Compiler arguments</div>
+        <div class="section-text" data-loc-id="compiler.arguments.description">Compiler arguments to modify the includes or defines used, e.g. <code>-nostdinc++</code>, <code>-m32</code>, etc.</div>
         <div>
             <div class="section-note" data-loc-id="one.argument.per.line">One argument per line.</div>
             <textarea name="inputValue" id="compilerArgs" rows="4" cols="93" style="width: 800px"></textarea>

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -489,8 +489,8 @@
     </div>
 
     <div class="section">
-        <div class="section-title" data-loc-id="compiler.arguments">Compiler arguments</div>
-        <div class="section-text" data-loc-id="compiler.arguments.description">Compiler arguments to modify the includes or defines used, e.g. <code>-nostdinc++</code>, <code>-m32</code>, etc.</div>
+        <div class="section-title" data-loc-id="compiler.args">Compiler arguments</div>
+        <div class="section-text" data-loc-id="compiler.arguments">Compiler arguments to modify the includes or defines used, e.g. <code>-nostdinc++</code>, <code>-m32</code>, etc.</div>
         <div>
             <div class="section-note" data-loc-id="one.argument.per.line">One argument per line.</div>
             <textarea name="inputValue" id="compilerArgs" rows="4" cols="93" style="width: 800px"></textarea>

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -18,6 +18,7 @@ const elementId: { [key: string]: string } = {
     compilerPath: "compilerPath",
     compilerPathInvalid: "compilerPathInvalid",
     knownCompilers: "knownCompilers",
+    noCompilerPathsDetected: "noCompilerPathsDetected",
     compilerArgs: "compilerArgs",
 
     intelliSenseMode: "intelliSenseMode",
@@ -338,19 +339,23 @@ class SettingsApp {
             }
 
             if (compilers.length === 0) {
-                this.showElement("noCompilerPathsDetected", true);
-                return;
-            }
-
-            this.showElement("compilerPath", true);
-            this.showElement("knownCompilers", true);
-
-            for (let path of compilers) {
+                // Get HTML element containing the string, as we can't localize strings in HTML js
+                let noCompilerSpan: HTMLSpanElement = <HTMLSpanElement>document.getElementById(elementId.noCompilerPathsDetected);
                 let option: HTMLOptionElement = document.createElement("option");
-                option.text = path;
-                option.value = path;
+                option.text = noCompilerSpan.textContent;
+                option.disabled = true;
                 list.append(option);
+            } else {
+                for (let path of compilers) {
+                    let option: HTMLOptionElement = document.createElement("option");
+                    option.text = path;
+                    option.value = path;
+                    list.append(option);
+                }
             }
+
+            this.showElement(elementId.compilerPath, true);
+            this.showElement(elementId.knownCompilers, true);
 
             // Initialize list with no selected item
             list.value = "";


### PR DESCRIPTION
Addresses #4727, #4879

Keeps the hidden span in the HTML file for the purpose of localization, but builds a new option to display in the drop-down.  (For some reason, it does not work to hide/show an option in the HTML file).

