### PR TITLE
Add 'quoteArgs' to launch.json schema

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -950,6 +950,13 @@
                     },
                     "description": "%c_cpp.debuggers.pipeTransport.pipeEnv.description%",
                     "default": {}
+                  },
+                  "quoteArgs": {
+                    "exceptions": {
+                      "type": "boolean",
+                      "description": "%c_cpp.debuggers.logging.quoteArgs.description%",
+                      "default": true
+                    }
                   }
                 }
               },
@@ -1136,6 +1143,13 @@
                     },
                     "description": "%c_cpp.debuggers.pipeTransport.pipeEnv.description%",
                     "default": {}
+                  },
+                  "quoteArgs": {
+                    "exceptions": {
+                      "type": "boolean",
+                      "description": "%c_cpp.debuggers.logging.quoteArgs.description%",
+                      "default": true
+                    }
                   }
                 }
               },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -77,6 +77,7 @@
     "c_cpp.debuggers.pipeTransport.pipeProgram.description": "The fully qualified pipe command to execute.",
     "c_cpp.debuggers.pipeTransport.pipeArgs.description": "Command line arguments passed to the pipe program to configure the connection.",
     "c_cpp.debuggers.pipeTransport.pipeEnv.description": "Environment variables passed to the pipe program.",
+    "c_cpp.debuggers.pipeTransport.quoteArgs.description": "If the pipeProgram's individual arguments contain characters (such as spaces or tabs), should it be quoted? If 'false', the debugger command will no longer be automatically quoted. \nDefault is 'true'.",
     "c_cpp.debuggers.logging.description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
     "c_cpp.debuggers.logging.exceptions.description": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
     "c_cpp.debuggers.logging.moduleLoad.description": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -45,6 +45,13 @@
           },
           "description": "%c_cpp.debuggers.pipeTransport.pipeEnv.description%",
           "default": {}
+        },
+        "quoteArgs": {
+          "exceptions": {
+            "type": "boolean",
+            "description": "%c_cpp.debuggers.logging.quoteArgs.description%",
+            "default": true
+          }
         }
       }
     },


### PR DESCRIPTION
With https://github.com/microsoft/MIEngine/pull/1006, the debug adapter
supports 'quoteArgs' in pipeTransports. If the user wishes to handle the
quoting for pipeTransport arguments, they should set this field to
'false'. It currently defaults to true.

For example, if quoteArgs is 'true', the pipe command will result in
`bash.exe -c '/usr/bin/gdb --interpreter=mi'` If false,
it will result to `bash.exe -c /usr/bin/gdb --interpreter=mi`.
In this example, the latter will not work, but will be needed for a pipeTransport command like `wsl.exe`