### PR TITLE
reports the correct __cplusplus macro for MSVC IntelliSense Mode

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -313,6 +313,10 @@ export class CppProperties {
         // browse.path is not set by default anymore. When it is not set, the includePath will be used instead.
         if (isUnset(settings.defaultDefines)) {
             configuration.defines = (process.platform === 'win32') ? ["_DEBUG", "UNICODE", "_UNICODE"] : [];
+            if ((settings.defaultIntelliSenseMode && settings.defaultIntelliSenseMode.startsWith("msvc")) ||
+                (this.defaultIntelliSenseMode && this.defaultIntelliSenseMode.startsWith("msvc"))) {
+                configuration.defines.push("/Zc:__cplusplus");
+            }
         }
         if (isUnset(settings.defaultMacFrameworkPath) && process.platform === 'darwin') {
             configuration.macFrameworkPath = this.defaultFrameworks;


### PR DESCRIPTION
feature-request: https://github.com/microsoft/vscode-cpptools/issues/2595
the language-server side is also altered to accommodate this feature. 
The reason I am adding a default value for _Cplusplus is that if the IntelliSense mode is MSVC and the std version is c++17, the default value for _cplusplus is  201703L.


