### PR TITLE
Adds workflows/configs for some GitHub Actions provided by vscode-github-triage-actions

### DIFF
--- a/.github/workflows/feature-request.yml
+++ b/.github/workflows/feature-request.yml
@@ -1,0 +1,38 @@
+name: Feature Request Manager
+on:
+  schedule:
+    - cron: 0 11 * * * # Run at 11 AM UTC (3 AM PST, 4 AM PDT)
+  issues:
+    types: [milestoned]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        if: github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'Feature Request')
+        uses: actions/checkout@v2
+        with:
+          repository: 'microsoft/vscode-github-triage-actions'
+          path: ./actions
+          ref: v35
+      - name: Install Actions
+        if: github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'Feature Request')
+        run: npm install --production --prefix ./actions
+      - name: Run Feature Request Manager
+        if: github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'Feature Request')
+        uses: ./actions/feature-request
+        with:
+          candidateMilestoneID: 30
+          candidateMilestoneName: Triage
+          backlogMilestoneID: 28
+          featureRequestLabel: feature-request
+          upvotesRequired: 20
+          numCommentsOverride: 20
+          initComment: "This feature request is now a candidate for our backlog. The community has 60 days to upvote the issue. If it receives 20 upvotes we will move it to our backlog. If not, we will close it.\n\nHappy Coding!"
+          warnComment: "This feature request has not yet received the 20 community [upvotes](https://github.com/microsoft/vscode/wiki/Issues-Triaging#up-voting-a-feature-request) it takes to make to our backlog. 10 days to go.\n\nHappy Coding!"
+          acceptComment: ":slightly_smiling_face: This feature request received a sufficient number of community upvotes and we moved it to our backlog.\n\nHappy Coding!"
+          rejectComment: ":slightly_frowning_face: In the last 60 days, this feature request has received less than 20 community upvotes and we closed it. Still a big Thank You to you for taking the time to create this issue!\n\nHappy Coding!"
+          warnDays: 10
+          closeDays: 60
+          milestoneDelaySeconds: 60

--- a/.github/workflows/feature-request.yml
+++ b/.github/workflows/feature-request.yml
@@ -1,7 +1,7 @@
 name: Feature Request Manager
 on:
   schedule:
-    - cron: 0 11 * * * # Run at 11 AM UTC (3 AM PST, 4 AM PDT)
+    - cron: 40 11 * * * # Run at 11:40 AM UTC (3:40 AM PST, 4:40 AM PDT)
   issues:
     types: [milestoned]
 
@@ -26,13 +26,13 @@ jobs:
           candidateMilestoneID: 30
           candidateMilestoneName: Triage
           backlogMilestoneID: 28
-          featureRequestLabel: feature-request
-          upvotesRequired: 20
+          featureRequestLabel: Feature Request
+          upvotesRequired: 2
           numCommentsOverride: 20
           initComment: "This feature request is now a candidate for our backlog. The community has 60 days to upvote the issue. If it receives 20 upvotes we will move it to our backlog. If not, we will close it.\n\nHappy Coding!"
-          warnComment: "This feature request has not yet received the 20 community [upvotes](https://github.com/microsoft/vscode/wiki/Issues-Triaging#up-voting-a-feature-request) it takes to make to our backlog. 10 days to go.\n\nHappy Coding!"
+          warnComment: "This feature request has not yet received the 2 community upvotes it takes to make it to our backlog. 10 days to go.\n\nHappy Coding!"
           acceptComment: ":slightly_smiling_face: This feature request received a sufficient number of community upvotes and we moved it to our backlog.\n\nHappy Coding!"
-          rejectComment: ":slightly_frowning_face: In the last 60 days, this feature request has received less than 20 community upvotes and we closed it. Still a big Thank You to you for taking the time to create this issue!\n\nHappy Coding!"
+          rejectComment: ":slightly_frowning_face: In the last 60 days, this feature request has received less than 2 community upvotes and we closed it. Still a big Thank You to you for taking the time to create this issue!\n\nHappy Coding!"
           warnDays: 10
           closeDays: 60
           milestoneDelaySeconds: 60

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,0 +1,23 @@
+name: Locker
+on:
+  schedule:
+    - cron: 0 11 * * * # Run at 11 AM UTC (3 AM PST, 4 AM PDT)
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'microsoft/vscode-github-triage-actions'
+          path: ./actions
+          ref: v35
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Locker
+        uses: ./actions/locker
+        with:
+          daysSinceClose: 45
+          daysSinceUpdate: 3
+          ignoredLabel: "*more votes needed"

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,7 +1,7 @@
 name: Locker
 on:
   schedule:
