### PR TITLE
Make commentContinuationPatterns, enhancedColorization and codeFolding window scope

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -283,7 +283,7 @@
             ]
           },
           "description": "%c_cpp.configuration.commentContinuationPatterns.description%",
-          "scope": "resource"
+          "scope": "window"
         },
         "C_Cpp.configurationWarnings": {
           "type": "string",
@@ -537,7 +537,7 @@
           ],
           "default": "Enabled",
           "description": "%c_cpp.configuration.enhancedColorization.description%",
-          "scope": "resource"
+          "scope": "window"
         },
         "C_Cpp.vcpkg.enabled": {
           "type": "boolean",
@@ -565,7 +565,7 @@
           ],
           "default": "Enabled",
           "description": "%c_cpp.configuration.codeFolding.description%",
-          "scope": "resource"
+          "scope": "window"
         }
       }
     },

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1414,27 +1414,29 @@ export class DefaultClient implements Client {
         const changedSettings: { [key: string]: string } = this.settingsTracker.getChangedSettings();
         this.notifyWhenReady(() => {
             if (Object.keys(changedSettings).length > 0) {
-                if (changedSettings["commentContinuationPatterns"]) {
-                    updateLanguageConfigurations();
-                }
-                if (changedSettings["codeFolding"]) {
-                    const settings: CppSettings = new CppSettings();
-                    if (settings.codeFolding) {
-                        this.codeFoldingProviderDisposable = vscode.languages.registerFoldingRangeProvider(this.documentSelector, new FoldingRangeProvider(this));
-                    } else if (this.codeFoldingProviderDisposable) {
-                        this.codeFoldingProviderDisposable.dispose();
-                        this.codeFoldingProviderDisposable = undefined;
+                if (isFirstClient) {
+                    if (changedSettings["commentContinuationPatterns"]) {
+                        updateLanguageConfigurations();
                     }
-                }
-                if (changedSettings["enhancedColorization"]) {
-                    const settings: CppSettings = new CppSettings();
-                    if (settings.enhancedColorization && this.semanticTokensLegend) {
-                        this.semanticTokensProvider = new SemanticTokensProvider(this);
-                        this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(this.documentSelector, new SemanticTokensProvider(this), this.semanticTokensLegend);                        ;
-                    } else if (this.semanticTokensProviderDisposable) {
-                        this.semanticTokensProviderDisposable.dispose();
-                        this.semanticTokensProviderDisposable = undefined;
-                        this.semanticTokensProvider = undefined;
+                    if (changedSettings["codeFolding"]) {
+                        const settings: CppSettings = new CppSettings();
+                        if (settings.codeFolding) {
+                            this.codeFoldingProviderDisposable = vscode.languages.registerFoldingRangeProvider(this.documentSelector, new FoldingRangeProvider(this));
+                        } else if (this.codeFoldingProviderDisposable) {
+                            this.codeFoldingProviderDisposable.dispose();
+                            this.codeFoldingProviderDisposable = undefined;
+                        }
+                    }
+                    if (changedSettings["enhancedColorization"]) {
+                        const settings: CppSettings = new CppSettings();
+                        if (settings.enhancedColorization && this.semanticTokensLegend) {
+                            this.semanticTokensProvider = new SemanticTokensProvider(this);
+                            this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(this.documentSelector, new SemanticTokensProvider(this), this.semanticTokensLegend);                        ;
+                        } else if (this.semanticTokensProviderDisposable) {
+                            this.semanticTokensProviderDisposable.dispose();
+                            this.semanticTokensProviderDisposable = undefined;
+                            this.semanticTokensProvider = undefined;
+                        }
                     }
                 }
                 this.configuration.onDidChangeSettings();

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -496,8 +496,8 @@ export function updateLanguageConfigurations(): void {
     languageConfigurations.forEach(d => d.dispose());
     languageConfigurations = [];
 
-    languageConfigurations.push(vscode.languages.setLanguageConfiguration('c', getLanguageConfig('c', clients.ActiveClient.RootUri)));
-    languageConfigurations.push(vscode.languages.setLanguageConfiguration('cpp', getLanguageConfig('cpp', clients.ActiveClient.RootUri)));
+    languageConfigurations.push(vscode.languages.setLanguageConfiguration('c', getLanguageConfig('c')));
+    languageConfigurations.push(vscode.languages.setLanguageConfiguration('cpp', getLanguageConfig('cpp')));
 }
 
 /**

--- a/Extension/src/LanguageServer/languageConfig.ts
+++ b/Extension/src/LanguageServer/languageConfig.ts
@@ -220,8 +220,8 @@ interface Rules {
     end: vscode.OnEnterRule[];
 }
 
-export function getLanguageConfig(languageId: string, resource?: vscode.Uri): vscode.LanguageConfiguration {
-    const settings: CppSettings = new CppSettings(resource);
+export function getLanguageConfig(languageId: string): vscode.LanguageConfiguration {
+    const settings: CppSettings = new CppSettings();
     const patterns: (string | CommentPattern)[] | undefined = settings.commentContinuationPatterns;
     return getLanguageConfigFromPatterns(languageId, patterns);
 }


### PR DESCRIPTION
This change makes the following settings 'window' scope instead of 'resource' scope, to ensure proper behavior in multiroot workspaces.

 - `commentContinuationPatterns` - This uses `vscode.languages.setLanguageConfiguration()`, which is not resource (folder) specific.
 - `enhancedColorization` and `codeFolding` - These involve registering providers.  In order to support these on a per resource (per folder) basis, some additional work would be needed.  However, it seems to make more sense for these settings to be window scope.  We don't think user would want to vary these per folder.

This change also updates `onDidChangeSettings()` to only handle changes to these settings once instead of per folder.
