### PR TITLE
Add timestamps to config warning output

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -134,7 +134,7 @@ function showWarning(params: ShowWarningParams): void {
         warningChannel = vscode.window.createOutputChannel(`${localize("c.cpp.warnings", "C/C++ Configuration Warnings")}`);
         workspaceDisposables.push(warningChannel);
     }
-    warningChannel.appendLine(`[${new Date().toLocaleString()}] ` + message);
+    warningChannel.appendLine(`[${new Date().toLocaleString()}] ${message}`);
     warningChannel.show(false);
 }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -134,7 +134,7 @@ function showWarning(params: ShowWarningParams): void {
         warningChannel = vscode.window.createOutputChannel(`${localize("c.cpp.warnings", "C/C++ Configuration Warnings")}`);
         workspaceDisposables.push(warningChannel);
     }
-    warningChannel.appendLine(message);
+    warningChannel.appendLine(`[${new Date().toLocaleString()}] ` + message);
     warningChannel.show(false);
 }
 


### PR DESCRIPTION
Adds a timestamp to config warning output.  i.e. :
```
[10/12/2020, 4:23:59 PM] "${workspaceFolder}\build\compile_commands.json" could not be found. 'includePath' from c_cpp_properties.json in folder 'test2' will be used instead.
```