### PR TITLE
Automatically fall back to config provider

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1432,6 +1432,7 @@ export class DefaultClient implements Client {
             if (!rootFolder) {
                 return; // There is no c_cpp_properties.json to edit because there is no folder open.
             }
+            this.configuration.handleConfigurationChange();
             const selectedProvider: string | undefined = this.configuration.CurrentConfigurationProvider;
             if (!selectedProvider) {
                 const ask: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("Client.registerProvider", true, rootFolder);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -715,17 +715,18 @@ export class CppProperties {
             if (providers.size === 1
                 && !this.propertiesFile
                 && !settings.defaultCompilerPath
+                && settings.defaultCompilerPath !== ""
                 && !settings.defaultIncludePath
                 && !settings.defaultDefines
                 && !settings.defaultMacFrameworkPath
-                && settings.defaultWindowsSdkVersion === ''
+                && settings.defaultWindowsSdkVersion === ""
                 && !settings.defaultForcedInclude
-                && settings.defaultCompileCommands === ''
+                && settings.defaultCompileCommands === ""
                 && !settings.defaultCompilerArgs
-                && settings.defaultCStandard === ''
-                && settings.defaultCppStandard === ''
-                && settings.defaultIntelliSenseMode === ''
-                && settings.defaultConfigurationProvider === '') {
+                && settings.defaultCStandard === ""
+                && settings.defaultCppStandard === ""
+                && settings.defaultIntelliSenseMode === ""
+                && settings.defaultConfigurationProvider === "") {
                 providers.forEach(provider => { configuration.configurationProvider = provider.extensionId; });
             }
         }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -483,6 +483,12 @@ export class CppProperties {
                     resolve();
                 }, () => {});
             } else {
+                const settings: CppSettings = new CppSettings(this.rootUri);
+                if (providerId) {
+                    settings.update("default.configurationProvider", providerId);
+                } else {
+                    settings.update("default.configurationProvider", undefined); // delete the setting
+                }
                 const config: Configuration | undefined = this.CurrentConfiguration;
                 if (config) {
                     config.configurationProvider = providerId;
@@ -958,9 +964,12 @@ export class CppProperties {
                 const fullPathToFile: string = path.join(this.configFolder, "c_cpp_properties.json");
                 // Since the properties files does not exist, there will be exactly 1 configuration.
                 // If we have decided to use a custom config provider, propagate that to the new config.
-                let providerId: string | undefined;
+                const settings: CppSettings = new CppSettings(this.rootUri);
+                let providerId: string | undefined = settings.defaultConfigurationProvider;
                 if (this.configurationJson) {
-                    providerId = this.configurationJson.configurations[0].configurationProvider;
+                    if (!providerId) {
+                        providerId = this.configurationJson.configurations[0].configurationProvider;
+                    }
                     this.resetToDefaultSettings(true);
                 }
                 this.applyDefaultIncludePathsAndFrameworks();

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -483,12 +483,6 @@ export class CppProperties {
                     resolve();
                 }, () => {});
             } else {
-                const settings: CppSettings = new CppSettings(this.rootUri);
-                if (providerId) {
-                    settings.update("default.configurationProvider", providerId);
-                } else {
-                    settings.update("default.configurationProvider", undefined); // delete the setting
-                }
                 const config: Configuration | undefined = this.CurrentConfiguration;
                 if (config) {
                     config.configurationProvider = providerId;
@@ -962,18 +956,18 @@ export class CppProperties {
                 }
 
                 const fullPathToFile: string = path.join(this.configFolder, "c_cpp_properties.json");
+                // Since the properties files does not exist, there will be exactly 1 configuration.
+                // If we have decided to use a custom config provider, propagate that to the new config.
+                let providerId: string | undefined;
                 if (this.configurationJson) {
+                    providerId = this.configurationJson.configurations[0].configurationProvider;
                     this.resetToDefaultSettings(true);
                 }
                 this.applyDefaultIncludePathsAndFrameworks();
-                const settings: CppSettings = new CppSettings(this.rootUri);
-                if (settings.defaultConfigurationProvider) {
+                if (providerId) {
                     if (this.configurationJson) {
-                        this.configurationJson.configurations.forEach(config => {
-                            config.configurationProvider = settings.defaultConfigurationProvider ? settings.defaultConfigurationProvider : undefined;
-                        });
+                        this.configurationJson.configurations[0].configurationProvider = providerId;
                     }
-                    settings.update("default.configurationProvider", undefined); // delete the setting
                 }
 
                 await util.writeFileText(fullPathToFile, jsonc.stringify(this.configurationJson, null, 4));


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/6150

Triggers a config refresh when a config provider is registered.
If `c_cpp_properties.json` does not exist, there are no other configuration setting specified in `C_Cpp.defaults.*`, and there is only one custom configuration provider registered, use that provider.
