### PR TITLE
ignore 'screen size is bogus' error; fixes microsoft/vscode/issues/100563 (and microsoft/vscode/issues/75932)

### DIFF
--- a/Extension/src/Debugger/nativeAttach.ts
+++ b/Extension/src/Debugger/nativeAttach.ts
@@ -175,6 +175,10 @@ function execChildProcess(process: string, workingDirectory?: string): Promise<s
             }
 
             if (stderr && stderr.length > 0) {
+                if (stderr.indexOf('screen size is bogus') >= 0) {
+                    // ignore this error silently; see https://github.com/microsoft/vscode/issues/75932
+                    // see similar fix for the Node - Debug (Legacy) Extension at https://github.com/microsoft/vscode-node-debug/commit/5298920
+                }
                 reject(new Error(stderr));
                 return;
             }

--- a/Extension/src/Debugger/nativeAttach.ts
+++ b/Extension/src/Debugger/nativeAttach.ts
@@ -178,8 +178,9 @@ function execChildProcess(process: string, workingDirectory?: string): Promise<s
                 if (stderr.indexOf('screen size is bogus') >= 0) {
                     // ignore this error silently; see https://github.com/microsoft/vscode/issues/75932
                     // see similar fix for the Node - Debug (Legacy) Extension at https://github.com/microsoft/vscode-node-debug/commit/5298920
+                } else {
+                    reject(new Error(stderr));
                 }
-                reject(new Error(stderr));
                 return;
             }
 


### PR DESCRIPTION
Corresponding issue: microsoft/vscode#100563
The error below appears when using the Debugger with "type": "cppdbg" and "request": "attach", while picking and attaching to a process through WSL. The root of the error is in the process of fetching remote diagnostics for 'WSL: Ubuntu' since the same error occurs when viewing the Process Explorer, as well. The proposed fix ignores this error silently. The fix imitates a similar commit implemented for the Node - Debug (Legacy) Extension (https://github.com/microsoft/vscode-node-debug/commit/5298920), which also fixes the same issue (microsoft/vscode#75932). The issue was closed, but the fix was only implemented for that particular extension.
!['screen size is bogus' error](https://user-images.githubusercontent.com/48370863/85198303-553a4a00-b2f0-11ea-9a8f-97d87dc9a318.PNG)