### PR TITLE
setup time (one line change)

### DIFF
--- a/Extension/src/LanguageServer/timeTelemetryCollector.ts
+++ b/Extension/src/LanguageServer/timeTelemetryCollector.ts
@@ -69,7 +69,7 @@ export class TimeTelemetryCollector {
         const startTime: number = timeStamps.firstFile ? timeStamps.firstFile : timeStamps.didOpen;
         let properties: any = {};
         let metrics: any = {
-            "setupTime": (timeStamps.setup - startTime),
+            "setupTime": (timeStamps.setup - timeStamps.didOpen),
             "updateRangeTime": (timeStamps.updateRange - timeStamps.setup),
             "totalTime": (timeStamps.updateRange - startTime)
         };


### PR DESCRIPTION
telemetry request: #5759

These are the timestamps:

firstFile: when the extension is activated by realActivation and the active text editor is a c/cpp file. Defined only for "cold" start cases.
didOpen: when the file appears in the editor (all files including the first file). Defined for "warm" start cases.
setup: when the Intellisense_client constructor is completed and we give the control back to the user at the end of textDocument_didOpen in language server side
updateRange: when publishDiagnostics is completed
We defined an extra startTime timestamp: when the extension activates, if the active text document is a c/cpp file, the startTime for this file is set to firstFile timestamp, otherwise it is set to didOpen timestamp.

These are the durations that are being calculated based on timestamps and logged:

activationTime = firstFile - didOpen logged only for the first file (cold start)
setupTime = setup - didOpen
updateRangeTime = updateRange - setup
totalTime = updateRange - startTime
there is a related pull request on the native side.