### PR TITLE
Fix workspace folder settings being incorrect.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1078,13 +1078,14 @@ export class DefaultClient implements Client {
             let settings: CppSettings[] = [];
             let otherSettings: OtherSettings[] = [];
 
-            settings.push(workspaceSettings);
-            otherSettings.push(workspaceOtherSettings);
             if (vscode.workspace.workspaceFolders) {
                 for (let workspaceFolder of vscode.workspace.workspaceFolders) {
                     settings.push(new CppSettings(workspaceFolder.uri));
                     otherSettings.push(new OtherSettings(workspaceFolder.uri));
                 }
+            } else {
+                settings.push(workspaceSettings);
+                otherSettings.push(workspaceOtherSettings);
             }
 
             for (let setting of settings) {


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/5134 .

This needs to get released ASAP, since it can cause major breakage in the workspace scenario (even with a single root folder).