-    - cron: 0 11 * * * # Run at 11 AM UTC (3 AM PST, 4 AM PDT)
+    - cron: 30 11 * * * # Run at 11:30 AM UTC (3:30 AM PST, 4:30 AM PDT)
 
 jobs:
   main:
@@ -20,4 +20,4 @@ jobs:
         with:
           daysSinceClose: 45
           daysSinceUpdate: 3
-          ignoredLabel: "*more votes needed"
+          ignoredLabel: "more votes needed"

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -1,0 +1,25 @@
+name: Needs More Info Closer
+on:
+  schedule:
+    - cron: 0 1 * * * # 1 AM (UTC?)
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'microsoft/vscode-github-triage-actions'
+          path: ./actions
+          ref: v35
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Needs More Info Closer
+        uses: ./actions/needs-more-info-closer
+        with:
+          label: more info needed
+          closeDays: 7
+          closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity.\n\nHappy Coding!"
+          pingDays: 80
+          pingComment: "Hey @${assignee}, this issue might need further attention.\n\n@${author}, you can help us out by closing this issue if the problem no longer exists, or adding more information."

--- a/.github/workflows/question-closer.yml
+++ b/.github/workflows/question-closer.yml
@@ -1,7 +1,7 @@
-name: Needs More Info Closer
+name: Question Closer
 on:
   schedule:
-    - cron: 10 11 * * * # Run at 11:10 AM UTC (3:10 AM PST, 4:10 AM PDT)
+    - cron: 20 11 * * * # Run at 11:20 AM UTC (3:20 AM PST, 4:20 AM PDT)
 
 jobs:
   main:
@@ -18,8 +18,8 @@ jobs:
       - name: Run Needs More Info Closer
         uses: ./actions/needs-more-info-closer
         with:
-          label: more info needed
+          label: question
           closeDays: 14
-          closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity.\n\nHappy Coding!"
+          closeComment: "This issue has been closed automatically because it's labeled as a 'question' and has not had recent activity.\n\nHappy Coding!"
           pingDays: 80
-          pingComment: "Hey @${assignee}, this issue might need further attention.\n\n@${author}, you can help us out by closing this issue if the problem no longer exists, or adding more information."
+          pingComment: "Hey @${assignee}, this issue might need further attention.\n\n@${author}, you can help us out by closing this issue if the question has been answered."


### PR DESCRIPTION
Adds workflows/configs for some GitHub Actions provided by vscode-github-triage-actions

Documentation on these actions are here: https://github.com/microsoft/vscode-github-triage-actions

For comparison, VS Code's workflows/configs for these actions are here: https://github.com/microsoft/vscode/tree/master/.github/workflows


 * Locker - Locks a closed issue after it has been closed for a period of time, and there has been no activity for a period of time.
Hosted here: https://github.com/microsoft/vscode-github-triage-actions/tree/master/locker

 * Needs More Info Closer - If an issue labeled with "need more info" has had no activity for more than a specific period of time, it is either closed (with a message to the user), or, if there is an assignee and the last commenter was not someone with write or admin permissions to the repo, a comment is added which pings both the author and assignee.
Hosted here: https://github.com/microsoft/vscode-github-triage-actions/tree/master/needs-more-info-closer

 * Question Closer - This is actually the same underlying action as Needs More Info Closer, but configured to close issues labeled with "question", and with different comment messages.

 * Feature Request - As currently configured, if an issue with the "Feature Request" label is in the Triage milestone, a comment will be posted that we are considering the issue for our backlog, but that it requires some number of votes.  If that number of votes has not been reached after 10 days, a warning comment is posted indicating that there are not yet enough votes.  After 60 days, if the issue has received enough votes, it's moved to the "Backlog" milestone.  If it hasn't receive enough votes, it's closed.  (Locker is configured not to lock issues with a "more votes needed" label, so users will still be able to vote).
Hosted here: https://github.com/microsoft/vscode-github-triage-actions/tree/master/feature-request

The comment messages are relatively unchanged from VS Code's use.  References to guidence specific to the vscode repo have been removed.
