### PR TITLE
Add telemetry for machineId changes and remoteName

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -812,6 +812,20 @@ export class DefaultClient implements Client {
                     this.semanticTokensLegend = new vscode.SemanticTokensLegend(tokenTypesLegend, tokenModifiersLegend);
 
                     if (firstClient) {
+                        // Don't log telemetry for machineId if it's a special value used by the dev host: someValue.machineid
+                        if (vscode.env.machineId !== "someValue.machineId") {
+                            const machineIdPersistentState: PersistentState<string | undefined> = new PersistentState<string | undefined>("CPP.machineId", undefined);
+                            if (!machineIdPersistentState.Value) {
+                                telemetry.logLanguageServerEvent("NewMachineID", { "machineId": vscode.env.machineId });
+                            } else if (machineIdPersistentState.Value !== vscode.env.machineId) {
+                                telemetry.logLanguageServerEvent("MachineIDChanged", { "machineId": vscode.env.machineId });
+                            }
+                            machineIdPersistentState.Value = vscode.env.machineId;
+                        }
+                        if (vscode.env.remoteName) {
+                            telemetry.logLanguageServerEvent("RemoteName", { "remoteName": vscode.env.remoteName });
+                        }
+
                         workspaceReferences = new refs.ReferencesManager(this);
 
                         // The configurations will not be sent to the language server until the default include paths and frameworks have been set.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -812,20 +812,6 @@ export class DefaultClient implements Client {
                     this.semanticTokensLegend = new vscode.SemanticTokensLegend(tokenTypesLegend, tokenModifiersLegend);
 
                     if (firstClient) {
-                        // Don't log telemetry for machineId if it's a special value used by the dev host: someValue.machineid
-                        if (vscode.env.machineId !== "someValue.machineId") {
-                            const machineIdPersistentState: PersistentState<string | undefined> = new PersistentState<string | undefined>("CPP.machineId", undefined);
-                            if (!machineIdPersistentState.Value) {
-                                telemetry.logLanguageServerEvent("NewMachineID", { "machineId": vscode.env.machineId });
-                            } else if (machineIdPersistentState.Value !== vscode.env.machineId) {
-                                telemetry.logLanguageServerEvent("MachineIDChanged", { "machineId": vscode.env.machineId });
-                            }
-                            machineIdPersistentState.Value = vscode.env.machineId;
-                        }
-                        if (vscode.env.remoteName) {
-                            telemetry.logLanguageServerEvent("RemoteName", { "remoteName": vscode.env.remoteName });
-                        }
-
                         workspaceReferences = new refs.ReferencesManager(this);
 
                         // The configurations will not be sent to the language server until the default include paths and frameworks have been set.

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -283,11 +283,11 @@ function sendActivationTelemetry(): void {
 }
 
 function realActivation(): void {
-    sendActivationTelemetry();
     if (new CppSettings().intelliSenseEngine === "Disabled") {
         throw new Error(intelliSenseDisabledError);
     } else {
         console.log("activating extension");
+        sendActivationTelemetry();
         const checkForConflictingExtensions: PersistentState<boolean> = new PersistentState<boolean>("CPP." + util.packageJson.version + ".checkForConflictingExtensions", true);
         if (checkForConflictingExtensions.Value) {
             checkForConflictingExtensions.Value = false;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -263,7 +263,27 @@ function onActivationEvent(): void {
     activatedPreviously.Value = true;
 }
 
+function sendActivationTelemetry(): void {
+    const activateEvent: { [key: string]: string } = {};
+    // Don't log telemetry for machineId if it's a special value used by the dev host: someValue.machineid
+    if (vscode.env.machineId !== "someValue.machineId") {
+        const machineIdPersistentState: PersistentState<string | undefined> = new PersistentState<string | undefined>("CPP.machineId", undefined);
+        if (!machineIdPersistentState.Value) {
+            activateEvent["newMachineId"] = vscode.env.machineId;
+        } else if (machineIdPersistentState.Value !== vscode.env.machineId) {
+            activateEvent["newMachineId"] = vscode.env.machineId;
+            activateEvent["oldMachineId"] = machineIdPersistentState.Value;
+        }
+        machineIdPersistentState.Value = vscode.env.machineId;
+    }
+    if (vscode.env.remoteName) {
+        activateEvent["remoteName"] = vscode.env.remoteName;
+    }
+    telemetry.logLanguageServerEvent("Activate", activateEvent);
+}
+
 function realActivation(): void {
+    sendActivationTelemetry();
     if (new CppSettings().intelliSenseEngine === "Disabled") {
         throw new Error(intelliSenseDisabledError);
     } else {


### PR DESCRIPTION
Bob requested logging of the machineId and if it changes, as well as the remoteName, per session.