### PR TITLE
Replace uses of process.env.HOME with os.homedir()

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1068,10 +1068,7 @@ function onShowRefCommand(arg?: TreeNode): void {
 function reportMacCrashes(): void {
     if (process.platform === "darwin") {
         prevCrashFile = "";
-        const home: string | undefined = process.env.HOME;
-        if (!home) {
-            return;
-        }
+        const home: string = os.homedir();
         const crashFolder: string = path.resolve(home, "Library/Logs/DiagnosticReports");
         fs.stat(crashFolder, (err, stats) => {
             const crashObject: { [key: string]: string } = {};

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -352,9 +352,7 @@ export function resolveVariables(input: string | undefined, additionalEnvironmen
 
     // Resolve '~' at the start of the path.
     regexp = () => /^\~/g;
-    ret = ret.replace(regexp(), (match: string, name: string) => {
-        return os.homedir();
-    });
+    ret = ret.replace(regexp(), (match: string, name: string) => os.homedir());
 
     return ret;
 }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -126,10 +126,7 @@ export function getVcpkgPathDescriptorFile(): string {
         }
         return path.join(pathPrefix, "vcpkg/vcpkg.path.txt");
     } else {
-        const pathPrefix: string | undefined = process.env.HOME;
-        if (!pathPrefix) {
-            throw new Error("Unable to read process.env.HOME");
-        }
+        const pathPrefix: string = os.homedir();
         return path.join(pathPrefix, ".vcpkg/vcpkg.path.txt");
     }
 }
@@ -356,8 +353,7 @@ export function resolveVariables(input: string | undefined, additionalEnvironmen
     // Resolve '~' at the start of the path.
     regexp = () => /^\~/g;
     ret = ret.replace(regexp(), (match: string, name: string) => {
-        const newValue: string | undefined = (process.platform === 'win32') ? process.env.USERPROFILE : process.env.HOME;
-        return newValue ? newValue : match;
+        return os.homedir();
     });
 
     return ret;

--- a/Extension/test/unitTests/common.test.ts
+++ b/Extension/test/unitTests/common.test.ts
@@ -3,12 +3,13 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as assert from "assert";
+import * as os from "os";
 import { envDelimiter, resolveVariables, escapeForSquiggles } from "../../src/common";
 
 suite("Common Utility validation", () => {
     suite("resolveVariables", () => {
         const success: string = "success";
-        const home: string = process.env.HOME || process.env.USERPROFILE;
+        const home: string = os.homedir();
 
         test("raw input", () => {
             const input: string = "test";


### PR DESCRIPTION
It's possible for `process.env.HOME` to fail.  os.homedir() is built into node, and seems to be the proper way to get the home directory.

I see various recommendations on the web to use os.homedir() instead of process.env.HOME, suggesting that it's more portable.  Looking at the code to node.js, it appears to leverage uv_os_homedir().  The doc for that mentions:

```
Gets the current user’s home directory. On Windows, uv_os_homedir() first checks the USERPROFILE environment variable using GetEnvironmentVariableW(). If USERPROFILE is not set, GetUserProfileDirectoryW() is called. On all other operating systems, uv_os_homedir() first checks the HOME environment variable using getenv(3). If HOME is not set, getpwuid_r(3) is called.
```
http://docs.libuv.org/en/v1.x/misc.html

Should address: https://github.com/microsoft/vscode-cpptools/issues/6468