### PR TITLE
Support Debug Welcome Panel

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -52,6 +52,13 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "debug",
+        "contents": "To learn more about launch.json, see [Configuring C/C++ debugging](https://code.visualstudio.com/docs/cpp/launch-json-reference).",
+        "when": "debugStartLanguage == cpp || debugStartLanguage == c"
+      }
+    ],
     "problemMatchers": [
       {
         "name": "gcc",
@@ -658,6 +665,10 @@
       {
         "type": "cppdbg",
         "label": "C++ (GDB/LLDB)",
+        "languages": [
+          "c",
+          "cpp"
+        ],
         "variables": {
           "pickProcess": "extension.pickNativeProcess",
           "pickRemoteProcess": "extension.pickRemoteNativeProcess"
@@ -1192,6 +1203,10 @@
       {
         "type": "cppvsdbg",
         "label": "C++ (Windows)",
+        "languages": [
+          "c",
+          "cpp"
+        ],
         "variables": {
           "pickProcess": "extension.pickNativeProcess"
         },

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -439,7 +439,9 @@ function rewriteManifest(): Promise<void> {
         "onCommand:C_Cpp.RescanWorkspace",
         "onCommand:C_Cpp.VcpkgClipboardInstallSuggested",
         "onCommand:C_Cpp.VcpkgClipboardOnlineHelpSuggested",
-        "onDebug",
+        "onDebugInitialConfigurations",
+        "onDebugResolve:cppdbg",
+        "onDebugResolve:cppvsdbg",
         "workspaceContains:/.vscode/c_cpp_properties.json",
         "onFileSystem:cpptools-schema"
     ];


### PR DESCRIPTION
This PR enables the Debug Welcome Panel for c/cpp languages.

This allows us to add content to the Debug Welcome Screen (no .vscode tasks or launch). at the moment I am just adding the C/C++ documentation. 
 
![image](https://user-images.githubusercontent.com/3953714/84554571-53a7cb00-accd-11ea-9353-cdebd74dd3ab.png)

Clicking on “Run and Debug” gives the “Run and Debug Active File” experience.
 
![image](https://user-images.githubusercontent.com/3953714/82083886-4207df00-969f-11ea-9916-19e4f0bd63cd.png)
![image](https://user-images.githubusercontent.com/3953714/82083891-459b6600-969f-11ea-80ac-a7153629d093.png)

Linked Issue: https://github.com/microsoft/vscode-cpptools/issues/4837
 


