### PR TITLE
don't overwrite options and args

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix issue with compiler querying not handling various clang command line options correctly. [6359](https://github.com/microsoft/vscode-cpptools/issues/6356)
 * Fix issue where std change warnings were not generated if IntelliSense mode was not set.
 * Fix issue macOS Framework search to only parse the "Current" framework folder when the "Headers" folder is not found. [#2046](https://github.com/microsoft/vscode-cpptools/issues/2046)
+* Fix issue to not overwrite the compiler options and args when building from a custom defined task. [#6366](https://github.com/microsoft/vscode-cpptools/issues/6366)
 
 ## Version 1.1.0-insiders2: October 15, 2020
 ### Bug Fixes

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -163,7 +163,7 @@ export class CppBuildTaskProvider implements TaskProvider {
         if (resolvedcompilerPath && !resolvedcompilerPath.startsWith("\"") && resolvedcompilerPath.includes(" ")) {
             resolvedcompilerPath = "\"" + resolvedcompilerPath + "\"";
         }
-        
+
         if (!definition) {
             const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
             const isWindows: boolean = os.platform() === 'win32';


### PR DESCRIPTION
don't overwrite options and args when building from a custom defined task
bugfix: https://github.com/microsoft/vscode-cpptools/issues/6366