### PR TITLE
remove extra telemtery

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -507,9 +507,6 @@ export function getInstalledBinaryPlatform(): string | undefined {
     } else if (checkFileExistsSync(path.join(extensionPath, "LLVM/bin/clang-format"))) {
         installedPlatform = "linux";
     }
-    if (!installedPlatform) {
-        Telemetry.logLanguageServerEvent("missingBinary", { "source": "clang-format" });
-    }
     return installedPlatform;
 }
 

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -86,7 +86,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
                 vscode.env.openExternal(vscode.Uri.parse(releaseDownloadUrl));
             }
         });
-    } else if (!installedPlatform || !(await util.checkInstallBinariesExist())) {
+    } else if (!(await util.checkInstallBinariesExist())) {
         errMsg = localize("extension.installation.failed", "The C/C++ extension failed to install successfully. You will need to repair or reinstall the extension for C/C++ language features to function properly.");
         const reload: string = localize("remove.extension", "Attempt to Repair");
         vscode.window.showErrorMessage(errMsg, reload).then(async (value?: string) => {


### PR DESCRIPTION
don't send telemetry when the "_installed platform"_ is unknown (we will send telemetry later based on the "_user's platform_"). 
bugfix: https://github.com/microsoft/vscode-cpptools/issues/6198