### PR TITLE
Use 'resolveDebugConfigWithSubVariables'

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -88,8 +88,8 @@ export class QuickPickConfigurationProvider implements vscode.DebugConfiguration
         return [selection.configuration];
     }
 
-    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-        return this.underlyingProvider.resolveDebugConfiguration ? this.underlyingProvider.resolveDebugConfiguration(folder, config, token) : undefined;
+    resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+        return this.underlyingProvider.resolveDebugConfigurationWithSubstitutedVariables ? this.underlyingProvider.resolveDebugConfigurationWithSubstitutedVariables(folder, config, token) : undefined;
     }
 }
 
@@ -188,7 +188,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
     /**
 	 * Try to add all missing attributes to the debug configuration being launched.
 	 */
-    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+    resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
         // [Microsoft/vscode#54213] If config or type is not specified, return null to trigger VS Code to open a configuration file.
         if (!config || !config.type) {
             return null;
@@ -274,8 +274,7 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
             const outputChannel: logger.Logger = logger.getOutputChannelLogger();
             outputChannel.appendLine(localize("debugger.launchConfig", "Launch configuration:"));
             outputChannel.appendLine(JSON.stringify(config, undefined, 2));
-	    // TODO: Enable when https://github.com/microsoft/vscode/issues/108619 is resolved.
-	    // logger.showOutputChannel();
+            logger.showOutputChannel();
         }
 
         return config;


### PR DESCRIPTION
This PR uses the
[DebugConfigurationProvider.resolveDebugConfigurationWithSubstitutedVariables](https://github.com/microsoft/vscode/issues/87450)
which allows the debug configuration to wait for the `preLaunchTask` to
complete before continuing on and resolving environment variables or processes
 that may have been set in the 'tasks.json'.

This also resolves the logging issue where the 'Build and Debug Active
File' preLaunchTask uses the current file but we switch to the output
window for logging.

Undo: https://github.com/microsoft/vscode-cpptools/pull/6304 but VS Code bug is still valid. 

Related Issues: #5287