### PR TITLE
Fix another issue with resolving compilerPath when compileCommands are used.

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -652,6 +652,14 @@ export class CppProperties {
                         configuration.macFrameworkPath = this.defaultFrameworks;
                     }
                 }
+            } else {
+                // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
+                if (configuration.compilerPath === "${default}") {
+                    configuration.compilerPath = settings.defaultCompilerPath;
+                } else if (configuration.compilerPath === null) {
+                    configuration.compilerPath = undefined;
+                }
+                configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
             }
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);
             configuration.configurationProvider = this.updateConfigurationString(configuration.configurationProvider, settings.defaultConfigurationProvider, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -654,12 +654,12 @@ export class CppProperties {
                 }
             } else {
                 // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
+                if (configuration.compilerPath === "${default}") {
+                    configuration.compilerPath = settings.defaultCompilerPath;
+                }
                 if (configuration.compilerPath === null) {
                     configuration.compilerPath = undefined;
-                } else {
-                    if (configuration.compilerPath === "${default}") {
-                        configuration.compilerPath = settings.defaultCompilerPath;
-                    }
+                } else if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                 }
             }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -654,12 +654,14 @@ export class CppProperties {
                 }
             } else {
                 // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
-                if (configuration.compilerPath === "${default}") {
-                    configuration.compilerPath = settings.defaultCompilerPath;
-                } else if (configuration.compilerPath === null) {
+                if (configuration.compilerPath === null) {
                     configuration.compilerPath = undefined;
+                } else {
+                    if (configuration.compilerPath === "${default}") {
+                        configuration.compilerPath = settings.defaultCompilerPath;
+                    }
+                    configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                 }
-                configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
             }
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);
             configuration.configurationProvider = this.updateConfigurationString(configuration.configurationProvider, settings.defaultConfigurationProvider, env);


### PR DESCRIPTION
Address a detail missed in https://github.com/microsoft/vscode-cpptools/pull/5838
