### PR TITLE
Allow comments in c_cpp_properties.json (use JSONC)

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -16,6 +16,7 @@ import { getCustomConfigProviders } from './customProviders';
 import { SettingsPanel } from './settingsPanel';
 import * as os from 'os';
 import escapeStringRegExp = require('escape-string-regexp');
+import * as jsonc from 'jsonc-parser';
 import * as nls from 'vscode-nls';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -959,7 +960,7 @@ export class CppProperties {
             }
 
             // Try to use the same configuration as before the change.
-            const newJson: ConfigurationJson = JSON.parse(readResults);
+            const newJson: ConfigurationJson = jsonc.parse(readResults);
             if (!newJson || !newJson.configurations || newJson.configurations.length === 0) {
                 throw { message: localize("invalid.configuration.file", "Invalid configuration file. There must be at least one configuration present in the array.") };
             }
@@ -1276,7 +1277,7 @@ export class CppProperties {
             // Replace all \<escape character> with \\<character>, except for \"
             // Otherwise, the JSON.parse result will have the \<escape character> missing.
             const configurationsText: string = util.escapeForSquiggles(curText);
-            const configurations: ConfigurationJson = JSON.parse(configurationsText);
+            const configurations: ConfigurationJson = jsonc.parse(configurationsText);
             const currentConfiguration: Configuration = configurations.configurations[this.CurrentConfigurationIndex];
 
             let curTextStartOffset: number = 0;


### PR DESCRIPTION
A simple fix to enable use of comments in c_cpp_properties.json, as suggested by: https://github.com/microsoft/vscode-cpptools/issues/5885

Use of the Configuration UI will still rewrite c_cpp_properties.json, overwriting any comments.

Although comments and trailing commas, etc., are allowed, I have not yet found a good way to automatically associate `c_cpp_properteis.json` with the the `jsonc` file type ("JSON with Comments"), short of adding code that injects it into the user's `files.associations`.

The `jsonc` document format is a VS Code specific convention.  The following issue may lead to a better ultimate solution: https://github.com/microsoft/vscode/issues/100688