### PR TITLE
Remove file from semantic token cached when closed

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1481,6 +1481,9 @@ export class DefaultClient implements Client {
     }
 
     public onDidCloseTextDocument(document: vscode.TextDocument): void {
+        if (this.semanticTokensProvider) {
+            this.semanticTokensProvider.invalidateFile(document.uri.toString());
+        }
         openFileVersions.delete(document.uri.toString());
     }
 


### PR DESCRIPTION
This was missed in https://github.com/microsoft/vscode-cpptools/pull/5814
