### PR TITLE
Fix settings telemetry to handle more deeply nested settings

### DIFF
--- a/Extension/src/LanguageServer/settingsTracker.ts
+++ b/Extension/src/LanguageServer/settingsTracker.ts
@@ -50,7 +50,11 @@ export class SettingsTracker {
             }
 
             // Iterate through dotted "sub" settings.
-            const collectSettingsRecursive = (key: string, val: Object) => {
+            const collectSettingsRecursive = (key: string, val: Object, depth: number) => {
+                if (depth > 4) {
+                    // Limit settings recursion to 4 dots (not counting the first one in: `C_Cpp.`)
+                    return;
+                }
                 for (const subKey in val) {
                     const newKey: string = key + "." + subKey;
                     const newRawSetting: any = util.packageJson.contributes.configuration.properties["C_Cpp." + newKey];
@@ -60,7 +64,7 @@ export class SettingsTracker {
                         continue;
                     }
                     if (subVal instanceof Object && !(subVal instanceof Array)) {
-                        collectSettingsRecursive(newKey, subVal);
+                        collectSettingsRecursive(newKey, subVal, depth + 1);
                     } else {
                         const entry: KeyValuePair | undefined = this.filterAndSanitize(newKey, subVal, correctlyScopedSubSettings, filter);
                         if (entry && entry.key && entry.value) {
@@ -70,7 +74,7 @@ export class SettingsTracker {
                 }
             };
             if (val instanceof Object && !(val instanceof Array)) {
-                collectSettingsRecursive(key, val);
+                collectSettingsRecursive(key, val, 1);
                 continue;
             }
 

--- a/Extension/src/LanguageServer/settingsTracker.ts
+++ b/Extension/src/LanguageServer/settingsTracker.ts
@@ -48,7 +48,9 @@ export class SettingsTracker {
             if (val === undefined) {
                 continue;
             }
-            if (val instanceof Object && !(val instanceof Array)) {
+
+            // Iterate through dotted "sub" settings.
+            const collectSettingsRecursive = (key: string, val: Object) => {
                 for (const subKey in val) {
                     const newKey: string = key + "." + subKey;
                     const newRawSetting: any = util.packageJson.contributes.configuration.properties["C_Cpp." + newKey];
@@ -57,11 +59,18 @@ export class SettingsTracker {
                     if (subVal === undefined) {
                         continue;
                     }
-                    const entry: KeyValuePair | undefined = this.filterAndSanitize(newKey, subVal, correctlyScopedSubSettings, filter);
-                    if (entry && entry.key && entry.value) {
-                        result[entry.key] = entry.value;
+                    if (subVal instanceof Object && !(subVal instanceof Array)) {
+                        collectSettingsRecursive(newKey, subVal);
+                    } else {
+                        const entry: KeyValuePair | undefined = this.filterAndSanitize(newKey, subVal, correctlyScopedSubSettings, filter);
+                        if (entry && entry.key && entry.value) {
+                            result[entry.key] = entry.value;
+                        }
                     }
                 }
+            };
+            if (val instanceof Object && !(val instanceof Array)) {
+                collectSettingsRecursive(key, val);
                 continue;
             }
 


### PR DESCRIPTION
Currently our settings telemetry only handles recursion one level deep (e.g. C_Cpp.default.includePath).  This change allows the correct telemetry to be sent for more deeply nested settings (e.g. the upcoming settings for Visual Studio formatting).