### PR TITLE
Update for 3 assets (no more 32-bit Linux)

### DIFF
--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -56,12 +56,12 @@ function isAsset(input: any): input is Asset {
 
 /**
  * Determine whether an object is of type Build. Note that earlier releases of the extension
- * do not have 4 or greater Assets (Mac, Win, Linux 32/64). Only call this on more recent Builds.
+ * do not have 3 or greater Assets (Mac, Win, Linux). Only call this on more recent Builds.
  * @param input Incoming object.
  * @return Whether input is of type Build.
  */
 function isBuild(input: any): input is Build {
-    return input && input.name && typeof(input.name) === "string" && isArrayOfAssets(input.assets) && input.assets.length >= 4;
+    return input && input.name && typeof(input.name) === "string" && isArrayOfAssets(input.assets) && input.assets.length >= 3;
 }
 
 /**

--- a/Extension/test/unitTests/updowngrade.test.ts
+++ b/Extension/test/unitTests/updowngrade.test.ts
@@ -11,9 +11,8 @@ suite("UpgradeDowngrade", () => {
 
     const asset_win32: Asset = {name: "cpptools-win32.vsix", browser_download_url: "https://github.com/microsoft/vscode-cpptools/releases/download/0.27.0/cpptools-win32.vsix"};
     const asset_linux: Asset = {name: "cpptools-linux.vsix", browser_download_url: "https://github.com/microsoft/vscode-cpptools/releases/download/0.27.0/cpptools-linux.vsix"};
-    const asset_linux32: Asset = {name: "cpptools-linux32.vsix", browser_download_url: "https://github.com/microsoft/vscode-cpptools/releases/download/0.27.0/cpptools-linux32.vsix"};
     const asset_osx: Asset = {name: "cpptools-osx.vsix", browser_download_url: "https://github.com/microsoft/vscode-cpptools/releases/download/0.27.0/cpptools-osx.vsix"};
-    const four_assets: Asset[] = [asset_win32, asset_linux, asset_linux32, asset_osx];
+    const three_assets: Asset[] = [asset_win32, asset_linux, asset_osx];
 
     const release1: string = "0.27.1";
     const insider3: string = "0.27.1-insiders3";
@@ -27,9 +26,9 @@ suite("UpgradeDowngrade", () => {
             test("Insiders to Release", () => {
                 const builds: Build[] = [{
                     name: insider3, assets: []}, {
-                    name: insider2, assets: four_assets}, {
-                    name: insider1, assets: four_assets}, {
-                    name: release0, assets: four_assets}];
+                    name: insider2, assets: three_assets}, {
+                    name: insider1, assets: three_assets}, {
+                    name: release0, assets: three_assets}];
 
                 const userVersion: PackageVersion = new PackageVersion(insider2);
                 const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -44,7 +43,7 @@ suite("UpgradeDowngrade", () => {
             suite("Internal Testing, no Downgrade", () => {
                 test("Insider to Release", () => {
                     const builds: Build[] = [{
-                        name: release0, assets: four_assets}];
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider1);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -52,9 +51,9 @@ suite("UpgradeDowngrade", () => {
                 });
                 test("Insider to Insider", () => {
                     const builds: Build[] = [{
-                        name: insider2, assets: four_assets}, {
-                        name: insider1, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider2, assets: three_assets}, {
+                        name: insider1, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider3);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -62,10 +61,10 @@ suite("UpgradeDowngrade", () => {
                 });
                 test("Release to Insider", () => {
                     const builds: Build[] = [{
-                        name: insider3, assets: four_assets}, {
-                        name: insider2, assets: four_assets}, {
-                        name: insider1, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider3, assets: three_assets}, {
+                        name: insider2, assets: three_assets}, {
+                        name: insider1, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(release1);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -79,7 +78,7 @@ suite("UpgradeDowngrade", () => {
                         name: insider3, assets: []}, {
                         name: insider2, assets: []}, {
                         name: insider1, assets: []}, {
-                        name: release0, assets: four_assets}];
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider3);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -89,8 +88,8 @@ suite("UpgradeDowngrade", () => {
                     const builds: Build[] = [{
                         name: insider3, assets: []}, {
                         name: insider2, assets: []}, {
-                        name: insider1, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider1, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider3);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -103,9 +102,9 @@ suite("UpgradeDowngrade", () => {
             suite("Automatic Upgrade", () => {
                 test("Release to Release", () => {
                     const builds: Build[] = [{
-                        name: release1, assets: four_assets}, {
-                        name: insider3, assets: four_assets}, {
-                        name: insider2, assets: four_assets}];
+                        name: release1, assets: three_assets}, {
+                        name: insider3, assets: three_assets}, {
+                        name: insider2, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(release0);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -113,9 +112,9 @@ suite("UpgradeDowngrade", () => {
                 });
                 test("Insider to Release", () => {
                     const builds: Build[] = [{
-                        name: release1, assets: four_assets}, {
-                        name: insider3, assets: four_assets}, {
-                        name: insider2, assets: four_assets}];
+                        name: release1, assets: three_assets}, {
+                        name: insider3, assets: three_assets}, {
+                        name: insider2, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider2);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -127,8 +126,8 @@ suite("UpgradeDowngrade", () => {
                 test("Release to Insider, Upgrade", () => {
                     const builds: Build[] = [{
                         name: insider2, assets: []}, {
-                        name: insider1, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider1, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(release0);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -138,7 +137,7 @@ suite("UpgradeDowngrade", () => {
                     const builds: Build[] = [{
                         name: insider2, assets: []}, {
                         name: insider1, assets: []}, {
-                        name: release0, assets: four_assets}];
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(release0);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -147,9 +146,9 @@ suite("UpgradeDowngrade", () => {
                 test("Insider to Insider, Upgrade", () => {
                     const builds: Build[] = [{
                         name: insider3, assets: []}, {
-                        name: insider2, assets: four_assets}, {
-                        name: insider1, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider2, assets: three_assets}, {
+                        name: insider1, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider1);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);
@@ -158,8 +157,8 @@ suite("UpgradeDowngrade", () => {
                 test("Insider to Insider, no Upgrade", () => {
                     const builds: Build[] = [{
                         name: insider3, assets: []}, {
-                        name: insider2, assets: four_assets}, {
-                        name: release0, assets: four_assets}];
+                        name: insider2, assets: three_assets}, {
+                        name: release0, assets: three_assets}];
 
                     const userVersion: PackageVersion = new PackageVersion(insider2);
                     const targetBuild: Build | undefined = getTargetBuild(builds, userVersion, updateChannel);


### PR DESCRIPTION
0.27.0 users won’t auto-update to 0.28.0-insiders without 4 assets, but we could fix that temporarily by adding a bogus 4th asset until we ship 0.28.0 with this change that checks for 3 or more assets.

32-bit Linux will get a failure when there's not cpptools-linux32.vsix in the assets, but when I tried it out the failure appears to be silent, so that seems okay.