### PR TITLE
Fix 'Build and Debug Active File' race condition with EngineLogs

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -274,6 +274,8 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
             const outputChannel: logger.Logger = logger.getOutputChannelLogger();
             outputChannel.appendLine(localize("debugger.launchConfig", "Launch configuration:"));
             outputChannel.appendLine(JSON.stringify(config, undefined, 2));
+	    // TODO: Enable when https://github.com/microsoft/vscode/issues/108619 is resolved.
+	    // logger.showOutputChannel();
         }
 
         return config;

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -274,7 +274,6 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
             const outputChannel: logger.Logger = logger.getOutputChannelLogger();
             outputChannel.appendLine(localize("debugger.launchConfig", "Launch configuration:"));
             outputChannel.appendLine(JSON.stringify(config, undefined, 2));
-            logger.showOutputChannel();
         }
 
         return config;


### PR DESCRIPTION
If users use 'Build and Debug Active File' with "engineLogging", the resolveDebugConfigurations will quickly switch to the output window and `${fileBasenameNoExtension}` will resolve to something similar to `./extension-output-#5`.

This may be a bug with VS Code determining the output window to be a file, but this will unblock users who need to enable engine logging for this scenario.

Example broken task.json
```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "g++ - Build and debug active file",
            "type": "cppdbg",
            "request": "launch",
            "program": "${fileDirname}/${fileBasenameNoExtension}",
            "args": [],
            "stopAtEntry": false,
            "cwd": "${workspaceFolder}",
            "environment": [],
            "externalConsole": false,
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ],
            "preLaunchTask": "C/C++: g++ build active file",
            "miDebuggerPath": "/usr/bin/gdb",
            "logging": {
                "engineLogging": true
            }
        }
    ]
}
```

Will result in:
```
g++: error: extension-output-#5: No such file or directory
g++: fatal error: no input files
compilation terminated.
The terminal process "/bin/bash '-c', '/usr/bin/g++ -g extension-output-#5 -o ./extension-output-#5'" failed to launch (exit code: 1).
```