### PR TITLE
Fix invalid architectures.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 1.1.1: November 9, 2020
+### Bug Fixes
+* Fix cpptools binaries sometimes not getting installed on Windows. [#6453](https://github.com/microsoft/vscode-cpptools/issues/6453)
+
 ## Version 1.1.0: November 5, 2020
 ### New Features
 * Add language server support for Windows ARM64 (no debugging yet). [#5583](https://github.com/microsoft/vscode-cpptools/issues/5583)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "1.1.0-master",
+  "version": "1.1.1-master",
   "publisher": "ms-vscode",
   "icon": "LanguageCCPP_color_128x.png",
   "readme": "README.md",
@@ -2419,7 +2419,7 @@
         "linux"
       ],
       "architectures": [
-        "x86_64"
+        "x64"
       ],
       "binaries": [
         "./bin/cpptools",
@@ -2476,10 +2476,8 @@
         "win32"
       ],
       "architectures": [
-        "x86_64",
-        "x86",
-        "i686",
-        "i386"
+        "x64",
+        "x86"
       ],
       "binaries": [
         "./bin/cpptools.exe",
@@ -2509,7 +2507,7 @@
         "linux"
       ],
       "architectures": [
-        "x86_64"
+        "x64"
       ],
       "binaries": [
         "./LLVM/bin/clang-format"
@@ -2583,7 +2581,7 @@
         "linux"
       ],
       "architectures": [
-        "x86_64"
+        "x64"
       ],
       "binaries": [
         "./debugAdapters/mono.linux-x86_64"
@@ -2665,10 +2663,8 @@
         "win32"
       ],
       "architectures": [
-        "x86_64",
-        "x86",
-        "i686",
-        "i386"
+        "x64",
+        "x86"
       ],
       "binaries": [
         "./debugAdapters/vsdbg/bin/vsdbg.exe"

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -37,7 +37,7 @@ export function initialize(context: vscode.ExtensionContext): void {
     // On non-windows platforms, the cppvsdbg debugger will not be registered for initial configurations.
     // This will cause it to not show up on the dropdown list.
     let vsdbgProvider: CppVsDbgConfigurationProvider | null = null;
-    if (os.platform() === 'win32' && os.arch() !== 'arm64') {
+    if (os.platform() === 'win32' && process.arch !== 'arm64') {
         vsdbgProvider = new CppVsDbgConfigurationProvider(configurationProvider);
         disposables.push(vscode.debug.registerDebugConfigurationProvider('cppvsdbg', new QuickPickConfigurationProvider(vsdbgProvider)));
     }

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -37,7 +37,7 @@ export function initialize(context: vscode.ExtensionContext): void {
     // On non-windows platforms, the cppvsdbg debugger will not be registered for initial configurations.
     // This will cause it to not show up on the dropdown list.
     let vsdbgProvider: CppVsDbgConfigurationProvider | null = null;
-    if (os.platform() === 'win32' && process.arch !== 'arm64') {
+    if (os.platform() === 'win32' && os.arch() !== 'arm64') {
         vsdbgProvider = new CppVsDbgConfigurationProvider(configurationProvider);
         disposables.push(vscode.debug.registerDebugConfigurationProvider('cppvsdbg', new QuickPickConfigurationProvider(vsdbgProvider)));
     }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -332,7 +332,7 @@ function realActivation(): void {
 
     PlatformInformation.GetPlatformInformation().then(info => {
         // Skip Insiders processing for 32-bit Linux.
-        if (info.platform !== "linux" || info.architecture === "x86_64" || info.architecture === "arm" || info.architecture === "arm64") {
+        if (info.platform !== "linux" || info.architecture === "x64" || info.architecture === "arm" || info.architecture === "arm64") {
             // Skip Insiders processing for unsupported VS Code versions.
             const vscodeVersion: PackageVersion = new PackageVersion(vscode.version);
             const abTestSettings: ABTestSettings = getABTestSettings();

--- a/Extension/src/githubAPI.ts
+++ b/Extension/src/githubAPI.ts
@@ -116,17 +116,15 @@ export function vsixNameForPlatform(info: PlatformInformation): string {
         switch (platformInfo.platform) {
             case 'win32':
                 switch (platformInfo.architecture) {
-                    case 'x86_64': return 'cpptools-win32.vsix'; // TODO: Change to cpptools-win64?
-                    case 'x86':
-                    case 'i386':
-                    case 'i686': return 'cpptools-win32.vsix';
+                    case 'x64': return 'cpptools-win32.vsix'; // TODO: Change to cpptools-win64?
+                    case 'x86': return 'cpptools-win32.vsix';
                     case 'arm64': return 'cpptools-win-arm64.vsix';
                     default: throw new Error(`Unexpected Windows architecture: ${platformInfo.architecture}`);
                 }
             case 'darwin': return 'cpptools-osx.vsix';
             default: {
                 switch (platformInfo.architecture) {
-                    case 'x86_64': return 'cpptools-linux.vsix';
+                    case 'x64': return 'cpptools-linux.vsix';
                     case 'arm': return 'cpptools-linux-armhf.vsix';
                     case 'arm64': return 'cpptools-linux-aarch64.vsix';
                     default: throw new Error(`Unexpected Linux architecture: ${platformInfo.architecture}`);

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -35,7 +35,7 @@ const disposables: vscode.Disposable[] = [];
 
 export async function activate(context: vscode.ExtensionContext): Promise<CppToolsApi & CppToolsExtension> {
     let errMsg: string = "";
-    if (process.arch !== 'x64' && (process.platform !== 'win32' || (process.arch !== 'ia32' && process.arch !== 'arm64')) && (process.platform !== 'linux' || (process.arch !== 'x64' && process.arch !== 'arm' && process.arch !== 'arm64' && process.arch !== 'aarch64'))) {
+    if (process.arch !== 'x64' && (process.platform !== 'win32' || (process.arch !== 'ia32' && process.arch !== 'arm64')) && (process.platform !== 'linux' || (process.arch !== 'x64' && process.arch !== 'arm' && process.arch !== 'arm64'))) {
         errMsg = localize("architecture.not.supported", "Architecture {0} is not supported. ", String(process.arch));
     } else if (process.platform === 'linux' && fs.existsSync('/etc/alpine-release')) {
         errMsg = localize("apline.containers.not.supported", "Alpine containers are not supported.");
@@ -372,7 +372,8 @@ function sendTelemetry(info: PlatformInformation): boolean {
         util.setProgress(util.getProgressInstallSuccess());
     }
 
-    installBlob.telemetryProperties['osArchitecture'] = info.architecture ?? "";
+    installBlob.telemetryProperties['osArchitecture'] = process.arch;
+    installBlob.telemetryProperties['infoArchitecture'] = info.architecture;
 
     Telemetry.logDebuggerEvent("acquisition", installBlob.telemetryProperties);
 

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -35,8 +35,9 @@ const disposables: vscode.Disposable[] = [];
 
 export async function activate(context: vscode.ExtensionContext): Promise<CppToolsApi & CppToolsExtension> {
     let errMsg: string = "";
-    if (process.arch !== 'x64' && (process.platform !== 'win32' || (process.arch !== 'ia32' && process.arch !== 'arm64')) && (process.platform !== 'linux' || (process.arch !== 'x64' && process.arch !== 'arm' && process.arch !== 'arm64'))) {
-        errMsg = localize("architecture.not.supported", "Architecture {0} is not supported. ", String(process.arch));
+    const arch: string = os.arch();
+    if (arch !== 'x64' && (process.platform !== 'win32' || (arch !== 'ia32' && arch !== 'arm64')) && (process.platform !== 'linux' || (arch !== 'x64' && arch !== 'arm' && arch !== 'arm64'))) {
+        errMsg = localize("architecture.not.supported", "Architecture {0} is not supported. ", String(arch));
     } else if (process.platform === 'linux' && fs.existsSync('/etc/alpine-release')) {
         errMsg = localize("apline.containers.not.supported", "Alpine containers are not supported.");
     }
@@ -372,7 +373,7 @@ function sendTelemetry(info: PlatformInformation): boolean {
         util.setProgress(util.getProgressInstallSuccess());
     }
 
-    installBlob.telemetryProperties['osArchitecture'] = process.arch;
+    installBlob.telemetryProperties['osArchitecture'] = os.arch();
     installBlob.telemetryProperties['infoArchitecture'] = info.architecture;
 
     Telemetry.logDebuggerEvent("acquisition", installBlob.telemetryProperties);

--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -491,7 +491,7 @@ export function VersionsMatch(pkg: IPackage, info: PlatformInformation): boolean
 }
 
 export function ArchitecturesMatch(value: IPackage, info: PlatformInformation): boolean {
-    return !value.architectures || (info.architecture !== undefined && value.architectures.indexOf(info.architecture) !== -1);
+    return !value.architectures || (value.architectures.indexOf(info.architecture) !== -1);
 }
 
 export function PlatformsMatch(value: IPackage, info: PlatformInformation): boolean {

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as os from 'os';
-import * as util from './common';
 import { LinuxDistribution } from './linuxDistribution';
 import * as plist from 'plist';
 import * as fs from 'fs';
@@ -24,26 +23,23 @@ export function GetOSName(processPlatform: string | undefined): string | undefin
 }
 
 export class PlatformInformation {
-    constructor(public platform: string, public architecture?: string, public distribution?: LinuxDistribution, public version?: string) { }
+    constructor(public platform: string, public architecture: string, public distribution?: LinuxDistribution, public version?: string) { }
 
     public static GetPlatformInformation(): Promise<PlatformInformation> {
         const platform: string = os.platform();
-        let architecturePromise: Promise<string | undefined>;
+        const architecture: string = PlatformInformation.GetArchitecture();
         let distributionPromise: Promise<LinuxDistribution | undefined> = Promise.resolve<LinuxDistribution | undefined>(undefined);
         let versionPromise: Promise<string | undefined> = Promise.resolve<string | undefined>(undefined);
 
         switch (platform) {
             case "win32":
-                architecturePromise = PlatformInformation.GetWindowsArchitecture();
                 break;
 
             case "linux":
-                architecturePromise = PlatformInformation.GetUnixArchitecture();
                 distributionPromise = LinuxDistribution.GetDistroInformation();
                 break;
 
             case "darwin":
-                architecturePromise = PlatformInformation.GetUnixArchitecture();
                 versionPromise = PlatformInformation.GetDarwinVersion();
                 break;
 
@@ -51,50 +47,28 @@ export class PlatformInformation {
                 throw new Error(localize("unknown.os.platform", "Unknown OS platform"));
         }
 
-        return Promise.all([architecturePromise, distributionPromise, versionPromise])
-            .then(([arch, distro, version]) =>
-                new PlatformInformation(platform, arch, distro, version)
+        return Promise.all([distributionPromise, versionPromise])
+            .then(([distro, version]) =>
+                new PlatformInformation(platform, architecture, distro, version)
             );
     }
 
-    public static GetUnknownArchitecture(): string { return "Unknown"; }
-
-    private static GetWindowsArchitecture(): Promise<string> {
-        return util.execChildProcess('wmic os get osarchitecture', util.extensionPath)
-            .then((architecture) => {
-                if (architecture) {
-                    const archArray: string[] = architecture.split(os.EOL);
-                    if (archArray.length >= 2) {
-                        const arch: string = archArray[1].trim();
-
-                        // Note: This string can be localized. So, we'll just check to see if it contains 32 or 64.
-                        if (arch.indexOf('64') >= 0) {
-                            if (arch.indexOf('ARM') >= 0) {
-                                return "arm64";
-                            }
-                            return "x86_64";
-                        } else if (arch.indexOf('32') >= 0) {
-                            return "x86";
-                        }
-                    }
+    public static GetArchitecture(): string {
+        switch (process.arch) {
+            case "x64":
+            case "arm64":
+            case "arm":
+                return process.arch;
+            case "x32":
+            case "ia32":
+                return "x86";
+            default:
+                if (os.platform() === "win32") {
+                    return "x86";
+                } else {
+                    return "x64";
                 }
-                return PlatformInformation.GetUnknownArchitecture();
-            }).catch((error) => PlatformInformation.GetUnknownArchitecture());
-    }
-
-    private static GetUnixArchitecture(): Promise<string | undefined> {
-        return util.execChildProcess('uname -m', util.packageJson.extensionFolderPath)
-            .then((architecture) => {
-                if (architecture) {
-                    if (architecture.startsWith('arm64') || architecture.startsWith('aarch64')) {
-                        return 'arm64';
-                    } else if (architecture.startsWith('armv')) {
-                        return 'arm';
-                    }
-                    return architecture.trim();
-                }
-                return undefined;
-            });
+        }
     }
 
     private static GetDarwinVersion(): Promise<string> {

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -54,11 +54,12 @@ export class PlatformInformation {
     }
 
     public static GetArchitecture(): string {
-        switch (process.arch) {
+        const arch: string = os.arch();
+        switch (arch) {
             case "x64":
             case "arm64":
             case "arm":
-                return process.arch;
+                return arch;
             case "x32":
             case "ia32":
                 return "x86";


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/6453. In certain cases, the architecture on Windows was getting computed as Unknown or undefined.

Also, should fix the Linux issue at https://github.com/microsoft/vscode-cpptools/issues/6090 .
