### PR TITLE
Fix C Standard selector in UI

### DIFF
--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -552,7 +552,7 @@
                 <option value="c11">c11</option>
                 <option value="c99">c99</option>
                 <option value="c89">c89</option>
-                <option value="gnu17">gnu18</option>
+                <option value="gnu18">gnu18</option>
                 <option value="gnu11">gnu11</option>
                 <option value="gnu99">gnu99</option>
                 <option value="gnu89">gnu89</option>


### PR DESCRIPTION
Fix C Standard Selector in UI:  gnu17 -> gnu18.