### PR TITLE
Add cleanUnusedBinaries stage

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -16,7 +16,7 @@ import * as nls from 'vscode-nls';
 import { CppToolsApi, CppToolsExtension } from 'vscode-cpptools';
 import { getTemporaryCommandRegistrarInstance, initializeTemporaryCommandRegistrar } from './commands';
 import { PlatformInformation } from './platform';
-import { PackageManager, PackageManagerError, IPackage } from './packageManager';
+import { PackageManager, PackageManagerError, IPackage, VersionsMatch, ArchitecturesMatch, PlatformsMatch } from './packageManager';
 import { getInstallationInformation, InstallationInformation, setInstallationStage, setInstallationType, InstallationType } from './installationInformation';
 import { Logger, getOutputChannelLogger, showOutputChannel } from './logger';
 import { CppTools1, NullCppTools } from './cppTools1';
@@ -103,6 +103,9 @@ async function offlineInstallation(): Promise<void> {
     setInstallationType(InstallationType.Offline);
     const info: PlatformInformation = await PlatformInformation.GetPlatformInformation();
 
+    setInstallationStage('cleanUpUnusedBinaries');
+    await cleanUpUnusedBinaries(info);
+
     setInstallationStage('makeBinariesExecutable');
     await makeBinariesExecutable();
 
@@ -168,14 +171,39 @@ function makeBinariesExecutable(): Promise<void> {
     return util.allowExecution(util.getDebugAdaptersPath("OpenDebugAD7"));
 }
 
+function packageMatchesPlatform(pkg: IPackage, info: PlatformInformation): boolean {
+    return PlatformsMatch(pkg, info) &&
+           (pkg.architectures === undefined || ArchitecturesMatch(pkg, info)) &&
+           VersionsMatch(pkg, info);
+}
+
 function makeOfflineBinariesExecutable(info: PlatformInformation): Promise<void> {
     let promises: Thenable<void>[] = [];
     let packages: IPackage[] = util.packageJson["runtimeDependencies"];
     packages.forEach(p => {
         if (p.binaries && p.binaries.length > 0 &&
-            p.platforms.findIndex(plat => plat === info.platform) !== -1 &&
-            (p.architectures === undefined || p.architectures.findIndex(arch => arch === info.architecture) !== - 1)) {
+            packageMatchesPlatform(p, info)) {
             p.binaries.forEach(binary => promises.push(util.allowExecution(util.getExtensionFilePath(binary))));
+        }
+    });
+    return Promise.all(promises).then(() => { });
+}
+
+function cleanUpUnusedBinaries(info: PlatformInformation): Promise<void> {
+    let promises: Thenable<void>[] = [];
+    let packages: IPackage[] = util.packageJson["runtimeDependencies"];
+    const logger: Logger = getOutputChannelLogger();
+
+    packages.forEach(p => {
+        if (p.binaries && p.binaries.length > 0 &&
+            !packageMatchesPlatform(p, info)) {
+            p.binaries.forEach(binary => {
+                const path: string = util.getExtensionFilePath(binary);
+                if (fs.existsSync(path)) {
+                    logger.appendLine(`deleting: ${path}`);
+                    promises.push(util.deleteFile(path));
+                }
+            });
         }
     });
     return Promise.all(promises).then(() => { });

--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -153,41 +153,11 @@ export class PackageManager {
         return this.GetPackageList()
             .then((list) =>
                 list.filter((value, index, array) =>
-                    this.ArchitecturesMatch(value) &&
-                        this.PlatformsMatch(value) &&
-                        this.VersionsMatch(value)
+                    ArchitecturesMatch(value, this.platformInfo) &&
+                        PlatformsMatch(value, this.platformInfo) &&
+                        VersionsMatch(value, this.platformInfo)
                 )
             );
-    }
-
-    private ArchitecturesMatch(value: IPackage): boolean {
-        return !value.architectures || (this.platformInfo.architecture !== undefined && value.architectures.indexOf(this.platformInfo.architecture) !== -1);
-    }
-
-    private PlatformsMatch(value: IPackage): boolean {
-        return !value.platforms || value.platforms.indexOf(this.platformInfo.platform) !== -1;
-    }
-
-    private VersionsMatch(value: IPackage): boolean {
-        if (value.versionRegex) {
-            // If we have a versionRegex but did not get a platformVersion
-            if (!this.platformInfo.version) {
-                // If we are expecting to match the versionRegex, return false since there was no version found.
-                //
-                // If we are expecting to not match the versionRegex, return true since we are expecting to
-                // not match the version string, the only match would be if versionRegex was not set.
-                return !value.matchVersion;
-            }
-            const regex: RegExp = new RegExp(value.versionRegex);
-
-            return (value.matchVersion ?
-                regex.test(this.platformInfo.version) :
-                !regex.test(this.platformInfo.version)
-            );
-        }
-
-        // No versionRegex provided.
-        return true;
     }
 
     private async DownloadPackage(pkg: IPackage, progressCount: string, progress: vscode.Progress<{message?: string; increment?: number}>): Promise<void> {
@@ -466,4 +436,34 @@ export class PackageManager {
             this.outputChannel.appendLine(text);
         }
     }
+}
+
+export function VersionsMatch(pkg: IPackage, info: PlatformInformation): boolean {
+    if (pkg.versionRegex) {
+        // If we have a versionRegex but did not get a platformVersion
+        if (!info.version) {
+            // If we are expecting to match the versionRegex, return false since there was no version found.
+            //
+            // If we are expecting to not match the versionRegex, return true since we are expecting to
+            // not match the version string, the only match would be if versionRegex was not set.
+            return !pkg.matchVersion;
+        }
+        const regex: RegExp = new RegExp(pkg.versionRegex);
+
+        return (pkg.matchVersion ?
+            regex.test(info.version) :
+            !regex.test(info.version)
+        );
+    }
+
+    // No versionRegex provided.
+    return true;
+}
+
+export function ArchitecturesMatch(value: IPackage, info: PlatformInformation): boolean {
+    return !value.architectures || (info.architecture !== undefined && value.architectures.indexOf(info.architecture) !== -1);
+}
+
+export function PlatformsMatch(value: IPackage, info: PlatformInformation): boolean {
+    return !value.platforms || value.platforms.indexOf(info.platform) !== -1;
 }


### PR DESCRIPTION
Our offline installer will include two versions of lldb.
./debugAdapters/lldb is lldb-mi 3.8 and is used for High-Sierra and older
./debugAdapters/lldb-mi is lldb-mi 10.x and is used for Mojave and
higher.

This clean up the folder that is unused. 

Refactored package platform checks to be unified in one area. 