### PR TITLE
Add setting to enable/disable code folding provider

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -529,6 +529,16 @@
           "default": false,
           "description": "%c_cpp.configuration.debugger.useBacktickCommandSubstitution.description%",
           "scope": "window"
+        },
+        "C_Cpp.codeFolding": {
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "default": "Enabled",
+          "description": "%c_cpp.configuration.codeFolding.description%",
+          "scope": "resource"
         }
       }
     },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -64,6 +64,7 @@
     "c_cpp.configuration.experimentalFeatures.description": "Controls whether \"experimental\" features are usable.",
     "c_cpp.configuration.suggestSnippets.description": "If true, snippets are provided by the language server.",
     "c_cpp.configuration.enhancedColorization.description": "If enabled, code is colorized based on IntelliSense. This setting has no effect if IntelliSense is disabled or if using the Default High Contrast theme.",
+    "c_cpp.configuration.codeFolding.description": "If enabled, code folding ranges are provided by the language server.",
     "c_cpp.configuration.vcpkg.enabled.markdownDescription": "Enable integration services for the [vcpkg dependency manager](https://aka.ms/vcpkg/).",
     "c_cpp.configuration.renameRequiresIdentifier.description": "If true, 'Rename Symbol' will require a valid C/C++ identifier.",
     "c_cpp.configuration.debugger.useBacktickCommandSubstitution.description": "If true, debugger shell command substitution will use obsolete backtick (`)",

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -156,6 +156,7 @@ export class CppSettings extends Settings {
     public get defaultSystemIncludePath(): string[] | undefined { return super.Section.get<string[]>("default.systemIncludePath"); }
     public get defaultEnableConfigurationSquiggles(): boolean | undefined { return super.Section.get<boolean>("default.enableConfigurationSquiggles"); }
     public get useBacktickCommandSubstitution(): boolean | undefined { return super.Section.get<boolean>("debugger.useBacktickCommandSubstitution"); }
+    public get codeFolding(): boolean { return super.Section.get<string>("codeFolding") === "Enabled"; }
 
     public get enhancedColorization(): boolean {
         return super.Section.get<string>("enhancedColorization") === "Enabled"


### PR DESCRIPTION
Adds a setting.

The provide is disposed when disabled, which causes VS Code to fall back to its default behavior.

I moved the provider class to outside of the constructor.  I will move it to it's own file (as well as others) in a subsequent PR, after 0.28.0 ships and semantic token changes are in.
