### PR TITLE
Prompt again for provider if config is cleared

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1134,7 +1134,7 @@ export class DefaultClient implements Client {
     }
 
     public onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void> {
-        let wasRegistered: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("Client.registerProvider.wasRegistered", true, this.RootPath);
+        let wasRegistered: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("Client.registerProvider.wasRegistered", false, this.RootPath);
         let onRegistered: () => void = () => {
             // version 2 providers control the browse.path. Avoid thrashing the tag parser database by pausing parsing until
             // the provider has sent the correct browse.path value.


### PR DESCRIPTION
This should address https://github.com/microsoft/vscode-cpptools/issues/2346 which occured because the configuration had been cleaned out, but we were still maintaining a `PersistentFolderState` preventing us from again prompting the user to use the provider.

Also moved assignment of ask.Value when allowing the config provider, to avoid blocking future prompts if updateCustomConfigurationProvider() fails.
