### PR TITLE
Use system installed clang-format only if newer, or bundled version is not executable

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "0.26.3-master",
+  "version": "0.27.0-master",
   "publisher": "ms-vscode",
   "preview": true,
   "icon": "LanguageCCPP_color_128x.png",

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -73,7 +73,7 @@ export class CppSettings extends Settings {
                 try {
                     let exePath: string = getExtensionFilePath("./LLVM/bin/" + this.clangFormatName);
                     let output: string[] = execSync(exePath + " --version").toString().split(" ");
-                    if (output.length < 3 || output[0] != "clang-format" || output[1] != "version" || !semver.valid(output[2])) {
+                    if (output.length < 3 || output[0] !== "clang-format" || output[1] !== "version" || !semver.valid(output[2])) {
                         return path;
                     }
                     clangFormatVersion = output[2];
@@ -85,7 +85,7 @@ export class CppSettings extends Settings {
                 // Invoke the version on the system to compare versions.  Use ours if it's more recent.
                 try {
                     let output: string[] = execSync("\"" + path + "\" --version").toString().split(" ");
-                    if (output.length < 3 || output[0] != "clang-format" || output[1] != "version" || semver.ltr(output[2], clangFormatVersion)) {
+                    if (output.length < 3 || output[0] !== "clang-format" || output[1] !== "version" || semver.ltr(output[2], clangFormatVersion)) {
                         path = "";
                     }
                 } catch (e) {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -71,8 +71,8 @@ export class CppSettings extends Settings {
                 // Attempt to invoke both our own version of clang-format to see if we can successfully execute it, and to get it's version.
                 let clangFormatVersion: string;
                 try {
-                    let exePath: string = getExtensionFilePath("./LLVM/bin/" + this.clangFormatName);
-                    let output: string[] = execSync(exePath + " --version").toString().split(" ");
+                    let exePath: string = getExtensionFilePath(`./LLVM/bin/${this.clangFormatName}`);
+                    let output: string[] = execSync(`${exePath} --version`).toString().split(" ");
                     if (output.length < 3 || output[0] !== "clang-format" || output[1] !== "version" || !semver.valid(output[2])) {
                         return path;
                     }
@@ -84,7 +84,7 @@ export class CppSettings extends Settings {
 
                 // Invoke the version on the system to compare versions.  Use ours if it's more recent.
                 try {
-                    let output: string[] = execSync("\"" + path + "\" --version").toString().split(" ");
+                    let output: string[] = execSync(`"${path}" --version`).toString().split(" ");
                     if (output.length < 3 || output[0] !== "clang-format" || output[1] !== "version" || semver.ltr(output[2], clangFormatVersion)) {
                         path = "";
                     }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -55,47 +55,45 @@ export class CppSettings extends Settings {
         switch (os.platform()) {
             case "win32":
                 return "clang-format.exe";
-            case "linux":
-                return "clang-format.darwin";
             case "darwin":
+                return "clang-format.darwin";
+            case "linux":
+            default:
                 return "clang-format";
         }
     }
 
     public get clangFormatPath(): string {
-        let clangFormatPath: string = super.Section.get<string>("clang_format_path");
-        if (!clangFormatPath) {
-            clangFormatPath = which.sync('clang-format', {nothrow: true});
-            if (clangFormatPath) {
+        let path: string = super.Section.get<string>("clang_format_path");
+        if (!path) {
+            path = which.sync('clang-format', {nothrow: true});
+            if (path) {
                 // Attempt to invoke both our own version of clang-format to see if we can successfully execute it, and to get it's version.
                 let clangFormatVersion: string;
                 try {
-                    let path: string = getExtensionFilePath("./LLVM/bin/" + this.clangFormatName);
-                    let output: string[] = execSync(path + " --version").toString().split(" ");
-
-                    // Compares against our version of clang-format.
-                    // This hard-coded version will need to be updated whenever we update our clang-format
+                    let exePath: string = getExtensionFilePath("./LLVM/bin/" + this.clangFormatName);
+                    let output: string[] = execSync(exePath + " --version").toString().split(" ");
                     if (output.length < 3 || output[0] != "clang-format" || output[1] != "version" || !semver.valid(output[2])) {
-                        return clangFormatPath;
+                        return path;
                     }
                     clangFormatVersion = output[2];
                 } catch (e) {
                     // Unable to invoke our own clang-format.  Use the system installed clang-format.
-                    return clangFormatPath;
+                    return path;
                 }
 
                 // Invoke the version on the system to compare versions.  Use ours if it's more recent.
                 try {
-                    let output: string[] = execSync("\"" + clangFormatPath + "\" --version").toString().split(" ");
+                    let output: string[] = execSync("\"" + path + "\" --version").toString().split(" ");
                     if (output.length < 3 || output[0] != "clang-format" || output[1] != "version" || semver.ltr(output[2], clangFormatVersion)) {
-                        clangFormatPath = "";
+                        path = "";
                     }
                 } catch (e) {
-                    clangFormatPath = "";
+                    path = "";
                 }
             }
         }
-        return clangFormatPath;
+        return path;
     }
 
     public get clangFormatStyle(): string { return super.Section.get<string>("clang_format_style"); }


### PR DESCRIPTION
If a path to clang-format is configured explicitly, we'll use it.  Otherwise, we will check for one on the system.  If we find one on the system, we will:
    - Try to invoke our own, to see if we can successfully do so, and to query its version.
        - If we fail to invoke our own, use the one found on the system.
        - If we successfully execute our own, try to invoke the one found on the system as well, to compare versions.
            - If it fails to execute, use our own.
            - If both are executable, use the one with the greater version.

This should address: https://github.com/microsoft/vscode-cpptools/issues/4963 