### PR TITLE
Fix task bugs.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "0.28.1-master",
+  "version": "0.28.2-master",
   "publisher": "ms-vscode",
   "preview": true,
   "icon": "LanguageCCPP_color_128x.png",

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -105,7 +105,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
 	 * Returns a list of initial debug configurations based on contextual information, e.g. package.json or folder.
 	 */
     async provideDebugConfigurations(folder?: vscode.WorkspaceFolder, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-        let buildTasks: vscode.Task[] = await getBuildTasks(true);
+        let buildTasks: vscode.Task[] = await getBuildTasks(true, true);
         if (buildTasks.length === 0) {
             return Promise.resolve(this.provider.getInitialConfigurations(this.type));
         }
@@ -119,11 +119,11 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
         // Filter out build tasks that don't match the currently selected debug configuration type.
         buildTasks = buildTasks.filter((task: vscode.Task) => {
             if (defaultConfig.name.startsWith("(Windows) ")) {
-                if (task.name.startsWith("cl.exe")) {
+                if (task.name.startsWith("C/C++: cl.exe")) {
                     return true;
                 }
             } else {
-                if (!task.name.startsWith("cl.exe")) {
+                if (!task.name.startsWith("C/C++: cl.exe")) {
                     return true;
                 }
             }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -47,7 +47,8 @@ let realActivationOccurred: boolean = false;
 let tempCommands: vscode.Disposable[] = [];
 let activatedPreviously: PersistentWorkspaceState<boolean>;
 let buildInfoCache: BuildInfo | undefined;
-const taskSourceStr: string = "shell";
+const taskTypeStr: string = "shell";
+const taskSourceStr: string = "C/C++";
 const cppInstallVsixStr: string = 'C/C++: Install vsix -- ';
 let taskProvider: vscode.Disposable;
 let codeActionProvider: vscode.Disposable;
@@ -171,8 +172,8 @@ export function activate(activationEventOccurred: boolean): void {
         return;
     }
 
-    taskProvider = vscode.tasks.registerTaskProvider(taskSourceStr, {
-        provideTasks: () => getBuildTasks(false),
+    taskProvider = vscode.tasks.registerTaskProvider(taskTypeStr, {
+        provideTasks: () => getBuildTasks(false, false),
         resolveTask(task: vscode.Task): vscode.Task | undefined {
             // Currently cannot implement because VS Code does not call this. Can implement custom output file directory when enabled.
             return undefined;
@@ -243,7 +244,7 @@ export interface BuildTaskDefinition extends vscode.TaskDefinition {
 /**
  * Generate tasks to build the current file based on the user's detected compilers, the user's compilerPath setting, and the current file's extension.
  */
-export async function getBuildTasks(returnCompilerPath: boolean): Promise<vscode.Task[]> {
+export async function getBuildTasks(returnCompilerPath: boolean, appendSourceToName: boolean): Promise<vscode.Task[]> {
     const editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
     if (!editor) {
         return [];
@@ -345,20 +346,20 @@ export async function getBuildTasks(returnCompilerPath: boolean): Promise<vscode
     let createTask: (compilerPath: string, compilerArgs?: string []) => vscode.Task = (compilerPath: string, compilerArgs?: string []) => {
         const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
         const compilerPathBase: string = path.basename(compilerPath);
-        const taskName: string = compilerPathBase + " build active file";
+        const taskName: string = (appendSourceToName ? taskSourceStr + ": " : "") + compilerPathBase + " build active file";
         const isCl: boolean = compilerPathBase === "cl.exe";
-        const cwd: string = isCl ? "" : path.dirname(compilerPath);
+        const cwd: string = "${workspaceFolder}";
         let args: string[] = isCl ? ['/Zi', '/EHsc', '/Fe:', filePath + '.exe', '${file}'] : ['-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
         if (compilerArgs && compilerArgs.length > 0) {
             args = args.concat(compilerArgs);
         }
 
         let kind: vscode.TaskDefinition = {
-            type: 'shell',
+            type: taskTypeStr,
             label: taskName,
             command: isCl ? compilerPathBase : compilerPath,
             args: args,
-            options: isCl ? undefined : {"cwd": cwd}
+            options: { "cwd": cwd }
         };
 
         if (returnCompilerPath) {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -93,7 +93,7 @@ export async function ensureBuildTaskExists(taskName: string): Promise<void> {
         return;
     }
 
-    const buildTasks: vscode.Task[] = await getBuildTasks(false);
+    const buildTasks: vscode.Task[] = await getBuildTasks(false, true);
     selectedTask = buildTasks.find(task => task.name === taskName);
     console.assert(selectedTask);
     if (!selectedTask) {
@@ -104,7 +104,12 @@ export async function ensureBuildTaskExists(taskName: string): Promise<void> {
 
     let selectedTask2: vscode.Task = selectedTask;
     if (!rawTasksJson.tasks.find((task: any) => task.label === selectedTask2.definition.label)) {
-        rawTasksJson.tasks.push(selectedTask2.definition);
+        let task: any = {
+            ...selectedTask2.definition,
+            problemMatcher: selectedTask2.problemMatchers,
+            group: { kind: "build", "isDefault": true }
+        };
+        rawTasksJson.tasks.push(task);
     }
 
     // TODO: It's dangerous to overwrite this file. We could be wiping out comments.


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-docs/issues/3724, https://github.com/microsoft/vscode-cpptools/issues/5561, https://github.com/microsoft/vscode-cpptools/issues/3295, https://github.com/microsoft/vscode-cpptools/issues/4761 .

Problems are:
1. The task source was incorrectly changed to "shell" (regression). Only the "type" registered task type needed to be shell: https://github.com/microsoft/vscode-docs/issues/3724 . 
2. Using Configure Default Build Task would create a task with "shell: " or "C/C++: " in the name, while F5 would not. The adding of the source to the name is caused by VS. I had added a bug report at https://github.com/microsoft/vscode/issues/98838, but I just closed it since we can work around the issue via always adding the source to the name.
3. Added the problemMatcher and group fields to the tasks created from F5 (and Build and Debug Active File): https://github.com/microsoft/vscode-cpptools/issues/3295 .
4. Change the cwd to be ${workspaceFolder} instead of "/usr/bin": https://github.com/microsoft/vscode-cpptools/issues/4761 . The reason we did this originally was because Cygwin would fail, but that can be worked around via either adding Cygwin's bin folder the path or changing the cwd for those cases (but most users won't want cwd to be the path to the compiler, and Cygwin usage is low compared to other scenarios).
