### PR TITLE
Update engine version to match vscode/types

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -12,7 +12,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.43.0"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-cpptools/issues",


### PR DESCRIPTION
It looks like a mismatch between the engine version and vscode/types will cause an error when building a vsix. Updating engine to match.

I believe the feature (refactor preview) was released in 1.42, but I had to update the types due to something that was missing there until 1.43.
