### PR TITLE
bypass launch.json in debug

### DIFF
--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -108,11 +108,17 @@ export function initialize(context: vscode.ExtensionContext): void {
 
             // Attempt to use the user's (possibly) modified configuration before using the generated one.
             try {
-                await vscode.debug.startDebugging(folder, selection.configuration.name);
-                Telemetry.logDebuggerEvent("buildAndDebug", { "success": "true" });
+                await util.ensureDebugConfigExists(selection.configuration.name);
+                try {
+                    await vscode.debug.startDebugging(folder, selection.configuration.name);
+                    Telemetry.logDebuggerEvent("buildAndDebug", { "success": "true" });
+                } catch (e) {
+                    Telemetry.logDebuggerEvent("buildAndDebug", { "success": "false" });
+                }
             } catch (e) {
                 try {
                     vscode.debug.startDebugging(folder, selection.configuration);
+                    Telemetry.logDebuggerEvent("buildAndDebug", { "success": "true" });
                 } catch (e) {
                     Telemetry.logDebuggerEvent("buildAndDebug", { "success": "false" });
                 }


### PR DESCRIPTION
bugfix: https://github.com/microsoft/vscode-cpptools/issues/6071

Open a ".cpp" file in your project folder
Run the command "C/C++: build and debug active file"
Vs Code will throw this error: Configuration 'cl.exe - Build and debug active file' is missing in 'launch.json'.
we won't get his error anymore:
![image](https://user-images.githubusercontent.com/16143955/92019936-3dc60700-ed0c-11ea-98e7-12804ea0cd92.png)
