### PR TITLE
Prevent config warnings from stealing user focus

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -135,7 +135,7 @@ function showWarning(params: ShowWarningParams): void {
         workspaceDisposables.push(warningChannel);
     }
     warningChannel.appendLine(`[${new Date().toLocaleString()}] ${message}`);
-    warningChannel.show(false);
+    warningChannel.show(true);
 }
 
 function publishDiagnostics(params: PublishDiagnosticsParams): void {


### PR DESCRIPTION
Partial fix for: https://github.com/microsoft/vscode-cpptools/issues/6308
