### PR TITLE
Regenerate action JS files

### DIFF
--- a/.github/actions/Locker/Locker.js
+++ b/.github/actions/Locker/Locker.js
@@ -17,7 +17,7 @@ class Locker extends ActionBase_1.ActionBase {
     async run() {
         const closedTimestamp = utils_1.daysAgoToHumanReadbleDate(this.daysSinceClose);
         const updatedTimestamp = utils_1.daysAgoToHumanReadbleDate(this.daysSinceUpdate);
-        const query = this.buildQuery((this.daysSinceClose ? `closed:<${updatedTimestamp} ` : "") + (this.daysSinceUpdate ? `updated:<${updatedTimestamp} ` : "") + "is:closed is:unlocked");
+        const query = this.buildQuery((this.daysSinceClose ? `closed:<${closedTimestamp} ` : "") + (this.daysSinceUpdate ? `updated:<${updatedTimestamp} ` : "") + "is:closed is:unlocked");
         for await (const page of this.github.query({ q: query })) {
             await Promise.all(page.map(async (issue) => {
                 const hydrated = await issue.getIssue();

--- a/.github/actions/common/utils.js
+++ b/.github/actions/common/utils.js
@@ -57,11 +57,8 @@ exports.getRateLimit = async (token) => {
 exports.errorLoggingIssue = (() => {
     try {
         const repo = github_1.context.repo.owner.toLowerCase() + '/' + github_1.context.repo.repo.toLowerCase();
-        if (repo === 'microsoft/vscode' || repo === 'microsoft/vscode-remote-release') {
-            return { repo: 'vscode', owner: 'Microsoft', issue: 93814 };
-        }
-        else if (/microsoft\//.test(repo)) {
-            return { repo: 'vscode-internalbacklog', owner: 'Microsoft', issue: 974 };
+        if (repo === 'microsoft/vscode-cpptools') {
+            return { repo: 'vscode-cpptools', owner: 'Microsoft', issue: 6282 };
         }
         else if (exports.getInput('errorLogIssueNumber')) {
             return { ...github_1.context.repo, issue: +exports.getRequiredInput('errorLogIssueNumber') };


### PR DESCRIPTION
The actions I copied from VS Code's action repo don't compiler TS on the fly.  Instead, JS files are checked in.  Those JS files were not regenerated after a couple of previous fixes.