### PR TITLE
Add missing semantic token old scope mappings

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1632,6 +1632,24 @@
     "semanticTokenScopes": [
       {
         "scopes": {
+          "label": [
+            "entity.name.label"
+          ],
+          "variable.global": [
+            "variable.other.global"
+          ],
+          "variable.local": [
+            "variable.other.local"
+          ],
+          "property.static": [
+            "variable.other.property.static"
+          ],
+          "member.static": [
+            "entity.name.function.member.static"
+          ],
+          "macro": [
+            "entity.name.function.preprocessor"
+          ],
           "referenceType": [
             "entity.name.type.class.reference"
           ],


### PR DESCRIPTION
This addresses: https://github.com/microsoft/vscode-cpptools/issues/5762

Adds mappings for some standard semantic token types to our original semantic colorization scopes.  I had added these mappings for our custom tokens, but mappings for some now standard semantic tokens were needed as well.
