### PR TITLE
Fix null reference in updateCustomBrowseConfiguration.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.27.0-insiders2: March 4, 2019
 ### Bug Fixes
 * Fix the `Open File...` scenario (without a workspace folder). [#5049](https://github.com/microsoft/vscode-cpptools/issues/5049)
+* Fix `browsePath` null reference that can occur with some configuration providers. [PR #5055](https://github.com/microsoft/vscode-cpptools/pull/5055)
 
 ## Version 0.27.0-insiders: March 3, 2019
 ### Enhancements

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1454,6 +1454,9 @@ export class DefaultClient implements Client {
             // Resume parsing on either resolve or reject, only if parsing was not resumed due to timeout
             let hasCompleted: boolean = false;
             task().then(async config => {
+                if (!config) {
+                    return;
+                }
                 // TODO: This is a hack to get around CMake Tools bug: https://github.com/microsoft/vscode-cmake-tools/issues/1073
                 let foundMatch: boolean = false;
                 for (let c of config.browsePath) {


### PR DESCRIPTION
Null reference occurs with some configuration providers.
Port a fix from https://github.com/microsoft/vscode-cpptools/pull/5030
