### PR TITLE
Fix issue with clang-format on-type failing at end of file

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -811,8 +811,8 @@ class OnTypeFormattingEditProvider implements vscode.OnTypeFormattingEditProvide
                                 line: position.line
                             },
                             end: {
-                                character: position.character,
-                                line: position.line
+                                character: 0,
+                                line: 0
                             }
                         }
                     };


### PR DESCRIPTION
Fix issue with wrong end line/character being sent when formatting on-type.