### PR TITLE
Fix bug with failed downloads not erroring out.

### DIFF
--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -220,7 +220,7 @@ export class PackageManager {
             } catch (error) {
                 retryCount += 1;
                 lastError = error;
-                if (retryCount > MAX_RETRIES) {
+                if (retryCount >= MAX_RETRIES) {
                     this.AppendChannel(" " + localize("failed.download.url", "Failed to download {0}", pkg.url));
                     throw error;
                 } else {


### PR DESCRIPTION
This was causing the integrity checking to not work from https://github.com/microsoft/vscode-cpptools/pull/5978