### PR TITLE
Generate a new telemetry key for comment continuation patterns

### DIFF
--- a/Extension/src/LanguageServer/settingsTracker.ts
+++ b/Extension/src/LanguageServer/settingsTracker.ts
@@ -158,6 +158,7 @@ export class SettingsTracker {
                     break;
                 }
                 case "commentContinuationPatterns": {
+                    key = "commentContinuationPatterns2";
                     value = this.areEqual(val, settings.inspect(key)?.defaultValue) ? "<default>" : "..."; // Track whether it's being used, but nothing specific about it.
                     break;
                 }


### PR DESCRIPTION
The old key was retired, so a new one needs to be generated