### PR TITLE
Doxygen strings for localization

### DIFF
--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -184,7 +184,10 @@
     "expands_to": "Expands to:",
     "file_label": "File:",
     "parameters_label": "Parameters:",
-    "returns_label": "Returns:",
+    "returns_label": {
+        "text": "Returns:",
+        "hint": "This label is for the return value description for a function. Usage example: 'Returns: Area of a shape.'"
+    },
     "deprecated_label": "Deprecated:",
     "exceptions_label": "Exceptions:"
 }

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -182,5 +182,9 @@
         "hint": "Refers to C++ template specializations. This is part of a description indicating there are N additional specializations of a function.  %d is replaced with that number."
     },
     "expands_to": "Expands to:",
-    "file_label": "File:"
+    "file_label": "File:",
+    "parameters_label": "Parameters:",
+    "returns_label": "Returns:",
+    "deprecated_label": "Deprecated:",
+    "exceptions_label": "Exceptions:"
 }


### PR DESCRIPTION
**Doxygen comment strings for localization:**
- Parameters
- Returns
- Deprecated
- Exceptions


**Example of strings used in Doxygen comment**
![image](https://user-images.githubusercontent.com/38734287/85071001-a5d46a80-b16b-11ea-86f9-260b93929f3a.png)


![image](https://user-images.githubusercontent.com/38734287/85071037-b84ea400-b16b-11ea-94bf-a89346af1ccf.png)
