### PR TITLE
Rename telemetry property that is being filtered

### DIFF
--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -161,10 +161,10 @@ export async function getTargetBuildInfo(updateChannel: string, isFromSettingsCh
                 telemetry.logLanguageServerEvent("UpgradeCheck", { "action": "none" });
             } else if (userVersion.isExtensionVersionGreaterThan(new PackageVersion(targetBuild.name))) {
                 // downgrade
-                telemetry.logLanguageServerEvent("UpgradeCheck", { "action": "downgrade", "version": targetBuild.name });
+                telemetry.logLanguageServerEvent("UpgradeCheck", { "action": "downgrade", "newVersion": targetBuild.name });
             } else {
                 // upgrade
-                telemetry.logLanguageServerEvent("UpgradeCheck", { "action": "upgrade", "version": targetBuild.name });
+                telemetry.logLanguageServerEvent("UpgradeCheck", { "action": "upgrade", "newVersion": targetBuild.name });
             }
             return targetBuild;
         })


### PR DESCRIPTION
"version" seems to be a reserved word or something because we have no data for the "version" property of the upgrade check.  I tested a rename and it appeared on my dashboard over the weekend.