### PR TITLE
Fix database when no folder is open.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -595,7 +595,7 @@ export class DefaultClient implements Client {
         }
 
         if (!storagePath) {
-            storagePath = path.join(this.RootPath, "/.vscode");
+            storagePath = this.RootPath ? path.join(this.RootPath, "/.vscode") : "";
         }
         if (workspaceFolder && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 1) {
             storagePath = path.join(storagePath, util.getUniqueWorkspaceStorageName(workspaceFolder));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/5176 . The language server side expects an empty storage path for the no workspace folder case.