### PR TITLE
Change C_Cpp.clang_format_path to be scope machine-overridable

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -84,13 +84,13 @@
           "type": "string",
           "default": "file",
           "description": "%c_cpp.configuration.clang_format_style.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.clang_format_fallbackStyle": {
           "type": "string",
           "default": "Visual Studio",
           "description": "%c_cpp.configuration.clang_format_fallbackStyle.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.clang_format_sortIncludes": {
           "type": [

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -78,7 +78,7 @@
         "C_Cpp.clang_format_path": {
           "type": "string",
           "description": "%c_cpp.configuration.clang_format_path.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.clang_format_style": {
           "type": "string",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -241,7 +241,7 @@
           ],
           "default": "Forward Slash",
           "description": "%c_cpp.configuration.preferredPathSeparator.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.commentContinuationPatterns": {
           "type": "array",
@@ -285,13 +285,13 @@
         "C_Cpp.intelliSenseCachePath": {
           "type": "string",
           "description": "%c_cpp.configuration.intelliSenseCachePath.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.intelliSenseCacheSize": {
           "type": "number",
           "default": 5120,
           "description": "%c_cpp.configuration.intelliSenseCacheSize.description%",
-          "scope": "resource",
+          "scope": "machine-overridable",
           "minimum": 0
         },
         "C_Cpp.default.includePath": {
@@ -304,7 +304,7 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.includePath.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.defines": {
           "type": [
@@ -316,7 +316,7 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.defines.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.macFrameworkPath": {
           "type": [
@@ -328,18 +328,18 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.macFrameworkPath.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.windowsSdkVersion": {
           "type": "string",
           "description": "%c_cpp.configuration.default.windowsSdkVersion.description%",
           "pattern": "^((\\d{2}\\.\\d{1}\\.\\d{5}\\.\\d{1}$|^8\\.1)|())$",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.compileCommands": {
           "type": "string",
           "description": "%c_cpp.configuration.default.compileCommands.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.forcedInclude": {
           "type": [
@@ -351,7 +351,7 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.forcedInclude.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.intelliSenseMode": {
           "type": "string",
@@ -365,7 +365,7 @@
             "clang-x86"
           ],
           "description": "%c_cpp.configuration.default.intelliSenseMode.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.compilerPath": {
           "type": [
@@ -386,7 +386,7 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.compilerArgs.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.cStandard": {
           "type": "string",
@@ -402,7 +402,7 @@
             "gnu18"
           ],
           "description": "%c_cpp.configuration.default.cStandard.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.cppStandard": {
           "type": "string",
@@ -422,7 +422,7 @@
             "gnu++20"
           ],
           "description": "%c_cpp.configuration.default.cppStandard.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.configurationProvider": {
           "type": "string",
@@ -439,12 +439,12 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.browse.path.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.browse.databaseFilename": {
           "type": "string",
           "description": "%c_cpp.configuration.default.browse.databaseFilename.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": {
           "type": "boolean",
@@ -462,7 +462,7 @@
           },
           "default": null,
           "description": "%c_cpp.configuration.default.systemIncludePath.description%",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "C_Cpp.default.enableConfigurationSquiggles": {
           "type": "boolean",


### PR DESCRIPTION

bug fix: https://github.com/microsoft/vscode-cpptools/issues/4121