### PR TITLE
Use detected default compiler

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -628,7 +628,7 @@ export class CppProperties {
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
-            if (!configuration.compilerPath && !!this.defaultCompilerPath) {
+            if ((configuration.compilerPath === undefined) && !!this.defaultCompilerPath) {
                 configuration.compilerPath = this.defaultCompilerPath;
                 if (!configuration.cStandard && !!this.defaultCStandard) {
                     configuration.cStandard = this.defaultCStandard;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -628,7 +628,9 @@ export class CppProperties {
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
-            if ((configuration.compilerPath === undefined) && !!this.defaultCompilerPath) {
+            if ((configuration.compilerPath === undefined) && !!this.defaultCompilerPath && !configuration.compileCommands) {
+                // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
+                // don't set a default when compileCommands is in use.
                 configuration.compilerPath = this.defaultCompilerPath;
                 if (!configuration.cStandard && !!this.defaultCStandard) {
                     configuration.cStandard = this.defaultCStandard;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -623,36 +623,34 @@ export class CppProperties {
             configuration.windowsSdkVersion = this.updateConfigurationString(configuration.windowsSdkVersion, settings.defaultWindowsSdkVersion, env);
             configuration.forcedInclude = this.updateConfigurationStringArray(configuration.forcedInclude, settings.defaultForcedInclude, env);
             configuration.compileCommands = this.updateConfigurationString(configuration.compileCommands, settings.defaultCompileCommands, env);
-            if (!configuration.compileCommands) {
-                // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
-                // don't set a default when compileCommands is in use.
-                configuration.compilerPath = this.updateConfigurationString(configuration.compilerPath, settings.defaultCompilerPath, env, true);
-            }
             configuration.compilerArgs = this.updateConfigurationStringArray(configuration.compilerArgs, settings.defaultCompilerArgs, env);
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
-            if ((configuration.compilerPath === undefined) && !!this.defaultCompilerPath && !configuration.compileCommands) {
+            if (!configuration.compileCommands) {
                 // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
                 // don't set a default when compileCommands is in use.
-                configuration.compilerPath = this.defaultCompilerPath;
-                if (!configuration.cStandard && !!this.defaultCStandard) {
-                    configuration.cStandard = this.defaultCStandard;
-                }
-                if (!configuration.cppStandard && !!this.defaultCppStandard) {
-                    configuration.cppStandard = this.defaultCppStandard;
-                }
-                if (!configuration.intelliSenseMode && !!this.defaultIntelliSenseMode) {
-                    configuration.intelliSenseMode = this.defaultIntelliSenseMode;
-                }
-                if (!configuration.windowsSdkVersion && !!this.defaultWindowsSdkVersion) {
-                    configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
-                }
-                if (!configuration.includePath && !!this.defaultIncludes) {
-                    configuration.includePath = this.defaultIncludes;
-                }
-                if (!configuration.macFrameworkPath && !!this.defaultFrameworks) {
-                    configuration.macFrameworkPath = this.defaultFrameworks;
+                configuration.compilerPath = this.updateConfigurationString(configuration.compilerPath, settings.defaultCompilerPath, env, true);
+                if (configuration.compilerPath === undefined && !!this.defaultCompilerPath) {
+                    configuration.compilerPath = this.defaultCompilerPath;
+                    if (!configuration.cStandard && !!this.defaultCStandard) {
+                        configuration.cStandard = this.defaultCStandard;
+                    }
+                    if (!configuration.cppStandard && !!this.defaultCppStandard) {
+                        configuration.cppStandard = this.defaultCppStandard;
+                    }
+                    if (!configuration.intelliSenseMode && !!this.defaultIntelliSenseMode) {
+                        configuration.intelliSenseMode = this.defaultIntelliSenseMode;
+                    }
+                    if (!configuration.windowsSdkVersion && !!this.defaultWindowsSdkVersion) {
+                        configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
+                    }
+                    if (!configuration.includePath && !!this.defaultIncludes) {
+                        configuration.includePath = this.defaultIncludes;
+                    }
+                    if (!configuration.macFrameworkPath && !!this.defaultFrameworks) {
+                        configuration.macFrameworkPath = this.defaultFrameworks;
+                    }
                 }
             }
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -628,6 +628,27 @@ export class CppProperties {
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
+            if (configuration.compilerPath === undefined && !!this.defaultCompilerPath) {
+                configuration.compilerPath = this.defaultCompilerPath;
+                if (configuration.cStandard === undefined && !!this.defaultCStandard) {
+                    configuration.cStandard = this.defaultCStandard;
+                }
+                if (configuration.cppStandard === undefined && !!this.defaultCppStandard) {
+                    configuration.cppStandard = this.defaultCppStandard;
+                }
+                if (configuration.includePath === undefined && !!this.defaultIncludes) {
+                    configuration.includePath = this.defaultIncludes;
+                }
+                if (configuration.intelliSenseMode === undefined && !!this.defaultIntelliSenseMode) {
+                    configuration.intelliSenseMode = this.defaultIntelliSenseMode;
+                }
+                if (configuration.macFrameworkPath === undefined && !!this.defaultFrameworks) {
+                    configuration.macFrameworkPath = this.defaultFrameworks;
+                }
+                if (configuration.windowsSdkVersion === undefined && !!this.defaultWindowsSdkVersion) {
+                    configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
+                }
+            }
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);
             configuration.configurationProvider = this.updateConfigurationString(configuration.configurationProvider, settings.defaultConfigurationProvider, env);
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -628,25 +628,25 @@ export class CppProperties {
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
-            if (configuration.compilerPath === undefined && !!this.defaultCompilerPath) {
+            if ((configuration.compilerPath === undefined || configuration.compilerPath === "") && !!this.defaultCompilerPath) {
                 configuration.compilerPath = this.defaultCompilerPath;
-                if (configuration.cStandard === undefined && !!this.defaultCStandard) {
+                if ((!configuration.cStandard || configuration.cStandard === "") && !!this.defaultCStandard) {
                     configuration.cStandard = this.defaultCStandard;
                 }
-                if (configuration.cppStandard === undefined && !!this.defaultCppStandard) {
+                if ((!configuration.cppStandard || configuration.cppStandard === "") && !!this.defaultCppStandard) {
                     configuration.cppStandard = this.defaultCppStandard;
                 }
-                if (configuration.includePath === undefined && !!this.defaultIncludes) {
-                    configuration.includePath = this.defaultIncludes;
-                }
-                if (configuration.intelliSenseMode === undefined && !!this.defaultIntelliSenseMode) {
+                if ((!configuration.intelliSenseMode || configuration.intelliSenseMode === "") && !!this.defaultIntelliSenseMode) {
                     configuration.intelliSenseMode = this.defaultIntelliSenseMode;
                 }
-                if (configuration.macFrameworkPath === undefined && !!this.defaultFrameworks) {
-                    configuration.macFrameworkPath = this.defaultFrameworks;
-                }
-                if (configuration.windowsSdkVersion === undefined && !!this.defaultWindowsSdkVersion) {
+                if ((!configuration.windowsSdkVersion || configuration.windowsSdkVersion === "") && !!this.defaultWindowsSdkVersion) {
                     configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
+                }
+                if (!configuration.includePath && !!this.defaultIncludes) {
+                    configuration.includePath = this.defaultIncludes;
+                }
+                if (!configuration.macFrameworkPath && !!this.defaultFrameworks) {
+                    configuration.macFrameworkPath = this.defaultFrameworks;
                 }
             }
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -623,7 +623,11 @@ export class CppProperties {
             configuration.windowsSdkVersion = this.updateConfigurationString(configuration.windowsSdkVersion, settings.defaultWindowsSdkVersion, env);
             configuration.forcedInclude = this.updateConfigurationStringArray(configuration.forcedInclude, settings.defaultForcedInclude, env);
             configuration.compileCommands = this.updateConfigurationString(configuration.compileCommands, settings.defaultCompileCommands, env);
-            configuration.compilerPath = this.updateConfigurationString(configuration.compilerPath, settings.defaultCompilerPath, env, true);
+            if (!configuration.compileCommands) {
+                // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
+                // don't set a default when compileCommands is in use.
+                configuration.compilerPath = this.updateConfigurationString(configuration.compilerPath, settings.defaultCompilerPath, env, true);
+            }
             configuration.compilerArgs = this.updateConfigurationStringArray(configuration.compilerArgs, settings.defaultCompilerArgs, env);
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -628,18 +628,18 @@ export class CppProperties {
             configuration.cStandard = this.updateConfigurationString(configuration.cStandard, settings.defaultCStandard, env);
             configuration.cppStandard = this.updateConfigurationString(configuration.cppStandard, settings.defaultCppStandard, env);
             configuration.intelliSenseMode = this.updateConfigurationString(configuration.intelliSenseMode, settings.defaultIntelliSenseMode, env);
-            if ((configuration.compilerPath === undefined || configuration.compilerPath === "") && !!this.defaultCompilerPath) {
+            if (!configuration.compilerPath && !!this.defaultCompilerPath) {
                 configuration.compilerPath = this.defaultCompilerPath;
-                if ((!configuration.cStandard || configuration.cStandard === "") && !!this.defaultCStandard) {
+                if (!configuration.cStandard && !!this.defaultCStandard) {
                     configuration.cStandard = this.defaultCStandard;
                 }
-                if ((!configuration.cppStandard || configuration.cppStandard === "") && !!this.defaultCppStandard) {
+                if (!configuration.cppStandard && !!this.defaultCppStandard) {
                     configuration.cppStandard = this.defaultCppStandard;
                 }
-                if ((!configuration.intelliSenseMode || configuration.intelliSenseMode === "") && !!this.defaultIntelliSenseMode) {
+                if (!configuration.intelliSenseMode && !!this.defaultIntelliSenseMode) {
                     configuration.intelliSenseMode = this.defaultIntelliSenseMode;
                 }
-                if ((!configuration.windowsSdkVersion || configuration.windowsSdkVersion === "") && !!this.defaultWindowsSdkVersion) {
+                if (!configuration.windowsSdkVersion && !!this.defaultWindowsSdkVersion) {
                     configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
                 }
                 if (!configuration.includePath && !!this.defaultIncludes) {


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/5776

The detected default compiler and associated values were used to populate newly created configurations, but were not used as a fallback if the compiler was unspecified.

This change handles the situation where no compiler was specified in the c_cpp_properties, or explicitly as a default setting.  Instead of using no/blank compiler, the detected compiler and associated values are used.