### PR TITLE
show compiler paths in "C/C++ build and debug active file"

### DIFF
--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -74,9 +74,9 @@ export function initialize(context: vscode.ExtensionContext): void {
             configuration: vscode.DebugConfiguration;
         }
 
-        const items: MenuItem[] = configs.map<MenuItem>(config => ({label: config.name, configuration: config}));
+        const items: MenuItem[] = configs.map<MenuItem>(config => ({ label: config.name, configuration: config, description: config.detail }));
 
-        vscode.window.showQuickPick(items, {placeHolder: (items.length === 0 ? localize("no.compiler.found", "No compiler found") : localize("select.compiler", "Select a compiler"))}).then(async selection => {
+        vscode.window.showQuickPick(items, { placeHolder: (items.length === 0 ? localize("no.compiler.found", "No compiler found") : localize("select.configuration", "Select a configuration")) }).then(async selection => {
             if (!selection) {
                 return; // User canceled it.
             }


### PR DESCRIPTION
bug fix: https://github.com/microsoft/vscode-cpptools/issues/6376
1. Modify the menu description from `select a compiler` into `select a configuration` to be compatible with "Run and Debug" menu.

2. Show details of the tasks as below:
![image](https://user-images.githubusercontent.com/16143955/98053828-5f1ba000-1dee-11eb-825c-d02764546549.png)
