### PR TITLE
Fix fileDirname.

### DIFF
--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -396,7 +396,7 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
         const file: string = editor.document.fileName;
         return {
             "file": file,
-            "fileDirname": fileDir.uri.fsPath,
+            "fileDirname": path.parse(file).dir,
             "fileBasenameNoExtension": path.parse(file).name,
             "workspaceFolder": fileDir.uri.fsPath
         };


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/6386 .

Build and debug active file would put the .exe in the root instead of the current folder.