### PR TITLE
Disable Insiders updates for unsupported cases.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 0.27.1: April 27, 2020
+### Bug Fix
+* Disable Insiders `updateChannel` for 32-bit Linux and VS Code older than 1.43.0.
+
 ## Version 0.27.0: March 30, 2020
 ### Enhancements
 * Improved multi-root implementation with a single language server process and database for the entire workspace (shared between workspace folders). Fixes most [multi-root bugs](https://github.com/microsoft/vscode-cpptools/issues?q=is%3Aopen+is%3Aissue+label%3A%22Feature%3A+Multiroot%22+label%3A%22fixed+%28release+pending%29%22+milestone%3A0.27.0).

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Version 0.27.1: April 27, 2020
+## Version 0.27.1: April 28, 2020
 ### Bug Fix
 * Disable Insiders `updateChannel` for 32-bit Linux and VS Code older than 1.43.0.
 

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "publisher": "ms-vscode",
   "preview": true,
   "icon": "LanguageCCPP_color_128x.png",

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -462,22 +462,22 @@ function realActivation(): void {
 
     vcpkgDbPromise = initVcpkgDatabase();
 
-	PlatformInformation.GetPlatformInformation().then(info => {
-		// Skip Insiders processing for 32-bit Linux.
-		if (info.platform !== "linux" || info.architecture === "x86_64") {
-			// Skip Insiders processing for VS Code newer than 1.42.1.
-			// TODO: Change this to not require the hardcoded version to be updated.
-			let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
-			let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
-			if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
-				if (settings.updateChannel === 'Default') {
-					suggestInsidersChannel();
-				} else if (settings.updateChannel === 'Insiders') {
-					checkAndApplyUpdate(settings.updateChannel);
-				}
-			}
-		}
-	});
+    PlatformInformation.GetPlatformInformation().then(info => {
+        // Skip Insiders processing for 32-bit Linux.
+        if (info.platform !== "linux" || info.architecture === "x86_64") {
+            // Skip Insiders processing for VS Code newer than 1.42.1.
+            // TODO: Change this to not require the hardcoded version to be updated.
+            let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
+            let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
+            if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
+                if (settings.updateChannel === 'Default') {
+                    suggestInsidersChannel();
+                } else if (settings.updateChannel === 'Insiders') {
+                    checkAndApplyUpdate(settings.updateChannel);
+                }
+            }
+        }
+    });
 
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json
     class SchemaProvider implements vscode.TextDocumentContentProvider {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -462,23 +462,22 @@ function realActivation(): void {
 
     vcpkgDbPromise = initVcpkgDatabase();
 
-    if (settings.updateChannel === 'Default') {
-        suggestInsidersChannel();
-    } else if (settings.updateChannel === 'Insiders') {
-		PlatformInformation.GetPlatformInformation().then(info => {
-			// Skip Insiders updates for 32-bit Linux.
-			if (info.platform !== "linux" || info.architecture === "x86_64") {
-				// Skip Insiders updates for VS Code newer than 1.42.1.
-				// TODO: Change this to not require the hardcoded version to be updated.
-				let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
-				let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
-				if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
-					insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval, settings.updateChannel);
+	PlatformInformation.GetPlatformInformation().then(info => {
+		// Skip Insiders processing for 32-bit Linux.
+		if (info.platform !== "linux" || info.architecture === "x86_64") {
+			// Skip Insiders processing for VS Code newer than 1.42.1.
+			// TODO: Change this to not require the hardcoded version to be updated.
+			let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
+			let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
+			if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
+    			if (settings.updateChannel === 'Default') {
+        			suggestInsidersChannel();
+				} else if (settings.updateChannel === 'Insiders') {
 					checkAndApplyUpdate(settings.updateChannel);
 				}
 			}
-		});
-    }
+		}
+	});
 
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json
     class SchemaProvider implements vscode.TextDocumentContentProvider {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -41,11 +41,12 @@ let ui: UI;
 let disposables: vscode.Disposable[] = [];
 let languageConfigurations: vscode.Disposable[] = [];
 let intervalTimer: NodeJS.Timer;
+let insiderUpdateEnabled: boolean = false;
 let insiderUpdateTimer: NodeJS.Timer;
+const insiderUpdateTimerInterval: number = 1000 * 60 * 60;
 let realActivationOccurred: boolean = false;
 let tempCommands: vscode.Disposable[] = [];
 let activatedPreviously: PersistentWorkspaceState<boolean>;
-const insiderUpdateTimerInterval: number = 1000 * 60 * 60;
 let buildInfoCache: BuildInfo | undefined;
 const taskSourceStr: string = "C/C++";
 const cppInstallVsixStr: string = 'C/C++: Install vsix -- ';
@@ -470,9 +471,11 @@ function realActivation(): void {
             let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
             let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
             if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
+                insiderUpdateEnabled = true;
                 if (settings.updateChannel === 'Default') {
                     suggestInsidersChannel();
                 } else if (settings.updateChannel === 'Insiders') {
+                    insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval, settings.updateChannel);
                     checkAndApplyUpdate(settings.updateChannel);
                 }
             }
@@ -521,15 +524,17 @@ function onDidChangeSettings(event: vscode.ConfigurationChangeEvent): void {
         }
     });
 
-    const newUpdateChannel: string = changedActiveClientSettings['updateChannel'];
-    if (newUpdateChannel) {
-        if (newUpdateChannel === 'Default') {
-            clearInterval(insiderUpdateTimer);
-        } else if (newUpdateChannel === 'Insiders') {
-            insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval);
-        }
+    if (insiderUpdateEnabled) {
+        const newUpdateChannel: string = changedActiveClientSettings['updateChannel'];
+        if (newUpdateChannel) {
+            if (newUpdateChannel === 'Default') {
+                clearInterval(insiderUpdateTimer);
+            } else if (newUpdateChannel === 'Insiders') {
+                insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval);
+            }
 
-        checkAndApplyUpdate(newUpdateChannel);
+            checkAndApplyUpdate(newUpdateChannel);
+        }
     }
 }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -470,8 +470,8 @@ function realActivation(): void {
 			let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
 			let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
 			if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
-    			if (settings.updateChannel === 'Default') {
-        			suggestInsidersChannel();
+				if (settings.updateChannel === 'Default') {
+					suggestInsidersChannel();
 				} else if (settings.updateChannel === 'Insiders') {
 					checkAndApplyUpdate(settings.updateChannel);
 				}

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -465,8 +465,19 @@ function realActivation(): void {
     if (settings.updateChannel === 'Default') {
         suggestInsidersChannel();
     } else if (settings.updateChannel === 'Insiders') {
-        insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval, settings.updateChannel);
-        checkAndApplyUpdate(settings.updateChannel);
+		PlatformInformation.GetPlatformInformation().then(info => {
+			// Skip Insiders updates for 32-bit Linux.
+			if (info.platform !== "linux" || info.architecture === "x86_64") {
+				// Skip Insiders updates for VS Code newer than 1.42.1.
+				// TODO: Change this to not require the hardcoded version to be updated.
+				let vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
+				let minimumSupportedVersionForInsidersUpgrades: PackageVersion = new PackageVersion("1.42.1");
+				if (vscodeVersion.isGreaterThan(minimumSupportedVersionForInsidersUpgrades, "insider")) {
+					insiderUpdateTimer = global.setInterval(checkAndApplyUpdate, insiderUpdateTimerInterval, settings.updateChannel);
+					checkAndApplyUpdate(settings.updateChannel);
+				}
+			}
+		});
     }
 
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json


### PR DESCRIPTION
Partial fix for https://github.com/microsoft/vscode-cpptools/issues/4873 .