### PR TITLE
Set jsonc for c_cpp_properties.json.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -452,6 +452,7 @@ function realActivation(): void {
 
     disposables.push(vscode.workspace.onDidChangeConfiguration(onDidChangeSettings));
     disposables.push(vscode.window.onDidChangeActiveTextEditor(onDidChangeActiveTextEditor));
+    ui.activeDocumentChanged(); // Handle already active documents (for non-cpp files that we don't register didOpen).
     disposables.push(vscode.window.onDidChangeTextEditorSelection(onDidChangeTextEditorSelection));
     disposables.push(vscode.window.onDidChangeVisibleTextEditors(onDidChangeVisibleTextEditors));
 

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -163,14 +163,19 @@ export class UI {
         } else {
             const isCpp: boolean = (activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "c"));
 
-            // It's sometimes desirable to see the config and icons when making settings changes.
             const isCppPropertiesJson: boolean = activeEditor.document.fileName.endsWith("c_cpp_properties.json");
             if (isCppPropertiesJson) {
                 vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
             }
+
+            // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
+            // TODO: Check some "AlwaysShow" setting here.
             this.ShowConfiguration = isCpp || isCppPropertiesJson ||
                 activeEditor.document.uri.scheme === "output" ||
-                activeEditor.document.fileName.endsWith("settings.json");
+                activeEditor.document.fileName.endsWith("settings.json") ||
+                activeEditor.document.fileName.endsWith("tasks.json") ||
+                activeEditor.document.fileName.endsWith("launch.json") ||
+                activeEditor.document.fileName.endsWith(".code-workspace");
         }
     }
 

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -164,9 +164,13 @@ export class UI {
             const isCpp: boolean = (activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "c"));
 
             // It's sometimes desirable to see the config and icons when making settings changes.
-            const isSettingsJson: boolean = ((activeEditor.document.fileName.endsWith("c_cpp_properties.json") || activeEditor.document.fileName.endsWith("settings.json")));
-
-            this.ShowConfiguration = isCpp || isSettingsJson;
+            const isCppPropertiesJson: boolean = activeEditor.document.fileName.endsWith("c_cpp_properties.json");
+            if (isCppPropertiesJson) {
+                vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
+            }
+            this.ShowConfiguration = isCpp || isCppPropertiesJson ||
+                activeEditor.document.uri.scheme === "output" ||
+                activeEditor.document.fileName.endsWith("settings.json");
         }
     }
 


### PR DESCRIPTION
Fix c_cpp_properties.json not opening as JSON with comments. Follow up to https://github.com/microsoft/vscode-cpptools/issues/5885
Fix the configuration UI disappearing when selection moves to the C/C++ or Log Diagnostics window, mentioned at https://github.com/microsoft/vscode-cpptools/issues/5822 .
Fix an unreported bug where the configuration UI wouldn't appear for non-cpp files that are active on startup (until the selection changed).