### PR TITLE
Action bug fixes

### DIFF
--- a/.github/actions/StaleCloser/StaleCloser.js
+++ b/.github/actions/StaleCloser/StaleCloser.js
@@ -39,15 +39,17 @@ class StaleCloser extends ActionBase_1.ActionBase {
                 ) {
                     if (!lastComment ||
                         lastComment.author.isGitHubApp ||
+                        pingTimestamp == undefined ||
                         // TODO: List the collaborators once per go rather than checking a single user each issue
-                        (pingTimestamp != undefined &&
-                            (this.additionalTeam.includes(lastComment.author.name) ||
-                                (await issue.hasWriteAccess(lastComment.author))))) {
-                        if (lastComment) {
-                            console.log(`Last comment on issue ${hydrated.number} by ${lastComment.author.name}. Closing.`);
-                        }
-                        else {
-                            console.log(`No comments on issue ${hydrated.number}. Closing.`);
+                        this.additionalTeam.includes(lastComment.author.name) ||
+                        await issue.hasWriteAccess(lastComment.author)) {
+                        if (pingTimestamp != undefined) {
+                            if (lastComment) {
+                                console.log(`Last comment on issue ${hydrated.number} by ${lastComment.author.name}. Closing.`);
+                            }
+                            else {
+                                console.log(`No comments on issue ${hydrated.number}. Closing.`);
+                            }
                         }
                         if (this.closeComment) {
                             console.log(`Posting comment on issue ${hydrated.number}`);
@@ -76,7 +78,7 @@ class StaleCloser extends ActionBase_1.ActionBase {
                         }
                         console.log(`Closing issue ${hydrated.number}.`);
                     }
-                    else if (pingTimestamp != undefined) {
+                    else {
                         // Ping 
                         if (hydrated.updatedAt < pingTimestamp && hydrated.assignee) {
                             console.log(`Last comment on issue ${hydrated.number} by ${lastComment.author.name}. Pinging @${hydrated.assignee}`);

--- a/.github/actions/StaleCloser/StaleCloser.ts
+++ b/.github/actions/StaleCloser/StaleCloser.ts
@@ -55,17 +55,19 @@ export class StaleCloser extends ActionBase {
 					if (
 						!lastComment ||
 						lastComment.author.isGitHubApp ||
+						pingTimestamp == undefined ||
 						// TODO: List the collaborators once per go rather than checking a single user each issue
-						(pingTimestamp != undefined &&
-							(this.additionalTeam.includes(lastComment.author.name) ||
-							(await issue.hasWriteAccess(lastComment.author))))
+						this.additionalTeam.includes(lastComment.author.name) ||
+						await issue.hasWriteAccess(lastComment.author)
 					) {
-						if (lastComment) {
-							console.log(
-								`Last comment on issue ${hydrated.number} by ${lastComment.author.name}. Closing.`,
-							)
-						} else {
-							console.log(`No comments on issue ${hydrated.number}. Closing.`)
+						if (pingTimestamp != undefined) {
+							if (lastComment) {
+								console.log(
+									`Last comment on issue ${hydrated.number} by ${lastComment.author.name}. Closing.`,
+								)
+							} else {
+								console.log(`No comments on issue ${hydrated.number}. Closing.`)
+							}
 						}
 						if (this.closeComment) {
 							console.log(`Posting comment on issue ${hydrated.number}`)
@@ -93,7 +95,7 @@ export class StaleCloser extends ActionBase {
 							await issue.setMilestone(+this.setMilestoneId)
 						}
 						console.log(`Closing issue ${hydrated.number}.`)
-					} else if (pingTimestamp != undefined) {
+					} else {
 						// Ping 
 						if (hydrated.updatedAt < pingTimestamp && hydrated.assignee) {
 							console.log(

--- a/.github/actions/common/ActionBase.js
+++ b/.github/actions/common/ActionBase.js
@@ -37,8 +37,9 @@ class ActionBase {
         // The name is used to construct the query, which does not accept ID.
         // The ID is used for comparisons with issue data, which does not include the name.
         // TODO: Figure out a way to convert either from milestone name to ID, or vice versa.
-        // If inclusion and exclusion are mixed, exclusion will take precedence.
+        // If label inclusion and exclusion are mixed, exclusion will take precedence.
         // For example, an issue with both labels A and B will not match if B is excluded, even if A is included.
+        // If a milestoneName/milestoneId are set, ignoreMilenameName/ignoreMilestoneIds are ignored.
         // GitHub does not appear to support searching for all issues with milestones (not lacking a milestone).  "-no:milestone" does not work.
         // GitHub does not appear to support searching for all issues with labels (not lacking a label).  "-no:label" does not work.
         // All indicated labels must be present
@@ -64,8 +65,11 @@ class ActionBase {
                 }
             }
         }
-        if (this.ignoreMilestoneNames) {
-            if (this.ignoreMilestoneNames == "*" && !this.milestoneName) { // only if no milestone
+        if (this.milestoneName) {
+            query = query.concat(` milestone:"${this.milestoneName}"`);
+        }
+        else if (this.ignoreMilestoneNames) {
+            if (this.ignoreMilestoneNames == "*") {
                 query = query.concat(` no:milestone`);
                 this.ignoreAllWithMilestones = true;
             }

--- a/.github/actions/common/ActionBase.ts
+++ b/.github/actions/common/ActionBase.ts
@@ -41,8 +41,10 @@ export class ActionBase {
 		// The ID is used for comparisons with issue data, which does not include the name.
 		// TODO: Figure out a way to convert either from milestone name to ID, or vice versa.
 
-		// If inclusion and exclusion are mixed, exclusion will take precedence.
+		// If label inclusion and exclusion are mixed, exclusion will take precedence.
 		// For example, an issue with both labels A and B will not match if B is excluded, even if A is included.
+
+		// If a milestoneName/milestoneId are set, ignoreMilenameName/ignoreMilestoneIds are ignored.
 
 		// GitHub does not appear to support searching for all issues with milestones (not lacking a milestone).  "-no:milestone" does not work.
 		// GitHub does not appear to support searching for all issues with labels (not lacking a label).  "-no:label" does not work.
@@ -71,8 +73,11 @@ export class ActionBase {
 			}
 		}
 
-		if (this.ignoreMilestoneNames) {
-			if (this.ignoreMilestoneNames == "*" && !this.milestoneName) { // only if no milestone
+		if (this.milestoneName) {
+			query = query.concat(` milestone:"${this.milestoneName}"`)
+		}
+		else if (this.ignoreMilestoneNames) {
+			if (this.ignoreMilestoneNames == "*") {
 				query = query.concat(` no:milestone`)
 				this.ignoreAllWithMilestones = true;
 			} else if (this.ignoreMilestoneIds) {


### PR DESCRIPTION
* Fixed issue with milestone query not actually being used.  This did not surface as an issue, because there is a validation phase that ensure the actions match the criteria, which was properly excluding non-matching issue.  (That validation phase is necessary, as GitHub sometimes returns incorrect results).
* Fix an issue with Feature Requests not getting closed if a user was the last to add a comment, despite assignee ping not being enabled (pingDays unset).
* Avoid logging out who left the last comment, if not using pingDays.