### PR TITLE
Fix build and debug active file with no .vscode folder on Linux/Mac.

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -676,8 +676,8 @@ export function writeFileText(filePath: string, content: string, encoding: strin
     const folders: string[] = filePath.split(path.sep).slice(0, -1);
     if (folders.length) {
         // create folder path if it doesn't exist
-        folders.reduce((last, folder) => {
-            const folderPath: string = last ? last + path.sep + folder : folder;
+        folders.reduce((previous, folder) => {
+            const folderPath: string = previous + path.sep + folder;
             if (!fs.existsSync(folderPath)) {
                 fs.mkdirSync(folderPath);
             }


### PR DESCRIPTION
On Linux/Mac, the path was missing the "/" at the start for Linux/Mac, causing the call to fs.existsSync to not work correctly.

Follow up to https://github.com/microsoft/vscode-cpptools/pull/6065 .