### PR TITLE
Fix issue with LSP process not getting shut down gracefully

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3103,7 +3103,7 @@ export class DefaultClient implements Client {
     }
 
     public dispose(): Thenable<void> {
-        const promise: Thenable<void> = (this.languageClient && clientCollection.Count === 0) ? this.languageClient.stop() : Promise.resolve();
+        const promise: Thenable<void> = this.languageClient ? this.languageClient.stop() : Promise.resolve();
         return promise.then(() => {
             this.disposables.forEach((d) => d.dispose());
             this.disposables = [];

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -559,7 +559,7 @@ export interface Client {
     handleConfigurationEditUICommand(): void;
     handleAddToIncludePathCommand(path: string): void;
     onInterval(): void;
-    dispose(): Thenable<void>;
+    dispose(): void;
     addFileAssociations(fileAssociations: string, is_c: boolean): void;
     sendDidChangeSettings(settings: any): void;
 }
@@ -3102,33 +3102,34 @@ export class DefaultClient implements Client {
         }
     }
 
-    public dispose(): Thenable<void> {
-        const promise: Thenable<void> = this.languageClient ? this.languageClient.stop() : Promise.resolve();
-        return promise.then(() => {
-            this.disposables.forEach((d) => d.dispose());
-            this.disposables = [];
-            if (this.documentFormattingProviderDisposable) {
-                this.documentFormattingProviderDisposable.dispose();
-                this.documentFormattingProviderDisposable = undefined;
-            }
-            if (this.formattingRangeProviderDisposable) {
-                this.formattingRangeProviderDisposable.dispose();
-                this.formattingRangeProviderDisposable = undefined;
-            }
-            if (this.onTypeFormattingProviderDisposable) {
-                this.onTypeFormattingProviderDisposable.dispose();
-                this.onTypeFormattingProviderDisposable = undefined;
-            }
-            if (this.codeFoldingProviderDisposable) {
-                this.codeFoldingProviderDisposable.dispose();
-                this.codeFoldingProviderDisposable = undefined;
-            }
-            if (this.semanticTokensProviderDisposable) {
-                this.semanticTokensProviderDisposable.dispose();
-                this.semanticTokensProviderDisposable = undefined;
-            }
-            this.model.dispose();
-        });
+    public dispose(): void {
+        this.disposables.forEach((d) => d.dispose());
+        this.disposables = [];
+        if (this.documentFormattingProviderDisposable) {
+            this.documentFormattingProviderDisposable.dispose();
+            this.documentFormattingProviderDisposable = undefined;
+        }
+        if (this.formattingRangeProviderDisposable) {
+            this.formattingRangeProviderDisposable.dispose();
+            this.formattingRangeProviderDisposable = undefined;
+        }
+        if (this.onTypeFormattingProviderDisposable) {
+            this.onTypeFormattingProviderDisposable.dispose();
+            this.onTypeFormattingProviderDisposable = undefined;
+        }
+        if (this.codeFoldingProviderDisposable) {
+            this.codeFoldingProviderDisposable.dispose();
+            this.codeFoldingProviderDisposable = undefined;
+        }
+        if (this.semanticTokensProviderDisposable) {
+            this.semanticTokensProviderDisposable.dispose();
+            this.semanticTokensProviderDisposable = undefined;
+        }
+        this.model.dispose();
+    }
+
+    public static stopLanguageClient(): Thenable<void> {
+        return languageClient ? languageClient.stop() : Promise.resolve();
     }
 
     public handleReferencesIcon(): void {
@@ -3254,10 +3255,9 @@ class NullClient implements Client {
     handleConfigurationEditUICommand(): void {}
     handleAddToIncludePathCommand(path: string): void {}
     onInterval(): void {}
-    dispose(): Thenable<void> {
+    dispose(): void {
         this.booleanEvent.dispose();
         this.stringEvent.dispose();
-        return Promise.resolve();
     }
     addFileAssociations(fileAssociations: string, is_c: boolean): void {}
     sendDidChangeSettings(settings: any): void {}

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -206,14 +206,12 @@ export class ClientCollection {
     }
 
     public dispose(): Thenable<void> {
-        const promises: Thenable<void>[] = [];
         this.disposables.forEach((d: vscode.Disposable) => d.dispose());
 
         // this.defaultClient is already in this.languageClients, so do not call dispose() on it.
-
-        this.languageClients.forEach(client => promises.push(client.dispose()));
+        this.languageClients.forEach(client => client.dispose());
         this.languageClients.clear();
         cpptools.disposeWorkspaceData();
-        return Promise.all(promises).then(() => undefined);
+        return cpptools.DefaultClient.stopLanguageClient();
     }
 }


### PR DESCRIPTION
This addresses an issue with how we were shutting down the LSP process.  We were not calling stop() due to an incorrect check, resulting in the shutdown message never being delivered to the LSP process.  This actually only impacted Windows users (likely causing frequent database rebuilds, as safety checks failed), due to Windows killing all child processes as VS Code terminates.  On Mac and Linux, the native process continued to execute, and gracefully shut down (and closed the DB properly) due to closing of std::cin.