### PR TITLE
Add string for log message regarding compiler probeability

### DIFF
--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -218,5 +218,6 @@
     "detected_language_standard_version": "Detected language standard version: {0}",
     "unhandled_default_target_detected": "Unhandled default compiler target value detected: {0}",
     "unhandled_target_arg_detected": "Unhandled target argument value detected: {0}",
-    "memory_limit_shutting_down_intellisense": "Shutting down IntelliSense server: {0}. Memory usage is {1} MB and has exceeded the {2} MB limit."
+    "memory_limit_shutting_down_intellisense": "Shutting down IntelliSense server: {0}. Memory usage is {1} MB and has exceeded the {2} MB limit.",
+    "failed_to_probe_for_standard_version": "Failed to probe compilerPath \"{0}\" for default standard versions.  Probing is disabled for this compiler."
 }

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -219,5 +219,6 @@
     "unhandled_default_target_detected": "Unhandled default compiler target value detected: {0}",
     "unhandled_target_arg_detected": "Unhandled target argument value detected: {0}",
     "memory_limit_shutting_down_intellisense": "Shutting down IntelliSense server: {0}. Memory usage is {1} MB and has exceeded the {2} MB limit.",
-    "failed_to_probe_for_standard_version": "Failed to probe compilerPath \"{0}\" for default standard versions.  Probing is disabled for this compiler."
+    "failed_to_probe_for_standard_version": "Failed to probe compilerPath \"{0}\" for default standard versions.  Probing is disabled for this compiler.",
+    "unrecognized_language_standard_version": "Compiler probe returned an unrecognized language standard version.  The latest supported version will be used instead."
 }


### PR DESCRIPTION
Add a localized string for new error message.  The rest of this change is on the native side.