### PR TITLE
add telemetry for missing format style

### DIFF
--- a/Extension/src/LanguageServer/settingsTracker.ts
+++ b/Extension/src/LanguageServer/settingsTracker.ts
@@ -148,6 +148,7 @@ export class SettingsTracker {
                     const newKey: string = key + "2";
                     if (val) {
                         switch (String(val).toLowerCase()) {
+                            case "emulated visual studio":
                             case "visual studio":
                             case "llvm":
                             case "google":


### PR DESCRIPTION
We added "Emulated Visual Studio" but didn't update the settings tracker.