### PR TITLE
Fix build task bugs.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "1.1.1-master",
+  "version": "1.1.3-master",
   "publisher": "ms-vscode",
   "icon": "LanguageCCPP_color_128x.png",
   "readme": "README.md",

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -150,12 +150,16 @@ class CppConfigurationProvider implements vscode.DebugConfigurationProvider {
         }
         // Filter out build tasks that don't match the currently selected debug configuration type.
         buildTasks = buildTasks.filter((task: CppBuildTask) => {
+            const command: string = task.definition.command as string;
+            if (!command) {
+                return false;
+            }
             if (defaultConfig.name.startsWith("(Windows) ")) {
-                if ((task.definition.command as string).includes("cl.exe")) {
+                if (command.includes("cl.exe")) {
                     return true;
                 }
             } else {
-                if (!(task.definition.command as string).includes("cl.exe")) {
+                if (!command.includes("cl.exe")) {
                     return true;
                 }
             }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -397,11 +397,19 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
             return undefined;
         }
         const file: string = editor.document.fileName;
+        const workspaceFolder: string = fileDir.uri.fsPath;
+        const relativeFile: string = path.relative(workspaceFolder, file);
+        const parsedPath: path.ParsedPath = path.parse(file);
         return {
+            "workspaceFolder": workspaceFolder,
+            "workspaceFolderBasename": path.basename(workspaceFolder),
             "file": file,
-            "fileDirname": path.parse(file).dir,
-            "fileBasenameNoExtension": path.parse(file).name,
-            "workspaceFolder": fileDir.uri.fsPath
+            "relativeFile": relativeFile,
+            "relativeFileDirname": path.parse(relativeFile).dir,
+            "fileBasename": parsedPath.base,
+            "fileBasenameNoExtension": parsedPath.name,
+            "fileDirname": parsedPath.dir,
+            "fileExtname": parsedPath.ext
         };
     }
 }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -200,6 +200,9 @@ export class CppBuildTaskProvider implements TaskProvider {
         const rawJson: any = await this.getRawTasksJson();
         const rawTasksJson: any = (!rawJson.tasks) ? new Array() : rawJson.tasks;
         const buildTasksJson: CppBuildTask[] = rawTasksJson.map((task: any) => {
+            if (!task.label) {
+                return null;
+            }
             const definition: CppBuildTaskDefinition = {
                 type: task.type,
                 label: task.label,
@@ -211,7 +214,7 @@ export class CppBuildTaskProvider implements TaskProvider {
             cppBuildTask.detail = task.detail;
             return cppBuildTask;
         });
-        return buildTasksJson;
+        return buildTasksJson.filter((task: CppBuildTask) => task !== null);
     }
 
     public async ensureBuildTaskExists(taskLabel: string): Promise<void> {

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -187,7 +187,7 @@ export class CppBuildTaskProvider implements TaskProvider {
         const task: CppBuildTask = new Task(definition, scope, definition.label, CppBuildTaskProvider.CppBuildSourceStr,
             new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> =>
                 // When the task is executed, this callback will run. Here, we setup for running the task.
-                new CustomBuildTaskTerminal(resolvedcompilerPath, resolvedDefinition ? resolvedDefinition.args : [], resolvedDefinition ? resolvedDefinition.options : undefined)
+                new CustomBuildTaskTerminal(resolvedcompilerPath, resolvedDefinition.args, resolvedDefinition.options)
             ), isCl ? '$msCompile' : '$gcc');
 
         task.group = TaskGroup.Build;


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/6538
Also, switch to using VS Code's taks variable resolving.
Also, avoids an error in the (invalid) case where there's no label for task.