### PR TITLE
Handle missing assert in getVsixDownloadUrl

### DIFF
--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -45,7 +45,6 @@ function getVsixDownloadUrl(build: Build, vsixName: string): string {
     return downloadUrl;
 }
 
-
 /**
  * Determine whether an object is of type Asset.
  * @param input Incoming object.

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -35,14 +35,16 @@ interface Build {
 * @return The download URL of the VSIX
 */
 function getVsixDownloadUrl(build: Build, vsixName: string): string {
-    const downloadUrl: string = build.assets.find(asset => {
+    const asset: Asset | undefined = build.assets.find(asset => {
         return asset.name === vsixName;
-    }).browser_download_url;
+    });
+    const downloadUrl: string | null = (asset) ? asset.browser_download_url : null;
     if (!downloadUrl) {
         throw new Error(`Failed to find VSIX: ${vsixName} in build: ${build.name}`);
     }
     return downloadUrl;
 }
+
 
 /**
  * Determine whether an object is of type Asset.
@@ -156,6 +158,9 @@ export async function getTargetBuildInfo(updateChannel: string): Promise<BuildIn
                 const platformInfo: PlatformInformation = await PlatformInformation.GetPlatformInformation();
                 const vsixName: string = vsixNameForPlatform(platformInfo);
                 const downloadUrl: string = getVsixDownloadUrl(build, vsixName);
+                if (!downloadUrl) {
+                    return undefined;
+                }
                 return { downloadUrl: downloadUrl, name: build.name };
             } catch (error) {
                 return Promise.reject(error);


### PR DESCRIPTION
Addresses an issue in which a null dereference could occur if an asset is removed from a release.  (Part of https://github.com/microsoft/vscode-cpptools/issues/4941 )
