### PR TITLE
Remove unintended loc.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2982,7 +2982,7 @@ export class DefaultClient implements Client {
             break;
         }
 
-        this.browseConfigurationLogging = localize("browse.configuration", "Custom browse configuration: {0}", `\n${JSON.stringify(sanitized, null, 4)}\n`);
+        this.browseConfigurationLogging = `Custom browse configuration: \n${JSON.stringify(sanitized, null, 4)}\n`;
 
         const params: CustomBrowseConfigurationParams = {
             browseConfiguration: sanitized,


### PR DESCRIPTION
One text in the C/C++ Output is being localized. The intent was that it was not to be localized. If we later choose to localize the text, it should all be localized. See https://github.com/microsoft/vscode-cpptools/issues/6012#issuecomment-679966603 for an example.