### PR TITLE
Delete temporary VSIX created during installation

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -823,7 +823,7 @@ async function applyUpdate(buildInfo: BuildInfo): Promise<void> {
     }
 
     // Delete temp VSIX file
-    if (!tempVSIX) {
+    if (tempVSIX) {
         tempVSIX.removeCallback();
     }
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -770,15 +770,10 @@ async function suggestInsidersChannel(): Promise<void> {
 }
 
 async function applyUpdate(buildInfo: BuildInfo): Promise<void> {
-    const tempVSIX: any = await util.CreateTempFileWithPostfix('.vsix').catch(error => {
-        if (error.message.indexOf('/') !== -1 || error.message.indexOf('\\') !== -1) {
-            error.message = "Potential PII hidden";
-        }
-        telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
-        return;
-    });
-
+    let tempVSIX: any;
     try {
+        tempVSIX = await util.createTempFileWithPostfix('.vsix');
+
         // Try to download VSIX
         let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
         let originalProxySupport: string | undefined = config.inspect<string>('http.proxySupport')?.globalValue;
@@ -828,7 +823,9 @@ async function applyUpdate(buildInfo: BuildInfo): Promise<void> {
     }
 
     // Delete temp VSIX file
-    tempVSIX.removeCallback();
+    if (!tempVSIX) {
+        tempVSIX.removeCallback();
+    }
 }
 
 /**

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -21,7 +21,6 @@ import { getCustomConfigProviders } from './customProviders';
 import { PlatformInformation } from '../platform';
 import { Range } from 'vscode-languageclient';
 import { ChildProcess, spawn, execSync } from 'child_process';
-import * as tmp from 'tmp';
 import { getTargetBuildInfo, BuildInfo } from '../githubAPI';
 import * as configs from './configurations';
 import { PackageVersion } from '../packageVersion';
@@ -771,11 +770,13 @@ async function suggestInsidersChannel(): Promise<void> {
 }
 
 async function applyUpdate(buildInfo: BuildInfo): Promise<void> {
-    const tempVSIX: tmp.FileResult = await util.CreateTempFileWithPostfix('.vsix');
-    if (!tempVSIX) {
-        telemetry.logLanguageServerEvent('installVsix', { 'error': 'Failed to create VSIX file.', 'success': 'false' });
+    const tempVSIX: any = await util.CreateTempFileWithPostfix('.vsix').catch(error => {
+        if (error.message.indexOf('/') !== -1 || error.message.indexOf('\\') !== -1) {
+            error.message = "Potential PII hidden";
+        }
+        telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
         return;
-    }
+    });
 
     try {
         // Try to download VSIX

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -770,64 +770,64 @@ async function suggestInsidersChannel(): Promise<void> {
     }
 }
 
-function applyUpdate(buildInfo: BuildInfo): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        tmp.file({postfix: '.vsix'}, async (err, vsixPath, fd, cleanupCallback) => {
-            if (err) {
-                reject(new Error('Failed to create vsix file'));
-                return;
-            }
+async function applyUpdate(buildInfo: BuildInfo): Promise<void> {
+    const tempVSIX: tmp.FileResult = await util.CreateTempFileWithPostfix('.vsix');
+    if (!tempVSIX) {
+        telemetry.logLanguageServerEvent('installVsix', { 'error': 'Failed to create VSIX file.', 'success': 'false' });
+        return;
+    }
 
-            // Place in try/catch as the .catch call catches a rejection in downloadFileToDestination
-            // then the .catch call will return a resolved promise
-            // Thusly, the .catch call must also throw, as a return would simply return an unused promise
-            // instead of returning early from this function scope
-            let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-            let originalProxySupport: string | undefined = config.inspect<string>('http.proxySupport')?.globalValue;
-            while (true) { // Might need to try again with a different http.proxySupport setting.
-                try {
-                    await util.downloadFileToDestination(buildInfo.downloadUrl, vsixPath);
-                } catch {
-                    // Try again with the proxySupport to "off".
-                    if (originalProxySupport !== config.inspect<string>('http.proxySupport')?.globalValue) {
-                        config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
-                        reject(new Error('Failed to download VSIX package with proxySupport off')); // Changing the proxySupport didn't help.
-                        return;
-                    }
-                    if (config.get('http.proxySupport') !== "off" && originalProxySupport !== "off") {
-                        config.update('http.proxySupport', "off", true);
-                        continue;
-                    }
-                    reject(new Error('Failed to download VSIX package'));
-                    return;
-                }
+    try {
+        // Try to download VSIX
+        let config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+        let originalProxySupport: string | undefined = config.inspect<string>('http.proxySupport')?.globalValue;
+        while (true) { // Might need to try again with a different http.proxySupport setting.
+            try {
+                await util.downloadFileToDestination(buildInfo.downloadUrl, tempVSIX.name);
+            } catch {
+                // Try again with the proxySupport to "off".
                 if (originalProxySupport !== config.inspect<string>('http.proxySupport')?.globalValue) {
                     config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
-                    telemetry.logLanguageServerEvent('installVsix', { 'error': "Success with proxySupport off", 'success': 'true' });
+                    throw new Error('Failed to download VSIX package with proxySupport off'); // Changing the proxySupport didn't help.
                 }
-                break;
+                if (config.get('http.proxySupport') !== "off" && originalProxySupport !== "off") {
+                    config.update('http.proxySupport', "off", true);
+                    continue;
+                }
+                throw new Error('Failed to download VSIX package');
             }
-            try {
-                await installVsix(vsixPath);
-            } catch (error) {
-                reject(error);
-                return;
+            if (originalProxySupport !== config.inspect<string>('http.proxySupport')?.globalValue) {
+                config.update('http.proxySupport', originalProxySupport, true); // Reset the http.proxySupport.
+                telemetry.logLanguageServerEvent('installVsix', { 'error': "Success with proxySupport off", 'success': 'true' });
             }
-            clearInterval(insiderUpdateTimer);
-            const message: string = localize("extension.updated",
-                "The C/C++ Extension has been updated to version {0}. Please reload the window for the changes to take effect.",
-                buildInfo.name);
-            util.promptReloadWindow(message);
-            telemetry.logLanguageServerEvent('installVsix', { 'success': 'true' });
-            resolve();
-        });
-    }).catch(error => {
+            break;
+        }
+
+        // Install VSIX
+        try {
+            await installVsix(tempVSIX.name);
+        } catch (error) {
+            throw new Error('Failed to install VSIX package');
+        }
+
+        // Installation successful
+        clearInterval(insiderUpdateTimer);
+        const message: string = localize("extension.updated",
+            "The C/C++ Extension has been updated to version {0}. Please reload the window for the changes to take effect.",
+            buildInfo.name);
+        util.promptReloadWindow(message);
+        telemetry.logLanguageServerEvent('installVsix', { 'success': 'true' });
+
+    } catch (error) {
         console.error(`${cppInstallVsixStr}${error.message}`);
         if (error.message.indexOf('/') !== -1 || error.message.indexOf('\\') !== -1) {
             error.message = "Potential PII hidden";
         }
         telemetry.logLanguageServerEvent('installVsix', { 'error': error.message, 'success': 'false' });
-    });
+    }
+
+    // Delete temp VSIX file
+    tempVSIX.removeCallback();
 }
 
 /**

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -777,11 +777,11 @@ export function promptReloadWindow(message: string): void {
     });
 }
 
-export async function CreateTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
+export function CreateTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
     return new Promise<tmp.FileResult>((resolve, reject) => {
         tmp.file({ postfix: postfix }, (err, path, fd, cleanupCallback) => {
             if (err) {
-                return reject();
+                return reject(err);
             }
             return resolve(<tmp.FileResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
         });

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -15,6 +15,7 @@ import { PlatformInformation } from './platform';
 import { getOutputChannelLogger, showOutputChannel } from './logger';
 import * as assert from 'assert';
 import * as https from 'https';
+import * as tmp from 'tmp';
 import { ClientRequest, OutgoingHttpHeaders } from 'http';
 import { getBuildTasks } from './LanguageServer/extension';
 import { OtherSettings } from './LanguageServer/settings';
@@ -773,6 +774,17 @@ export function promptReloadWindow(message: string): void {
         if (value === reload) {
             vscode.commands.executeCommand("workbench.action.reloadWindow");
         }
+    });
+}
+
+export async function CreateTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
+    return new Promise<tmp.FileResult>((resolve, reject) => {
+        tmp.file({ postfix: postfix }, (err, path, fd, cleanupCallback) => {
+            if (err) {
+                return reject();
+            }
+            return resolve(<tmp.FileResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
+        });
     });
 }
 

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -777,7 +777,7 @@ export function promptReloadWindow(message: string): void {
     });
 }
 
-export function CreateTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
+export function createTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
     return new Promise<tmp.FileResult>((resolve, reject) => {
         tmp.file({ postfix: postfix }, (err, path, fd, cleanupCallback) => {
             if (err) {


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/3923

**Issue:**
The created temp file for the VSIX content does not get deleted after its use is no longer needed.

**Fix:**
Delete temporary VSIX file after downloading and installing operations completes or fails by calling `removeCallback()` on the temporary VSIX file `tmp.FileResult` object.