### PR TITLE
Fix error when renaming

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Version 0.27.0-insiders3: March 12, 2019
+## Version 0.27.0-insiders3: March 13, 2020
 ### Bug Fixes
 * Fix update to clang-format 9.0.1 (and without shared library dependencies). [#2887](https://github.com/microsoft/vscode-cpptools/issues/2887), [#3174](https://github.com/microsoft/vscode-cpptools/issues/3174)
 * Add new setting `C_Cpp.debugger.useBacktickCommandSubstitution` to fix debugging when CShell is the remote default shell. [#4015](https://github.com/microsoft/vscode-cpptools/issues/4015)
@@ -17,12 +17,12 @@
 * Fix Pause (break all) not working on Mac with Attach debugging.
 * Other language server crash fixes.
 
-## Version 0.27.0-insiders2: March 4, 2019
+## Version 0.27.0-insiders2: March 4, 2020
 ### Bug Fixes
 * Fix the `Open File...` scenario (without a workspace folder). [#5049](https://github.com/microsoft/vscode-cpptools/issues/5049)
 * Fix `browsePath` null reference that can occur with some configuration providers. [PR #5055](https://github.com/microsoft/vscode-cpptools/pull/5055)
 
-## Version 0.27.0-insiders: March 3, 2019
+## Version 0.27.0-insiders: March 3, 2020
 ### Enhancements
 * Improved multi-root implementation with a single language server process and database for the entire workspace (shared between workspace folders). Fixes most [multi-root bugs](https://github.com/microsoft/vscode-cpptools/issues?q=is%3Aopen+is%3Aissue+label%3A%22Feature%3A+Multiroot%22+label%3A%22fixed+%28release+pending%29%22+milestone%3A0.27.0).
 * Update to clang-format 9.0.1 (and without shared library dependencies). [#2887](https://github.com/microsoft/vscode-cpptools/issues/2887), [#3174](https://github.com/microsoft/vscode-cpptools/issues/3174)

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -70,7 +70,7 @@ export class QuickPickConfigurationProvider implements vscode.DebugConfiguration
             throw new Error(); // User canceled it.
         }
         if (selection.label.startsWith("cl.exe")) {
-            if (!process.env.DevEnvDir || process.env.DevEnvDir.length === 0) {
+            if (!process.env.DevEnvDir) {
                 vscode.window.showErrorMessage(localize("cl.exe.not.available", "{0} build and debug is only usable when VS Code is run from the Developer Command Prompt for VS.", "cl.exe"));
                 throw new Error();
             }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -593,6 +593,7 @@ export class DefaultClient implements Client {
                 storagePath = path;
             }
         }
+
         if (!storagePath) {
             storagePath = path.join(this.RootPath, "/.vscode");
         }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1291,7 +1291,7 @@ export class CppProperties {
                     if (isWindows && compilerPathAndArgs.compilerName === "cl.exe") {
                         continue; // Don't squiggle invalid cl.exe paths because it could be for an older preview build.
                     }
-                    if (!compilerPathAndArgs.compilerPath) {
+                    if (compilerPathAndArgs.compilerPath === undefined) {
                         continue;
                     }
                     // Squiggle when the compiler's path has spaces without quotes but args are used.

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1254,7 +1254,7 @@ function onRenameViewAddFile(arg?: TreeNode): void {
 }
 
 function onRenameViewAddReferenceType(arg?: TreeNode): void {
-    if (!arg || !arg.referenceType) {
+    if (!arg || arg.referenceType === undefined) {
         return;
     }
     arg.model.setAllReferenceTypeRenamesPending(arg.referenceType);

--- a/Extension/src/LanguageServer/referencesModel.ts
+++ b/Extension/src/LanguageServer/referencesModel.ts
@@ -277,7 +277,7 @@ export class ReferencesModel {
         let referenceInfos: ReferenceInfo[] = [];
         this.nodes.forEach(n => {
             if (!n.isRenameCandidate) {
-                if (!n.filename || !n.referenceLocation || !n.referenceText || n.referenceType === undefined) {
+                if (!n.filename || !n.referenceLocation || n.referenceText === undefined || n.referenceType === undefined) {
                     throw new Error("Invalid TreeNode detected in completeRename()");
                 }
                 let referenceInfo: ReferenceInfo = {

--- a/Extension/src/LanguageServer/referencesModel.ts
+++ b/Extension/src/LanguageServer/referencesModel.ts
@@ -277,7 +277,7 @@ export class ReferencesModel {
         let referenceInfos: ReferenceInfo[] = [];
         this.nodes.forEach(n => {
             if (!n.isRenameCandidate) {
-                if (!n.filename || !n.referenceLocation || !n.referenceText || !n.referenceType) {
+                if (!n.filename || !n.referenceLocation || !n.referenceText || n.referenceType === undefined) {
                     throw new Error("Invalid TreeNode detected in completeRename()");
                 }
                 let referenceInfo: ReferenceInfo = {

--- a/Extension/src/LanguageServer/referencesTreeDataProvider.ts
+++ b/Extension/src/LanguageServer/referencesTreeDataProvider.ts
@@ -118,7 +118,7 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
                 return resultFile;
 
             case NodeType.reference:
-                if (!element.referenceText) {
+                if (element.referenceText === undefined) {
                     throw new Error("Null or undefined referenceText in getTreeItem()");
                 }
                 if (element.referenceType === undefined) {

--- a/Extension/src/LanguageServer/referencesTreeDataProvider.ts
+++ b/Extension/src/LanguageServer/referencesTreeDataProvider.ts
@@ -76,13 +76,13 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
 
     getTreeItem(element: TreeNode): vscode.TreeItem {
         if (this.referencesModel === undefined) {
-            throw new Error("Null or undefined RefrencesModel in getTreeItem()");
+            throw new Error("Undefined RefrencesModel in getTreeItem()");
         }
 
         switch (element.node) {
             case NodeType.referenceType:
-                if (!element.referenceType) {
-                    throw new Error("Null or undefined referenceType in getTreeItem()");
+                if (element.referenceType === undefined) {
+                    throw new Error("Undefined referenceType in getTreeItem()");
                 }
                 const label: string = getReferenceTagString(element.referenceType, this.referencesModel.isCanceled, true);
                 let resultRefType: vscode.TreeItem = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
@@ -93,8 +93,8 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
 
             case NodeType.file:
             case NodeType.fileWithPendingRef:
-                if (!element.fileUri) {
-                    throw new Error("Null or undefined fileUri in getTreeItem()");
+                if (element.fileUri === undefined) {
+                    throw new Error("Undefined fileUri in getTreeItem()");
                 }
                 let resultFile: vscode.TreeItem = new vscode.TreeItem(element.fileUri);
                 resultFile.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
@@ -119,10 +119,10 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
 
             case NodeType.reference:
                 if (element.referenceText === undefined) {
-                    throw new Error("Null or undefined referenceText in getTreeItem()");
+                    throw new Error("Undefined referenceText in getTreeItem()");
                 }
                 if (element.referenceType === undefined) {
-                    throw new Error("Null or undefined referenceType in getTreeItem()");
+                    throw new Error("Undefined referenceType in getTreeItem()");
                 }
                 let resultRef: vscode.TreeItem = new vscode.TreeItem(element.referenceText, vscode.TreeItemCollapsibleState.None);
                 resultRef.iconPath = getReferenceItemIconPath(element.referenceType, this.referencesModel.isCanceled);

--- a/Extension/src/LanguageServer/referencesTreeDataProvider.ts
+++ b/Extension/src/LanguageServer/referencesTreeDataProvider.ts
@@ -75,7 +75,7 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
     }
 
     getTreeItem(element: TreeNode): vscode.TreeItem {
-        if (!this.referencesModel) {
+        if (this.referencesModel === undefined) {
             throw new Error("Null or undefined RefrencesModel in getTreeItem()");
         }
 
@@ -121,7 +121,7 @@ export class ReferencesTreeDataProvider implements vscode.TreeDataProvider<TreeN
                 if (!element.referenceText) {
                     throw new Error("Null or undefined referenceText in getTreeItem()");
                 }
-                if (!element.referenceType) {
+                if (element.referenceType === undefined) {
                     throw new Error("Null or undefined referenceType in getTreeItem()");
                 }
                 let resultRef: vscode.TreeItem = new vscode.TreeItem(element.referenceText, vscode.TreeItemCollapsibleState.None);

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -174,7 +174,7 @@ export function getVcpkgPathDescriptorFile(): string {
 
 let vcpkgRoot: string;
 export function getVcpkgRoot(): string {
-    if (!vcpkgRoot && vcpkgRoot !== "") {
+    if (!vcpkgRoot) {
         vcpkgRoot = "";
         // Check for vcpkg instance.
         if (fs.existsSync(getVcpkgPathDescriptorFile())) {


### PR DESCRIPTION
For enum values, the "!" operator will indicate true for enum values that are 0, in additional to null or undefined.

Switch checks to use `=== undefined` instead.
