### PR TITLE
Fix some settings so they are editable in settings UI

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -483,11 +483,8 @@
           "scope": "resource"
         },
         "C_Cpp.default.enableConfigurationSquiggles": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
+          "type": "boolean",
+          "default": false,
           "description": "%c_cpp.configuration.default.enableConfigurationSquiggles.description%",
           "scope": "resource"
         },

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -184,20 +184,12 @@
           "maximum": 1
         },
         "C_Cpp.inactiveRegionForegroundColor": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
+          "type": "string",
           "description": "%c_cpp.configuration.inactiveRegionForegroundColor.description%",
           "scope": "resource"
         },
         "C_Cpp.inactiveRegionBackgroundColor": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
+          "type": "string",
           "description": "%c_cpp.configuration.inactiveRegionBackgroundColor.description%",
           "scope": "resource"
         },

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -476,7 +476,7 @@
         },
         "C_Cpp.default.enableConfigurationSquiggles": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%c_cpp.configuration.default.enableConfigurationSquiggles.description%",
           "scope": "resource"
         },

--- a/Extension/src/LanguageServer/colorization.ts
+++ b/Extension/src/LanguageServer/colorization.ts
@@ -386,10 +386,18 @@ export class ColorizationState {
         if (settings.dimInactiveRegions) {
             let opacity: number | undefined = settings.inactiveRegionOpacity;
             if (opacity !== null && opacity !== undefined) {
+                let backgroundColor: string | undefined = settings.inactiveRegionBackgroundColor;
+                if (backgroundColor === "") {
+                    backgroundColor = undefined;
+                }
+                let color: string | undefined = settings.inactiveRegionForegroundColor;
+                if (color === "") {
+                    color = undefined;
+                }
                 this.inactiveDecoration = vscode.window.createTextEditorDecorationType({
                     opacity: opacity.toString(),
-                    backgroundColor: settings.inactiveRegionBackgroundColor,
-                    color: settings.inactiveRegionForegroundColor,
+                    backgroundColor: backgroundColor,
+                    color: color,
                     rangeBehavior: vscode.DecorationRangeBehavior.OpenOpen
                 });
             }


### PR DESCRIPTION
Fix some settings so they are editable in settings UI

Fixes the definitions of the following settings, such that they can be edited using the settings UI in VS Code.
* C_Cpp.default.enableConfigurationSquiggles
* C_Cpp.inactiveRegionForegroundColor
* C_Cpp.inactiveRegionBackgroundColor
