### PR TITLE
Generate and validate integrity of downloaded packages

### DIFF
--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -298,16 +298,10 @@ gulp.task("translations-import", (done) => {
 // ****************************
 
 async function DownloadFile(urlString) {
-    const url = new URL(urlString);
-    const options = {
-        host: url.host,
-        path: url.path,
-    };
-
     const buffers = [];
     return new Promise((resolve, reject) => {
         const req = https.request(urlString, (response) => {
-            if (response.statusCode === 301 || response.statusCode === 302 && !response.headers.location) {
+            if (response.statusCode === 301 || response.statusCode === 302) {
                 // Redirect - download from new location
                 let redirectUrl;
                 if (typeof response.headers.location === "string") {

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -298,10 +298,16 @@ gulp.task("translations-import", (done) => {
 // ****************************
 
 async function DownloadFile(urlString) {
+    const url = new URL(urlString);
+    const options = {
+        host: url.host,
+        path: url.path,
+    };
+
     const buffers = [];
     return new Promise((resolve, reject) => {
         const req = https.request(urlString, (response) => {
-            if (response.statusCode === 301 || response.statusCode === 302) {
+            if (response.statusCode === 301 || response.statusCode === 302 && !response.headers.location) {
                 // Redirect - download from new location
                 let redirectUrl;
                 if (typeof response.headers.location === "string") {

--- a/Extension/gulpfile.js
+++ b/Extension/gulpfile.js
@@ -293,7 +293,7 @@ gulp.task("translations-import", (done) => {
 });
 
 // ****************************
-// Command: generate-hash
+// Command: generate-package-hashes
 // Generates a hash for each dependency package
 // ****************************
 

--- a/Extension/jobs/build.windows.yml
+++ b/Extension/jobs/build.windows.yml
@@ -17,6 +17,10 @@ jobs:
     displayName: "Install Dependencies"
     workingDirectory: '$(Build.SourcesDirectory)\Extension'
 
+  - script: yarn run generatePackageHashes
+    displayName: "Generate hashes for runtime dependency packages"
+    workingDirectory: '$(Build.SourcesDirectory)/Extension'
+
   - script: yarn run compile
     displayName: "Compile Sources"
     workingDirectory: '$(Build.SourcesDirectory)\Extension'

--- a/Extension/jobs/build.yml
+++ b/Extension/jobs/build.yml
@@ -16,6 +16,10 @@ jobs:
     displayName: "Install Dependencies"
     workingDirectory: '$(Build.SourcesDirectory)/Extension'
 
+  - script: yarn run generatePackageHashes
+    displayName: "Generate hashes for runtime dependency packages"
+    workingDirectory: '$(Build.SourcesDirectory)/Extension'
+
   - script: yarn run compile
     displayName: "Compile Sources"
     workingDirectory: '$(Build.SourcesDirectory)/Extension'

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2208,7 +2208,7 @@
     "translations-import": "node ./tools/prepublish.js && gulp translations-import",
     "prepublishjs": "node ./tools/prepublish.js",
     "pretest": "tsc -p test.tsconfig.json",
-    "generatePackageHash" : "gulp generate-package-hash",
+    "generatePackageHashes": "gulp generate-package-hashes",
     "pr-check": "gulp pr-check",
     "lint": "gulp lint",
     "unitTests": "tsc -p test.tsconfig.json && node ./out/test/unitTests/runTest.js",
@@ -2300,7 +2300,8 @@
       "binaries": [
         "./bin/cpptools",
         "./bin/cpptools-srv"
-      ]
+      ],
+      "integrity": "292D438B2573D17D18E30C4723702118BBCCB0049388C1B76879E9A15FE784FD"
     },
     {
       "description": "C/C++ language components (Linux / armhf)",
@@ -2314,7 +2315,8 @@
       "binaries": [
         "./bin/cpptools",
         "./bin/cpptools-srv"
-      ]
+      ],
+      "integrity": "61C2656ABD3856A657D6103D169838528F9454D39E7DA36A92B272AC2A052067"
     },
     {
       "description": "C/C++ language components (Linux / aarch64)",
@@ -2328,7 +2330,8 @@
       "binaries": [
         "./bin/cpptools",
         "./bin/cpptools-srv"
-      ]
+      ],
+      "integrity": "61C2656ABD3856A657D6103D169838528F9454D39E7DA36A92B272AC2A052067"
     },
     {
       "description": "C/C++ language components (OS X)",
@@ -2339,7 +2342,8 @@
       "binaries": [
         "./bin/cpptools",
         "./bin/cpptools-srv"
-      ]
+      ],
+      "integrity": "3CAAFD3A5375F4F3EA2D7EA4B432C1917FDC3B548CA81C5D032041A07821B121"
     },
     {
       "description": "C/C++ language components (Windows)",
@@ -2350,7 +2354,8 @@
       "binaries": [
         "./bin/cpptools.exe",
         "./bin/cpptools-srv.exe"
-      ]
+      ],
+      "integrity": "F98CB4D80013A119EB0043BA1A85E1E5966E6F160264A28E19D9D57ABD7FD015"
     },
     {
       "description": "ClangFormat (Linux / x86_64)",
@@ -2363,7 +2368,8 @@
       ],
       "binaries": [
         "./LLVM/bin/clang-format"
-      ]
+      ],
+      "integrity": "B8381B87B83EE1AF9088AA6679F2DA013DC23A21D9EC5603C58DEFC323ED9617"
     },
     {
       "description": "ClangFormat (Linux / armhf)",
@@ -2376,7 +2382,8 @@
       ],
       "binaries": [
         "./LLVM/bin/clang-format"
-      ]
+      ],
+      "integrity": "F06D3741192FFD7BB96BF9327D9DE1BBF6A9DB9753DA971C727D20D38835C1A9"
     },
     {
       "description": "ClangFormat (Linux / aarch64)",
@@ -2389,7 +2396,8 @@
       ],
       "binaries": [
         "./LLVM/bin/clang-format"
-      ]
+      ],
+      "integrity": "F06D3741192FFD7BB96BF9327D9DE1BBF6A9DB9753DA971C727D20D38835C1A9"
     },
     {
       "description": "ClangFormat (OS X)",
@@ -2399,7 +2407,8 @@
       ],
       "binaries": [
         "./LLVM/bin/clang-format.darwin"
-      ]
+      ],
+      "integrity": "416D3B814A76E52D943B3372D517D6AADE0AB0BD9FD9921F871C1FB89D7B17B1"
     },
     {
       "description": "ClangFormat (Windows)",
@@ -2409,7 +2418,8 @@
       ],
       "binaries": [
         "./LLVM/bin/clang-format.exe"
-      ]
+      ],
+      "integrity": "E5A2543FA2D45B964B43AE770A6D50F8698B592485E7E883005FFF52BFAD0CCD"
     },
     {
       "description": "Mono Framework Assemblies",
@@ -2418,7 +2428,8 @@
         "linux",
         "darwin"
       ],
-      "binaries": []
+      "binaries": [],
+      "integrity": "579295329C1825588B6251EEA56571D1B9555BD529AA1A319CDFE741BC22D786"
     },
     {
       "description": "Mono Runtime (Linux / x86_64)",
@@ -2431,7 +2442,8 @@
       ],
       "binaries": [
         "./debugAdapters/mono.linux-x86_64"
-      ]
+      ],
+      "integrity": "927C5094E83CE64EDC3A267EE1F13267CFA09FC1E9A5ADC870A752C05AD26F17"
     },
     {
       "description": "Mono Runtime (Linux / armhf)",
@@ -2444,7 +2456,8 @@
       ],
       "binaries": [
         "./debugAdapters/mono.linux-armhf"
-      ]
+      ],
+      "integrity": "D2D1FE7FB5CC5B2A60364F08829467509879D603FC951AC3805B530C8CEEF981"
     },
     {
       "description": "Mono Runtime (Linux / arm64)",
@@ -2457,7 +2470,8 @@
       ],
       "binaries": [
         "./debugAdapters/mono.linux-arm64"
-      ]
+      ],
+      "integrity": "946C54C8C6BF5BF79AC05D4E152F8D8647700FA786C21505832B3C79988339B4"
     },
     {
       "description": "Mono Runtime (OS X)",
@@ -2467,7 +2481,8 @@
       ],
       "binaries": [
         "./debugAdapters/mono.osx"
-      ]
+      ],
+      "integrity": "5D9E5AB3E921D138887BD12FF46B02BFC85B692B438EDFAAEB1E1E7837F1D40B"
     },
     {
       "description": "LLDB-MI (macOS Mojave and higher)",
@@ -2479,7 +2494,8 @@
       "matchVersion": false,
       "binaries": [
         "./debugAdapters/lldb-mi/bin/lldb-mi"
-      ]
+      ],
+      "integrity": "6C2CD2797380DE2F3EA2A991BA4DACE265920922C4E18A80FAC515B30C1D0B99"
     },
     {
       "description": "LLDB 3.8.0 (macOS High Sierra and lower)",
@@ -2494,7 +2510,8 @@
         "./debugAdapters/lldb/bin/lldb-mi",
         "./debugAdapters/lldb/bin/lldb-argdumper",
         "./debugAdapters/lldb/bin/lldb-launcher"
-      ]
+      ],
+      "integrity": "D4ACCD43F562E42CE30879AC15ADF5FB6AA50656795DCE8F3AD32FB108BB3B7E"
     },
     {
       "description": "Visual Studio Windows Debugger",
@@ -2504,7 +2521,8 @@
       ],
       "binaries": [
         "./debugAdapters/vsdbg/bin/vsdbg.exe"
-      ]
+      ],
+      "integrity": "CF1A01AA75275F76800F6BC1D289F2066DCEBCD983376D344ABF6B03FDB8FEA0"
     }
   ]
 }

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2208,6 +2208,7 @@
     "translations-import": "node ./tools/prepublish.js && gulp translations-import",
     "prepublishjs": "node ./tools/prepublish.js",
     "pretest": "tsc -p test.tsconfig.json",
+    "generatePackageHash" : "gulp generate-package-hash",
     "pr-check": "gulp pr-check",
     "lint": "gulp lint",
     "unitTests": "tsc -p test.tsconfig.json && node ./out/test/unitTests/runTest.js",


### PR DESCRIPTION
https://github.com/microsoft/vscode-cpptools/issues/5268

- Add function to generate hash keys per runtime dependency package listed in package.json. This can be invoked by using the gulp script "generate-package-hashes". Run this script whenever URL of package changes.
- Add ability to validate hash of runtime dependency package at time of download.
- Added hash or integrity keys to package.json.