### PR TITLE
Resolve compiler filename if in PATH

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -18,6 +18,7 @@ import * as os from 'os';
 import escapeStringRegExp = require('escape-string-regexp');
 import * as jsonc from 'jsonc-parser';
 import * as nls from 'vscode-nls';
+import which = require('which');
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -664,6 +665,19 @@ export class CppProperties {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                 }
             }
+
+            if (configuration.compilerPath
+                && configuration.compilerPath.length > 0
+                && configuration.compilerPath[0] !== '/'
+                && !fs.existsSync(configuration.compilerPath)) {
+                // If a compiler path is specified, and it doesn't resolve to a file,
+                // try looking for it in the current path.
+                try {
+                    configuration.compilerPath = which.sync(configuration.compilerPath);
+                } catch {
+                }
+            }
+
             configuration.customConfigurationVariables = this.updateConfigurationStringDictionary(configuration.customConfigurationVariables, settings.defaultCustomConfigurationVariables, env);
             configuration.configurationProvider = this.updateConfigurationString(configuration.configurationProvider, settings.defaultConfigurationProvider, env);
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -20,7 +20,7 @@ import { getLanguageConfig } from './languageConfig';
 import { getCustomConfigProviders } from './customProviders';
 import { PlatformInformation } from '../platform';
 import { Range } from 'vscode-languageclient';
-import { ChildProcess, spawn, execSync } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import { getTargetBuildInfo, BuildInfo } from '../githubAPI';
 import * as configs from './configurations';
 import { PackageVersion } from '../packageVersion';
@@ -29,6 +29,7 @@ import * as rd from 'readline';
 import * as yauzl from 'yauzl';
 import { Readable, Writable } from 'stream';
 import * as nls from 'vscode-nls';
+import * as which from 'which';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -648,8 +649,7 @@ function installVsix(vsixLocation: string): Thenable<void> {
             } else {
                 const vsCodeBinName: string = path.basename(process.execPath);
                 try {
-                    const stdout: Buffer = execSync('which ' + vsCodeBinName);
-                    return stdout.toString().trim();
+                    return which.sync(vsCodeBinName);
                 } catch (error) {
                     return undefined;
                 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/5908

Also addresses a case in which we were invoking 'which' via the shell rather than using the node module.