### PR TITLE
Remove null default for intelliSenseCachePath

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -313,7 +313,6 @@
         },
         "C_Cpp.intelliSenseCachePath": {
           "type": "string",
-          "default": null,
           "description": "%c_cpp.configuration.intelliSenseCachePath.description%",
           "scope": "resource"
         },


### PR DESCRIPTION
This was missed in https://github.com/microsoft/vscode-cpptools/pull/5030

VS Code will return "" for a string setting when it's not present, by default.  If we allow a type of 'null', the setting is not properly editable as a string in the VS Code settings UI.  Currently, `compilerPath` is the only string setting for which a value of "" has a meaning different from null.  So, for all other strings, I removed the use of null as a valid value, in favor of "", so those settings can be edited properly in VS Code settings UI.
