### PR TITLE
Add support to Apple Silicon

### DIFF
--- a/Extension/ThirdPartyNotices.Mono.txt
+++ b/Extension/ThirdPartyNotices.Mono.txt
@@ -1,0 +1,2226 @@
+THIRD PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This Microsoft product may utilize material made available by third parties under the following license terms.  Any source code that Microsoft is required to make available can be found at http://3rdpartysource.microsoft.com. You may also obtain a copy of any such source code (during the period provided by the license) by sending a check or money order for US $5.00 to: 
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052 USA
+
+Please write “Source for [OSS PROJECT NAME]” in the memo line of your payment. 
+
+In general, the runtime and its class libraries are licensed under the
+terms of the MIT license, and some third party code is licensed under
+the 3-clause BSD license.  See the file "PATENTS.TXT" for Microsoft's
+patent grant on the Mono codebase.
+
+The Mono distribution does include a handful of pieces of code that
+are used during the build system and are covered under different
+licenses, those include:
+
+Build Time Code
+===============
+
+This is code that is used at build time, or during the maintenance of
+Mono itself, and does not end up in the redistributable part of Mono:
+
+* gettext
+
+  m4 source files used to probe features at build time: GPL
+
+* Benchmark Source Files
+
+  Logic.cs and zipmark.cs are GPL source files.
+
+* mono/docs/HtmlAgilityPack
+
+  MS-PL licensed
+
+* mcs/jay: 4-clause BSD licensed
+
+* mcs/nunit24: MS-PL
+
+* mcs/class/I18N/mklist.sh, tools/cvt.sh: GNU GPLv2
+
+Runtime Code
+============
+
+The following code is linked with the final Mono runtime, the libmono
+embeddable runtime:
+
+* support/minizip: BSD license.
+
+* mono/utils/memcheck.h: BSD license, used on debug builds that use Valgrind.
+
+* mono/utils/freebsd-dwarf.h, freebsd-elf_common.h, freebsd-elf64.h freebsd-elf32.h: BSD license.
+
+* mono/utils/bsearch.c: BSD license.
+
+* mono/metadata/w32file-unix-glob.c, w32file-unix-glob.h: BSD license
+
+Class Library code
+==================
+
+These are class libraries that can be loaded by your process:
+
+* mcs/class/RabbitMQ.Client: dual licensed in Apache v2, and Mozilla Public License 1.1
+
+* mcs/class/Compat.ICSharpCode.SharpZipLib and
+  mcs/class/ICSharpCode.SharpZipLib are GPL with class-path exception.
+  Originates with the SharpDevelop project.
+
+* mcs/class/System.Core/System/TimeZoneInfo.Android.cs
+
+  This is a port of Apache 2.0-licensed Android code, and thus is
+  licensed under the Apache 2.0 license
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+API Documentation
+=================
+
+The API documentation is licensed under the terms of the Creative
+Commons Attribution 4.0 International Public License
+
+
+The Licenses
+============
+
+	These are the licenses used in Mono, the files are located:
+
+### MIT X11 License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+### Mozilla.MPL
+
+                          MOZILLA PUBLIC LICENSE
+                                Version 1.1
+
+                              ---------------
+
+1. Definitions.
+
+     1.0.1. "Commercial Use" means distribution or otherwise making the
+     Covered Code available to a third party.
+
+     1.1. "Contributor" means each entity that creates or contributes to
+     the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original
+     Code, prior Modifications used by a Contributor, and the Modifications
+     made by that particular Contributor.
+
+     1.3. "Covered Code" means the Original Code or Modifications or the
+     combination of the Original Code and Modifications, in each case
+     including portions thereof.
+
+     1.4. "Electronic Distribution Mechanism" means a mechanism generally
+     accepted in the software development community for the electronic
+     transfer of data.
+
+     1.5. "Executable" means Covered Code in any form other than Source
+     Code.
+
+     1.6. "Initial Developer" means the individual or entity identified
+     as the Initial Developer in the Source Code notice required by Exhibit
+     A.
+
+     1.7. "Larger Work" means a work which combines Covered Code or
+     portions thereof with code not governed by the terms of this License.
+
+     1.8. "License" means this document.
+
+     1.8.1. "Licensable" means having the right to grant, to the maximum
+     extent possible, whether at the time of the initial grant or
+     subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means any addition to or deletion from the
+     substance or structure of either the Original Code or any previous
+     Modifications. When Covered Code is released as a series of files, a
+     Modification is:
+          A. Any addition to or deletion from the contents of a file
+          containing Original Code or previous Modifications.
+
+          B. Any new file that contains any part of the Original Code or
+          previous Modifications.
+
+     1.10. "Original Code" means Source Code of computer software code
+     which is described in the Source Code notice required by Exhibit A as
+     Original Code, and which, at the time of its release under this
+     License is not already Covered Code governed by this License.
+
+     1.10.1. "Patent Claims" means any patent claim(s), now owned or
+     hereafter acquired, including without limitation,  method, process,
+     and apparatus claims, in any patent Licensable by grantor.
+
+     1.11. "Source Code" means the preferred form of the Covered Code for
+     making modifications to it, including all modules it contains, plus
+     any associated interface definition files, scripts used to control
+     compilation and installation of an Executable, or source code
+     differential comparisons against either the Original Code or another
+     well known, available Covered Code of the Contributor's choice. The
+     Source Code can be in a compressed or archival form, provided the
+     appropriate decompression or de-archiving software is widely available
+     for no charge.
+
+     1.12. "You" (or "Your")  means an individual or a legal entity
+     exercising rights under, and complying with all of the terms of, this
+     License or a future version of this License issued under Section 6.1.
+     For legal entities, "You" includes any entity which controls, is
+     controlled by, or is under common control with You. For purposes of
+     this definition, "control" means (a) the power, direct or indirect,
+     to cause the direction or management of such entity, whether by
+     contract or otherwise, or (b) ownership of more than fifty percent
+     (50%) of the outstanding shares or beneficial ownership of such
+     entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant.
+     The Initial Developer hereby grants You a world-wide, royalty-free,
+     non-exclusive license, subject to third party intellectual property
+     claims:
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Initial Developer to use, reproduce,
+          modify, display, perform, sublicense and distribute the Original
+          Code (or portions thereof) with or without Modifications, and/or
+          as part of a Larger Work; and
+
+          (b) under Patents Claims infringed by the making, using or
+          selling of Original Code, to make, have made, use, practice,
+          sell, and offer for sale, and/or otherwise dispose of the
+          Original Code (or portions thereof).
+
+          (c) the licenses granted in this Section 2.1(a) and (b) are
+          effective on the date Initial Developer first distributes
+          Original Code under the terms of this License.
+
+          (d) Notwithstanding Section 2.1(b) above, no patent license is
+          granted: 1) for code that You delete from the Original Code; 2)
+          separate from the Original Code;  or 3) for infringements caused
+          by: i) the modification of the Original Code or ii) the
+          combination of the Original Code with other software or devices.
+
+     2.2. Contributor Grant.
+     Subject to third party intellectual property claims, each Contributor
+     hereby grants You a world-wide, royalty-free, non-exclusive license
+
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Contributor, to use, reproduce, modify,
+          display, perform, sublicense and distribute the Modifications
+          created by such Contributor (or portions thereof) either on an
+          unmodified basis, with other Modifications, as Covered Code
+          and/or as part of a Larger Work; and
+
+          (b) under Patent Claims infringed by the making, using, or
+          selling of  Modifications made by that Contributor either alone
+          and/or in combination with its Contributor Version (or portions
+          of such combination), to make, use, sell, offer for sale, have
+          made, and/or otherwise dispose of: 1) Modifications made by that
+          Contributor (or portions thereof); and 2) the combination of
+          Modifications made by that Contributor with its Contributor
+          Version (or portions of such combination).
+
+          (c) the licenses granted in Sections 2.2(a) and 2.2(b) are
+          effective on the date Contributor first makes Commercial Use of
+          the Covered Code.
+
+          (d)    Notwithstanding Section 2.2(b) above, no patent license is
+          granted: 1) for any code that Contributor has deleted from the
+          Contributor Version; 2)  separate from the Contributor Version;
+          3)  for infringements caused by: i) third party modifications of
+          Contributor Version or ii)  the combination of Modifications made
+          by that Contributor with other software  (except as part of the
+          Contributor Version) or other devices; or 4) under Patent Claims
+          infringed by Covered Code in the absence of Modifications made by
+          that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Application of License.
+     The Modifications which You create or to which You contribute are
+     governed by the terms of this License, including without limitation
+     Section 2.2. The Source Code version of Covered Code may be
+     distributed only under the terms of this License or a future version
+     of this License released under Section 6.1, and You must include a
+     copy of this License with every copy of the Source Code You
+     distribute. You may not offer or impose any terms on any Source Code
+     version that alters or restricts the applicable version of this
+     License or the recipients' rights hereunder. However, You may include
+     an additional document offering the additional rights described in
+     Section 3.5.
+
+     3.2. Availability of Source Code.
+     Any Modification which You create or to which You contribute must be
+     made available in Source Code form under the terms of this License
+     either on the same media as an Executable version or via an accepted
+     Electronic Distribution Mechanism to anyone to whom you made an
+     Executable version available; and if made available via Electronic
+     Distribution Mechanism, must remain available for at least twelve (12)
+     months after the date it initially became available, or at least six
+     (6) months after a subsequent version of that particular Modification
+     has been made available to such recipients. You are responsible for
+     ensuring that the Source Code version remains available even if the
+     Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications.
+     You must cause all Covered Code to which You contribute to contain a
+     file documenting the changes You made to create that Covered Code and
+     the date of any change. You must include a prominent statement that
+     the Modification is derived, directly or indirectly, from Original
+     Code provided by the Initial Developer and including the name of the
+     Initial Developer in (a) the Source Code, and (b) in any notice in an
+     Executable version or related documentation in which You describe the
+     origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+          (a) Third Party Claims.
+          If Contributor has knowledge that a license under a third party's
+          intellectual property rights is required to exercise the rights
+          granted by such Contributor under Sections 2.1 or 2.2,
+          Contributor must include a text file with the Source Code
+          distribution titled "LEGAL" which describes the claim and the
+          party making the claim in sufficient detail that a recipient will
+          know whom to contact. If Contributor obtains such knowledge after
+          the Modification is made available as described in Section 3.2,
+          Contributor shall promptly modify the LEGAL file in all copies
+          Contributor makes available thereafter and shall take other steps
+          (such as notifying appropriate mailing lists or newsgroups)
+          reasonably calculated to inform those who received the Covered
+          Code that new knowledge has been obtained.
+
+          (b) Contributor APIs.
+          If Contributor's Modifications include an application programming
+          interface and Contributor has knowledge of patent licenses which
+          are reasonably necessary to implement that API, Contributor must
+          also include this information in the LEGAL file.
+
+               (c)    Representations.
+          Contributor represents that, except as disclosed pursuant to
+          Section 3.4(a) above, Contributor believes that Contributor's
+          Modifications are Contributor's original creation(s) and/or
+          Contributor has sufficient rights to grant the rights conveyed by
+          this License.
+
+     3.5. Required Notices.
+     You must duplicate the notice in Exhibit A in each file of the Source
+     Code.  If it is not possible to put such notice in a particular Source
+     Code file due to its structure, then You must include such notice in a
+     location (such as a relevant directory) where a user would be likely
+     to look for such a notice.  If You created one or more Modification(s)
+     You may add your name as a Contributor to the notice described in
+     Exhibit A.  You must also duplicate this License in any documentation
+     for the Source Code where You describe recipients' rights or ownership
+     rights relating to Covered Code.  You may choose to offer, and to
+     charge a fee for, warranty, support, indemnity or liability
+     obligations to one or more recipients of Covered Code. However, You
+     may do so only on Your own behalf, and not on behalf of the Initial
+     Developer or any Contributor. You must make it absolutely clear than
+     any such warranty, support, indemnity or liability obligation is
+     offered by You alone, and You hereby agree to indemnify the Initial
+     Developer and every Contributor for any liability incurred by the
+     Initial Developer or such Contributor as a result of warranty,
+     support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions.
+     You may distribute Covered Code in Executable form only if the
+     requirements of Section 3.1-3.5 have been met for that Covered Code,
+     and if You include a notice stating that the Source Code version of
+     the Covered Code is available under the terms of this License,
+     including a description of how and where You have fulfilled the
+     obligations of Section 3.2. The notice must be conspicuously included
+     in any notice in an Executable version, related documentation or
+     collateral in which You describe recipients' rights relating to the
+     Covered Code. You may distribute the Executable version of Covered
+     Code or ownership rights under a license of Your choice, which may
+     contain terms different from this License, provided that You are in
+     compliance with the terms of this License and that the license for the
+     Executable version does not attempt to limit or alter the recipient's
+     rights in the Source Code version from the rights set forth in this
+     License. If You distribute the Executable version under a different
+     license You must make it absolutely clear that any terms which differ
+     from this License are offered by You alone, not by the Initial
+     Developer or any Contributor. You hereby agree to indemnify the
+     Initial Developer and every Contributor for any liability incurred by
+     the Initial Developer or such Contributor as a result of any such
+     terms You offer.
+
+     3.7. Larger Works.
+     You may create a Larger Work by combining Covered Code with other code
+     not governed by the terms of this License and distribute the Larger
+     Work as a single product. In such a case, You must make sure the
+     requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+
+     If it is impossible for You to comply with any of the terms of this
+     License with respect to some or all of the Covered Code due to
+     statute, judicial order, or regulation then You must: (a) comply with
+     the terms of this License to the maximum extent possible; and (b)
+     describe the limitations and the code they affect. Such description
+     must be included in the LEGAL file described in Section 3.4 and must
+     be included with all distributions of the Source Code. Except to the
+     extent prohibited by statute or regulation, such description must be
+     sufficiently detailed for a recipient of ordinary skill to be able to
+     understand it.
+
+5. Application of this License.
+
+     This License applies to code to which the Initial Developer has
+     attached the notice in Exhibit A and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions.
+     Netscape Communications Corporation ("Netscape") may publish revised
+     and/or new versions of the License from time to time. Each version
+     will be given a distinguishing version number.
+
+     6.2. Effect of New Versions.
+     Once Covered Code has been published under a particular version of the
+     License, You may always continue to use it under the terms of that
+     version. You may also choose to use such Covered Code under the terms
+     of any subsequent version of the License published by Netscape. No one
+     other than Netscape has the right to modify the terms applicable to
+     Covered Code created under this License.
+
+     6.3. Derivative Works.
+     If You create or use a modified version of this License (which you may
+     only do in order to apply it to code which is not already Covered Code
+     governed by this License), You must (a) rename Your license so that
+     the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape",
+     "MPL", "NPL" or any confusingly similar phrase do not appear in your
+     license (except to note that your license differs from this License)
+     and (b) otherwise make it clear that Your version of the license
+     contains terms which differ from the Mozilla Public License and
+     Netscape Public License. (Filling in the name of the Initial
+     Developer, Original Code or Contributor in the notice described in
+     Exhibit A shall not of themselves be deemed to be modifications of
+     this License.)
+
+7. DISCLAIMER OF WARRANTY.
+
+     COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS,
+     WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+     WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF
+     DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING.
+     THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE
+     IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT,
+     YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE
+     COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER
+     OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+     ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. TERMINATION.
+
+     8.1.  This License and the rights granted hereunder will terminate
+     automatically if You fail to comply with terms herein and fail to cure
+     such breach within 30 days of becoming aware of the breach. All
+     sublicenses to the Covered Code which are properly granted shall
+     survive any termination of this License. Provisions which, by their
+     nature, must remain in effect beyond the termination of this License
+     shall survive.
+
+     8.2.  If You initiate litigation by asserting a patent infringement
+     claim (excluding declatory judgment actions) against Initial Developer
+     or a Contributor (the Initial Developer or Contributor against whom
+     You file such action is referred to as "Participant")  alleging that:
+
+     (a)  such Participant's Contributor Version directly or indirectly
+     infringes any patent, then any and all rights granted by such
+     Participant to You under Sections 2.1 and/or 2.2 of this License
+     shall, upon 60 days notice from Participant terminate prospectively,
+     unless if within 60 days after receipt of notice You either: (i)
+     agree in writing to pay Participant a mutually agreeable reasonable
+     royalty for Your past and future use of Modifications made by such
+     Participant, or (ii) withdraw Your litigation claim with respect to
+     the Contributor Version against such Participant.  If within 60 days
+     of notice, a reasonable royalty and payment arrangement are not
+     mutually agreed upon in writing by the parties or the litigation claim
+     is not withdrawn, the rights granted by Participant to You under
+     Sections 2.1 and/or 2.2 automatically terminate at the expiration of
+     the 60 day notice period specified above.
+
+     (b)  any software, hardware, or device, other than such Participant's
+     Contributor Version, directly or indirectly infringes any patent, then
+     any rights granted to You by such Participant under Sections 2.1(b)
+     and 2.2(b) are revoked effective as of the date You first made, used,
+     sold, distributed, or had made, Modifications made by that
+     Participant.
+
+     8.3.  If You assert a patent infringement claim against Participant
+     alleging that such Participant's Contributor Version directly or
+     indirectly infringes any patent where such claim is resolved (such as
+     by license or settlement) prior to the initiation of patent
+     infringement litigation, then the reasonable value of the licenses
+     granted by such Participant under Sections 2.1 or 2.2 shall be taken
+     into account in determining the amount or value of any payment or
+     license.
+
+     8.4.  In the event of termination under Sections 8.1 or 8.2 above,
+     all end user license agreements (excluding distributors and resellers)
+     which have been validly granted by You or any distributor hereunder
+     prior to termination shall survive termination.
+
+9. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+     (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL
+     DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE,
+     OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR
+     ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY
+     CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL,
+     WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+     COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+     INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+     LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY
+     RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW
+     PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE
+     EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO
+     THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. GOVERNMENT END USERS.
+
+     The Covered Code is a "commercial item," as that term is defined in
+     48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer
+     software" and "commercial computer software documentation," as such
+     terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48
+     C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995),
+     all U.S. Government End Users acquire Covered Code with only those
+     rights set forth herein.
+
+11. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject
+     matter hereof. If any provision of this License is held to be
+     unenforceable, such provision shall be reformed only to the extent
+     necessary to make it enforceable. This License shall be governed by
+     California law provisions (except to the extent applicable law, if
+     any, provides otherwise), excluding its conflict-of-law provisions.
+     With respect to disputes in which at least one party is a citizen of,
+     or an entity chartered or registered to do business in the United
+     States of America, any litigation relating to this License shall be
+     subject to the jurisdiction of the Federal Courts of the Northern
+     District of California, with venue lying in Santa Clara County,
+     California, with the losing party responsible for costs, including
+     without limitation, court costs and reasonable attorneys' fees and
+     expenses. The application of the United Nations Convention on
+     Contracts for the International Sale of Goods is expressly excluded.
+     Any law or regulation which provides that the language of a contract
+     shall be construed against the drafter shall not apply to this
+     License.
+
+12. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is
+     responsible for claims and damages arising, directly or indirectly,
+     out of its utilization of rights under this License and You agree to
+     work with Initial Developer and Contributors to distribute such
+     responsibility on an equitable basis. Nothing herein is intended or
+     shall be deemed to constitute any admission of liability.
+
+13. MULTIPLE-LICENSED CODE.
+
+     Initial Developer may designate portions of the Covered Code as
+     "Multiple-Licensed".  "Multiple-Licensed" means that the Initial
+     Developer permits you to utilize portions of the Covered Code under
+     Your choice of the NPL or the alternative licenses, if any, specified
+     by the Initial Developer in the file described in Exhibit A.
+
+EXHIBIT A -Mozilla Public License.
+
+     ``The contents of this file are subject to the Mozilla Public License
+     Version 1.1 (the "License"); you may not use this file except in
+     compliance with the License. You may obtain a copy of the License at
+     http://www.mozilla.org/MPL/
+
+     Software distributed under the License is distributed on an "AS IS"
+     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+     License for the specific language governing rights and limitations
+     under the License.
+
+     The Original Code is ______________________________________.
+
+     The Initial Developer of the Original Code is ________________________.
+     Portions created by ______________________ are Copyright (C) ______
+     _______________________. All Rights Reserved.
+
+     Contributor(s): ______________________________________.
+
+     Alternatively, the contents of this file may be used under the terms
+     of the _____ license (the  "[___] License"), in which case the
+     provisions of [______] License are applicable instead of those
+     above.  If you wish to allow use of your version of this file only
+     under the terms of the [____] License and not to allow others to use
+     your version of this file under the MPL, indicate your decision by
+     deleting  the provisions above and replace  them with the notice and
+     other provisions required by the [___] License.  If you do not delete
+     the provisions above, a recipient may use your version of this file
+     under either the MPL or the [___] License."
+
+     [NOTE: The text of this Exhibit A may differ slightly from the text of
+     the notices in the Source Code files of the Original Code. You should
+     use the text of this Exhibit A rather than the text found in the
+     Original Code Source Code for Your Modifications.]
+
+### Microsoft Public License
+
+Microsoft Permissive License (Ms-PL)
+ 
+	This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+ 
+1. Definitions
+
+	The terms ?reproduce,? ?reproduction,? ?derivative works,? and ?distribution? have the same meaning here as under U.S. copyright law.
+	A ?contribution? is the original software, or any additions or changes to the software.
+	A ?contributor? is any person that distributes its contribution under this license.
+	 ?Licensed patents? are a contributor?s patent claims that read directly on its contribution.
+ 
+2. Grant of Rights
+
+	(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+	(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+ 
+3. Conditions and Limitations
+
+	(A) No Trademark License- This license does not grant you rights to use any contributors? name, logo, or trademarks.
+	(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+	(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
+	(D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+	(E) The software is licensed ?as-is.? You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+	(F) If you distribute the software or derivative works with programs you develop, you agree to indemnify, defend, and hold harmless all contributors from any claims, including attorneys? fees, related to the distribution or use of your programs.  For clarity, you have no such obligations to a contributor for any claims based solely on the unmodified contributions of that contributor.
+	(G) If you make any additions or changes to the original software, you may only distribute them under a new namespace.  In addition, you will clearly identify your changes or additions as your own.
+
+### Infozip BSD
+
+This is version 2009-Jan-02 of the Info-ZIP license. The definitive
+version of this document should be available at
+ftp://ftp.info-zip.org/pub/infozip/license.html indefinitely and a
+copy at http://www.info-zip.org/pub/infozip/license.html.
+
+Copyright (c) 1990-2009 Info-ZIP. All rights reserved.
+
+For the purposes of this copyright and license, "Info-ZIP" is defined
+as the following set of individuals: Mark Adler, John Bush, Karl
+Davis, Harald Denker, Jean-Michel Dubois, Jean-loup Gailly, Hunter
+Goatley, Ed Gordon, Ian Gorman, Chris Herborth, Dirk Haase, Greg
+Hartwig, Robert Heath, Jonathan Hudson, Paul Kienitz, David
+Kirschbaum, Johnny Lee, Onno van der Linden, Igor Mandrichenko, Steve
+P. Miller, Sergio Monesi, Keith Owens, George Petrov, Greg Roelofs,
+Kai Uwe Rommel, Steve Salisbury, Dave Smith, Steven M. Schweda,
+Christian Spieler, Cosmin Truta, Antoine Verheijen, Paul von Behren,
+Rich Wales, Mike White.
+
+This software is provided "as is," without warranty of any kind,
+express or implied. In no event shall Info-ZIP or its contributors be
+held liable for any direct, indirect, incidental, special or
+consequential damages arising out of the use of or inability to use
+this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the above disclaimer and the following
+restrictions:
+
+Redistributions of source code (in whole or in part) must retain the
+above copyright notice, definition, disclaimer, and this list of
+conditions.
+
+Redistributions in binary form (compiled executables and libraries)
+must reproduce the above copyright notice, definition, disclaimer, and
+this list of conditions in documentation and/or other materials
+provided with the distribution. Additional documentation is not needed
+for executables where a command line license option provides these and
+a note regarding this option is in the executable's startup
+banner. The sole exception to this condition is redistribution of a
+standard UnZipSFX binary (including SFXWiz) as part of a
+self-extracting archive; that is permitted without inclusion of this
+license, as long as the normal SFX banner has not been removed from
+the binary or disabled.
+
+Altered versions--including, but not limited to, ports to new
+operating systems, existing ports with new graphical interfaces,
+versions with modified or added functionality, and dynamic, shared, or
+static library versions not from Info-ZIP--must be plainly marked as
+such and must not be misrepresented as being the original source or,
+if binaries, compiled from the original source. Such altered versions
+also must not be misrepresented as being Info-ZIP releases--including,
+but not limited to, labeling of the altered versions with the names
+"Info-ZIP" (or any variation thereof, including, but not limited to,
+different capitalizations), "Pocket UnZip," "WiZ" or "MacZip" without
+the explicit permission of Info-ZIP. Such altered versions are further
+prohibited from misrepresentative use of the Zip-Bugs or Info-ZIP
+e-mail addresses or the Info-ZIP URL(s), such as to imply Info-ZIP
+will provide support for the altered versions.
+
+Info-ZIP retains the right to use the names "Info-ZIP," "Zip,"
+"UnZip," "UnZipSFX," "WiZ," "Pocket UnZip," "Pocket Zip," and "MacZip"
+for its own source and binary releases.
+
+### License Creative Commons 2.5
+
+// Copyright 2006 James Newton-King
+// http://www.newtonsoft.com
+//
+// This work is licensed under the Creative Commons Attribution 2.5 License
+// http://creativecommons.org/licenses/by/2.5/
+//
+// You are free:
+//    * to copy, distribute, display, and perform the work
+//    * to make derivative works
+//    * to make commercial use of the work
+//
+// Under the following conditions:
+//    * For any reuse or distribution, you must make clear to others the license terms of this work.
+//    * Any of these conditions can be waived if you get permission from the copyright holder.
+
+From: james.newtonking@gmail.com [mailto:james.newtonking@gmail.com] On Behalf Of James Newton-King
+Sent: Tuesday, June 05, 2007 6:36 AM
+To: Konstantin Triger
+Subject: Re: Support request by Konstantin Triger for Json.NET
+
+Hey Kosta
+
+I think it would be awesome to use Json.NET in Mono for System.Web.Extensions.
+
+The CC license has the following clause: Any of the above conditions can be waived if you get permission from the copyright holder.
+
+I can waive that statement for you and Mono. Would that be acceptable?
+
+
+Regards,
+James
+
+### Creative Commons Attribution 4.0 International Public License
+
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public: 
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+### GPL version 2
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year  name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.
+
+
+
+Format-Specification: http://dep.debian.net/deps/dep5/
+Upstream-Name: Mono
+Upstream-Source: http://ftp.novell.com/pub/mono/sources/mono
+
+Files: *
+Copyright: © 2001 Andreas Jonsson
+           © 2001 Andrew Sutton
+           © 2001 Bob Smith. http://www.thestuff.net
+           © 2001 Chris Hynes
+           © 2001 Christopher Podurgiel
+           © 2001 Daniel Weber
+           © 2001 David Dawkins
+           © 2001 Derek Holden (dholden@draper.com)
+           © 2001 Garrett Rooney (rooneg@electricjellyfish.net)
+           © 2001 John Barnette
+           © 2001 John R. Hicks (angryjohn69@nc.rr.com)
+           © 2001 Krister Hansson
+           © 2001 Mads Pultz
+           © 2001 Marcel Narings
+           © 2001 Martin Weindel
+           © 2001 Matthew S. Ford
+           © 2001 Michael Lambert, All Rights Reserved
+           © 2001 Moonlight Enterprises, All Rights Reserved
+           © 2001 Phillip Pearson (http://www.myelin.co.nz)
+           © 2001 Ricardo Fernández Pascual
+           © 2001 Scott Sanders
+           © 2001 Wictor Wilén (wictor@iBizkit.se)
+           © 2001-2002 Jason Diamond  http://injektilo.org/
+           © 2001-2002 Marcin Szczepanski
+           © 2001-2002 Mike Kestner
+           © 2001-2002 Nick Drochak II
+           © 2001-2002 Southern Storm Software, Pty Ltd.
+           © 2001-2002 Vladimir Vukicevic (vladimir@pobox.com)
+           © 2001-2002 Wild West Software
+           © 2001-2003 Ximian, Inc.  http://www.ximian.com
+           © 2002 Alejandro Sánchez Acosta  <raciel@es.gnu.org>
+           © 2002 Ameya Sailesh Gargesh (ameya_13@yahoo.com)
+           © 2002 Brian Ritchie
+           © 2002 Chew Keong TAN
+           © 2002 Chris J Breisch
+           © 2002 Dan Lewis
+           © 2002 Daniel Stodden  <stodden@in.tum.de>   
+           © 2002 Duco Fijma
+           © 2002 Franklin Wise
+           © 2002 Free Software Foundation
+           © 2002 Gaurav Vaish
+           © 2002 Jaime Anguiano Olarra
+           © 2002 John Donagher
+           © 2002 Jon Guymon
+           © 2002 Kevin Winchester
+           © 2002 Kral Ferch
+           © 2002 Lawrence Pit
+           © 2002 Martin Adoue
+           © 2002 Martin Baulig
+           © 2002 Matt Hunter
+           © 2002 Miguel de Icaza
+           © 2002 Owen Brady (Ocean at owenbrady dot net)
+           © 2002 Piers Haken
+           © 2002 Rodrigo Moya
+           © 2002 Stuart Caborn
+           © 2002 Ulrich Kunitz
+           © 2002-2003 Dave Bettin
+           © 2002-2003 Eduardo Garcia Cebollero <kiwnix@yahoo.es>
+           © 2002-2003 Greg Reinacker, Reinacker & Associates, Inc. All rights reserved 
+           © 2002-2003 Jackson Harper, All rights reserved
+           © 2002-2003 Ville Palo
+           © 2002-2004 Motus Technologies Inc. (http://www.motus.com)
+           © 2002-2004 Tim Coleman
+           © 2002-2005 Cesar Lopez Nataren
+           © 2002-2005 Lluis Sanchez Gual
+           © 2002-2005 Rafael Teixeira
+           © 2002-2008 Daniel Morgan
+           © 2002-2008 Mainsoft Corporation.
+           © 2002-2010 Novell, Inc (http://www.novell.com)
+           © 2003 Aleksey Sanin (aleksey@aleksey.com)
+           © 2003 Alexandre Pigolkine (pigolkine@gmx.de)
+           © 2003 Brad Fitzpatrick
+           © 2003 Dominik Fretz
+           © 2003 Duncan Mak, Ximian Inc.
+           © 2003 Eric Glass
+           © 2003 Erik LeBel
+           © 2003 Gilles Freart
+           © 2003 Ian MacLean
+           © 2003 Jean-Marc André <jean-marc.andre@polymtl.ca>
+           © 2003 Jochen Wezel (CompuMaster GmbH)
+           © 2003 Johannes Roith <johannes@jroith.de>
+           © 2003 Joshua Tauberer
+           © 2003 Latitude Geographics Group, All rights reserved
+           © 2003 Lee Mallabone <gnome@fonicmonkey.net>
+           © 2003 Martin Willemoes Hansen
+           © 2003 Oleg Tkachenko
+           © 2003 Patrick Kalkman
+           © 2003 Patrik Torstensson
+           © 2003 Pedro Martínez Juliá  <yoros@wanadoo.es>
+           © 2003 Peter Van Isacker
+           © 2003 Phillip Jerkins
+           © 2003 Sergey Chaban (serge@wildwestsoftware.com)
+           © 2003 Stefan Görling
+           © 2003 The Mentalis.org Team (http://www.mentalis.org/)
+           © 2003 Thong (Tum) Nguyen [tum@veridicus.com]
+           © 2003-2004 Andreas Nahr
+           © 2003-2004 Atsushi Enomoto
+           © 2003-2004 Ben Maurer
+           © 2003-2004 Carlos Guzman Alvarez
+           © 2003-2004 Todd Berman
+           © 2003-2007 Alp Toker <alp@atoker.com>
+           © 2003-2007 Juraj Skripsky
+           © 2003-2008 Jonathan Pryor
+           © 2003-2008 Niels Kokholm
+           © 2003-2008 Peter Sestoft
+           © 2004 Edd Dumbill
+           © 2004 Everaldo Canuto
+           © 2004 IT+ A/S (http://www.itplus.dk)
+           © 2004 Ivan Hamilton
+           © 2004 Luca Barbieri
+           © 2004 Matthijs ter Woord
+           © 2004 Punit Todi
+           © 2004-2005 Geoff Norton.
+           © 2004-2006 Jaroslaw Kowalski
+           © 2004-2006 John Luke
+           © 2004-2008 Gert Driesen
+           © 2004-2008 HotFeet GmbH (http://www.hotfeet.ch)
+           © 2005 akiramei (mei@work.email.ne.jp)
+           © 2005 Carlo Kok (ck@carlo-kok.com)
+           © 2005 David Waite (mass@akuma.org)
+           © 2005 Hubert FONGARNAND
+           © 2005 Iain McCoy
+           © 2005 Senganal T
+           © 2005 Sharif FarsiWeb, Inc. (http://www.farsiweb.info)
+           © 2005 Voelcker Informatik AG
+           © 2005-2007 Marek Sieradzki
+           © 2005-2008 Jb Evain (http://evain.net)
+           © 2005-2008 Jiri George Moudry
+           © 2005-2008 Kornél Pál
+           © 2006 Alexander Olk
+           © 2006 Bruno Haible
+           © 2006 Evaluant RC S.A
+           © 2006 Forcom (http://www.forcom.com.pl/)
+           © 2006 Marek Habersack
+           © 2006 Matt Hargett
+           © 2006 Patrick Earl
+           © 2006 Sridhar Kulkarni
+           © 2006-2007 Dmitry S. Kataev
+           © 2006-2009 Daniel Nauck
+           © 2006-2009 Jonathan Chambers
+           © 2007 Andreas Noever
+           © 2007 Dean Brettle
+           © 2007 Marcos Cobena (http://www.youcannoteatbits.org/)
+           © 2007-2008 Andreia Gaita
+           © 2007-2008 Ivan N. Zlatev
+           © 2007-2008 Pascal Craponne
+           © 2007-2008 Stefan Klinger
+           © 2008 Andy Hume
+           © 2008 db4objects, Inc. (http://www.db4o.com)
+           © 2008 Eric Butler
+           © 2008 George Giolfan
+           © 2008 James Fitzsimons
+           © 2008 Michael Barker
+           © 2008 Realtime Worlds Ltd
+           © 2008-2009 Jérémie "Garuma" Laval
+           © 2009 Aaron Bockover
+           © 2009 Craig Sutherland
+           © 2009 Eric Maupin (http://www.ermau.com)
+           © 2009 leppie (http://xacc.wordpress.com/)
+           © 2009 Olivier Dufour olivier(dot)duff(at)gmail(dot)com
+           © 2011-2013 Xamarin Inc (http://www.xamarin.com)
+License: MIT
+
+Files: debian/*
+Copyright: © 2002 Robert McQueen <robot101@debian.org>
+           © 2002-2003 Alp Toker <alp@atoker.com>
+           © 2004-2013 Mirco Bauer <meebey@debian.org>
+           © 2008-2010 Jo Shields <directhex@apebox.org>
+License: GPL
+
+Files: debian/detector/*
+Copyright: © Ilya Konstantinov <future@shiny.co.il>
+           © 2005 Colin Watson <cjwatson@debian.org>
+License: GPL-2
+
+Files: mono/*
+Copyright: © 1995-1997 Peter Mattis, Spencer Kimball and Josh MacDonald
+           © 2000 Intel Corporation.  All rights reserved.
+           © 2001 Martin Weindel
+           © 2001 Radek Doulik
+           © 2001-2002 Ximian, Inc.
+           © 2002 Sergey Chaban
+           © 2002-2004 Neale Ferguson
+           © 2002-2009 Novell, Inc (http://www.novell.com)
+           © 2003 PT Cakram Datalingga Duaribu  http://www.cdl2000.com
+           © 2003-2004 Bernie Solomon
+           © 2006 Broadcom
+           © 2006 Sergey Tikhonov (tsv@solvo.ru)
+           © 2007 Randolph Chung
+           © 2007-2008 Andreas Faerber
+           © 2008 Kornél Pál
+           © 2011-2012 Xamarin Inc (http://www.xamarin.com)
+License: LGPL-2
+
+Files: libgc/*
+Copyright: © 1988-1989 Hans-J. Boehm, Alan J. Demers
+           © 1991-1996 by Xerox Corporation.  All rights reserved.
+           © 1996-1999 by Silicon Graphics.  All rights reserved.
+           © 1998 Fergus Henderson.  All rights reserved.
+           © 1999-2004 by Hewlett-Packard Company. All rights reserved.
+           © 1999-2001 by Red Hat, Inc. All rights reserved.
+License: other
+ THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
+ OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
+ 
+ Permission is hereby granted to use or copy this program
+ for any purpose,  provided the above notices are retained on all copies.
+ Permission to modify the code and to distribute modified code is granted,
+ provided the above notices are retained, and a notice that the code was
+ modified is included with the above copyright notice.
+
+Files: mono/benchmark/logic.cs, 
+       mcs/tools/prj2make/*, 
+       mcs/class/Compat.ICSharpCode.SharpZipLib/*, 
+       mcs/class/ICSharpCode.SharpZipLib/*
+Copyright: © 1998-2001 Free Software Foundation, Inc.
+           © 2001 Southern Storm Software, Pty Ltd.
+           © 2001-2005 Mike Krueger
+           © 2004 Francisco T. Martinez <paco@mfcon.com>
+           © 2004-2005 John Reilly
+License: GPL-2+
+
+Files: mcs/tools/pdb2mdb/*, 
+       mcs/class/dlr/*,
+       mcs/class/MicrosoftAjaxLibrary/*, 
+       mcs/class/System.Web.Mvc/*,
+       mcs/class/System.Web.Mvc2/*,
+       mono/docs/HtmlAgilityPack/*
+Copyright: © 2003 Ximian, Inc (http://www.ximian.com)
+           © 2007-2009 Microsoft Corporation
+           © 2009 Simon Mourier
+License: Ms-PL
+
+Files: mcs/tools/monodoc/Lucene.Net/*
+Copyright: © 2004 The Apache Software Foundation
+License: Apache-2.0
+
+Files: mcs/tools/csharp/repl.cs, 
+       mcs/mcs/*
+Copyright: © 2001-2003 Ximian, Inc (http://www.ximian.com)
+           © 2003-2009 Novell, Inc
+           © 2008 John Resig (jquery.com)
+License: MIT | GPL-2
+
+Files: mcs/class/ByteFX.Data/*, 
+       mcs/class/Npgsql/*
+Copyright: © 2001 Matthew S. Ford
+           © 2002-2004 ByteFX, Inc.
+           © 2002-2006 The Npgsql Development Team
+           © 2003 Pedro Martínez Juliá  <yoros@wanadoo.es>
+           © 2003 PostgreSQL Global Development Group
+           © 2003 PT Cakram Datalingga Duaribu (http://www.cdl2000.com)
+           © 2004 Emiliano Necciari
+           © 2004-2005 Novell, Inc (http://www.novell.com)
+           © 2004-2009 Rolf Bjarne Kvinge, RKvinge@novell.com
+License: LGPL-2.1+
+
+Files: mcs/tools/csharp/getline.cs
+Copyright: © 2008 Novell, Inc.
+License: MIT | Apache-2.0
+
+Files: mcs/tools/lc/*
+Copyright: © 2009 RemObjects Software
+           © 2008 Novell (http://www.novell.com)
+License: MIT
+
+Files: mcs/class/System.Web.Extensions/System.Web.Script.Serialization/JSON/*
+Copyright: © 2007 James Newton-King
+License: MIT
+
+Files: mcs/nunit24/*
+Copyright: © 2000-2002 Philip A. Craig
+           © 2002-2004 James W. Newkirk
+           © 2002-2004 Michael C. Two
+           © 2002-2004 Alexei A. Vorontsov
+           © 2002-2008 Charlie Poole
+License: other
+ This software is provided 'as-is', without any express or implied warranty. 
+ In no event will the authors be held liable for any damages arising from the 
+ use of this software.
+ 
+ Permission is granted to anyone to use this software for any purpose, including
+ commercial applications, and to alter it and redistribute it freely, subject to
+ the following restrictions:
+ 
+  1. The origin of this software must not be misrepresented; you must not claim
+  that you wrote the original software. If you use this software in a product,
+  an acknowledgment (see the following) in the product documentation is
+  required.
+ 
+    Portions Copyright © 2002-2007 Charlie Poole or Copyright © 2002-2004 James
+    W. Newkirk, Michael C. Two, Alexei A. Vorontsov or Copyright © 2000-2002
+    Philip A. Craig
+ 
+  2. Altered source versions must be plainly marked as such, and must not be
+  misrepresented as being the original software.
+ 
+  3. This notice may not be removed or altered from any source distribution.
+
+Files: mono/utils/strtod.c,
+       mcs/nunit24/NUnitExtensions/core/RowTest/*,
+       mcs/nunit24/NUnitExtensions/framework/RowTestAttribute.cs,
+       mcs/nunit24/NUnitExtensions/framework/SpecialValue.cs,
+       mcs/nunit24/NUnitExtensions/framework/RowAttribute.cs,
+       mcs/nunit24/NUnitExtensions/framework/RowTest/*
+Copyright: © 1991-2001 by Lucent Technologies
+           © 2007 Andreas Schlapsi
+License: MIT
+
+Files: ikvm-native/*,
+       mono/io-layer/wapi_glob.*,
+       mono/utils/freebsd-*,
+       mcs/jay/*,
+       mcs/class/RabbitMQ.Client/docs/*
+Copyright: © 1989-1993 The Regents of the University of California.  All rights reserved.
+           © 1996-1998 John D. Polstra.
+           © 2004 Apple Computer, Inc.
+           © 2004 Jeroen Frijters
+           © 2004 The Mozilla Foundation
+           © 2009 AMQP Working Group
+License: BSD
+
+Files: mcs/class/Mono.CodeContracts/*
+Copyright: © 2010 Chris Bacon
+           © 2011 Alexander Chebaturkin
+License: MIT
+
+Files: mcs/class/Mono.Parallel/*
+Copyright: © 2008-2011 Jérémie "Garuma" Laval
+License: MIT
+
+Files: mcs/class/System.ComponentModel.Composition.4.5/*
+Copyright: © Microsoft Corporation.  All rights reserved.
+License: Ms-PL
+Comment:
+  This directory contains an import of Microsoft's Mananged Extensibility 2
+  Preview 4 as downloaded from: http://mef.codeplex.com/
+  Licensed under Ms-PL: http://mef.codeplex.com/license
+
+Files: mcs/class/System.Net.Http/*
+Copyright: © 2011-2012 Xamarin Inc (http://www.xamarin.com)
+License: MIT
+
+Files: mcs/class/System.Threading.Tasks.Dataflow/*
+Copyright: © 2011 Jérémie "garuma" Laval
+           © 2012 Petr Onderka
+License: MIT
+
+Files: mcs/class/System.Web.Mvc3/*
+       mcs/class/System.Json.Microsoft/*
+Copyright: © Microsoft Corporation. All rights reserved.
+License: Apache-2.0
+Comment:
+  This directory contains an import of Microsoft's ASP.NET MVC project:
+  http://aspnetwebstack.codeplex.com/
+  Licensed under Apache-2.0: http://aspnetwebstack.codeplex.com/license
+
+Files: mcs/class/System.Json.Microsoft/Test/*
+Copyright: © 2011 Xamarin, Inc.
+License: MIT
+
+Files: mcs/class/System/Mono.Net.Dns/*
+Copyright: © 2011 Gonzalo Paniagua Javier
+License: Apache-2.0
+
+Files: external/Lucene.Net/*
+Copyright: © 2006-2012 The Apache Software Foundation
+License: Apache-2.0
+
+Files: external/Lucene.Net/src/contrib/Snowball/SF/Snowball/Ext/HungarianStemmer.cs
+       external/Lucene.Net/src/contrib/Snowball/SF/Snowball/Ext/PortugueseStemmer.cs
+       external/Lucene.Net/src/contrib/Snowball/SF/Snowball/Ext/TurkishStemmer.cs
+       external/Lucene.Net/src/contrib/Snowball/SF/Snowball/Ext/RomanianStemmer.cs
+Copyright: © 2001 Dr Martin Porter
+           © 2002 Richard Boulton
+           © 2006-2012 The Apache Software Foundation
+License: Apache-2.0 | BSD
+
+Files: external/Lucene.Net/src/core/Util/UnicodeUtil.cs
+Copyright: © 2001-2004 Unicode, Inc.
+           © 2006-2012 The Apache Software Foundation
+License: Apache 2.0 | other
+ Disclaimer
+
+ This source code is provided as is by Unicode, Inc. No claims are
+ made as to fitness for any particular purpose. No warranties of any
+ kind are expressed or implied. The recipient agrees to determine
+ applicability of information provided. If this file has been
+ purchased on magnetic or optical media from Unicode, Inc., the
+ sole remedy for any claim will be exchange of defective media
+ within 90 days of receipt.
+
+ Limitations on Rights to Redistribute This Code
+
+ Unicode, Inc. hereby grants the right to freely use the information
+ supplied in this file in the creation of products supporting the
+ Unicode Standard, and to make copies of this file in any form
+ for internal or external distribution as long as this notice
+ remains attached.
+
+Files: external/Newtonsoft.Json/*
+Copyright: © 2007 James Newton-King
+License: MIT
+
+Files: external/Newtonsoft.Json/Src/Newtonsoft.Json/Utilities/LinqBridge.cs
+Copyright: © 2007-2009 Atif Aziz, Joseph Albahari. All rights reserved.
+License: BSD
+
+Files: external/aspnetwebstack/*
+Copyright: © Microsoft Corporation.  All rights reserved.
+License: Apache-2.0
+
+Files: external/aspnetwebstack/test/System.Web.Helpers.Test/TestFiles/xhtml11-flat.dtd
+Copyright: © 1998-2000 World Wide Web Consortium
+License: other
+ Permission to use, copy, modify and distribute the XHTML DTD and its
+ accompanying documentation for any purpose and without fee is hereby
+ granted in perpetuity, provided that the above copyright notice and
+ this paragraph appear in all copies.  The copyright holders make no
+ representation about the suitability of the DTD for any purpose.
+
+ It is provided "as is" without expressed or implied warranty.
+
+Files: external/cecil/*
+Copyright: © 2002-2003 Ximian, Inc. http://www.ximian.com
+           © 2003 Motus Technologies Inc. (http://www.motus.com)
+           © 2004-2006 Novell Inc. (http://www.novell.com)
+           © 2008-2011 Jb Evain
+           © 2008 Juerg Billeter
+License: MIT
+
+Files: external/cecil/symbols/pdb/Microsoft.Cci.Pdb/*
+Copyright: © Microsoft. All rights reserved
+License: Ms-PL
+
+Files: external/entityframework/*
+Copyright: © Microsoft Open Technologies, Inc.  All rights reserved.
+License: Apache-2.0
+
+Files: external/ikvm/openjdk/*
+       external/ikvm/openjdk/java/awt/image/BufferedImage.java
+       external/ikvm/openjdk/java/awt/image/IndexColorModel.java
+       external/ikvm/openjdk/java/awt/GraphicsConfiguration.java
+       external/ikvm/runtime/fdlibm/*
+       external/ikvm/openjdk/sun/font/StrikeCache.java
+       external/ikvm/openjdk/sun/font/FontManager.java
+Copyright: © 1994-1997, 2003, 2006-2008, 2010-2012 Oracle and/or its affiliates. All rights reserved
+           © 1996, 1997 Taligent, Inc. - All Rights Reserved
+           © 1996-1999 IBM Corp. - All Rights Reserved
+           © 1999-2001, 2004-2006, 2008, 2011 Free Software Foundation, Inc
+           © 2002-2007, 2009 Jeroen Frijters
+           © 2007 Red Hat, Inc
+           © 2009-2012 Volker Berlin (i-net software)
+           © 2010-2011 Karsten Heinrich (i-net software)
+License: GPL-2
+
+Files: external/ikvm/openjdk/java/util/zip/*
+       external/ikvm/openjdk/java/awt/color/ICC_ColorSpace.java
+       external/ikvm/openjdk/java/awt/image/*
+       external/ikvm/openjdk/icedtea/jce/
+       external/ikvm/openjdk/gnu/java/*
+       external/ikvm/openjdk/sun/java2d/SunCompositeContext.java
+Copyright: © 1999-2005, 2011 Free Software Foundation, Inc
+License: GPL-2+
+
+Files: external/ikvm/openjdk/java/lang/LangHelper.java
+       external/ikvm/openjdk/java/util/zip/ClassStubZipEntry.java
+       external/ikvm/openjdk/java/net/SocketUtil.java
+       external/ikvm/openjdk/java/lang/ref/Reference.java
+       external/ikvm/openjdk/java/lang/VMSystemProperties.java
+       external/ikvm/openjdk/java/lang/LangHelper.java
+       external/ikvm/openjdk/java/lang/reflect/ReflectHelper.java
+       external/ikvm/openjdk/sun/net/www/protocol/ikvmres/Handler.java
+       external/ikvm/openjdk/sun/font/*
+       external/ikvm/openjdk/sun/java2d/*
+       external/ikvm/openjdk/sun/jdbc/odbc/*
+       external/ikvm/openjdk/sun/security/*
+       external/ikvm/openjdk/sun/awt/Win32FontManager.java
+       external/ikvm/openjdk/sun/awt/windows/WPrinterJob.java
+       external/ikvm/openjdk/sun/awt/IkvmDataTransferer.java
+       external/ikvm/openjdk/sun/awt/AppContextDC.java
+       external/ikvm/openjdk/sun/awt/image/GifImageDecoder.java
+       external/ikvm/openjdk/sun/awt/image/JPEGImageDecoder.java
+       external/ikvm/openjdk/sun/awt/image/IkvmImageDecoder.java
+       external/ikvm/openjdk/sun/awt/image/ImageRepresentation.java
+       external/ikvm/openjdk/sun/nio/ch/SelectionKeyImpl.java
+       external/ikvm/openjdk/sun/nio/fs/NetFileSystemProvider.java
+       external/ikvm/openjdk/sun/nio/fs/DefaultFileSystemProvider.java
+       external/ikvm/openjdk/sun/nio/fs/DefaultFileTypeDetector.java
+       external/ikvm/openjdk/sun/nio/fs/NetFileSystem.java
+       external/ikvm/openjdk/sun/nio/fs/NetPath.java
+       external/ikvm/openjdk/sun/misc/Unsafe.java
+       external/ikvm/openjdk/sun/misc/MiscHelper.java
+       external/ikvm/openjdk/sun/print/PrintPeer.java
+       external/ikvm/openjdk/sun/print/UnixPrintServiceLookup.java
+       external/ikvm/openjdk/sun/print/Win32PrintJob.java
+       external/ikvm/openjdk/sun/print/Win32PrintServiceLookup.java
+       external/ikvm/openjdk/sun/management/FileSystemImpl.java
+       external/ikvm/openjdk/com/sun/imageio/plugins/jpeg/JPEGImageWriter.java
+       external/ikvm/openjdk/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
+       external/ikvm/openjdk/com/sun/management/OperatingSystem.java
+       external/ikvm/openjdk/ikvm/awt/IkvmToolkit.java
+       external/ikvm/openjdk/ikvm/internal/*
+       external/ikvm/openjdk/ExtensionAttribute.java
+       external/ikvm/openjdk/GenerateSystemCore.cs
+       external/ikvm/classpath/sun/misc/Ref.java
+       external/ikvm/classpath/ikvm/*
+       external/ikvm/classpath/gnu/*
+       external/ikvm/runtime/*
+       external/ikvm/debugger/*
+       external/ikvm/ikvm/*
+       external/ikvm/ikvmstub/*
+       external/ikvm/ikvmc/*
+       external/ikvm/awt/*
+       external/ikvm/tools/*
+       external/ikvm/msbuild/*
+       external/ikvm/reflect/*
+       external/ikvm/native/*
+Copyright: © 2002-2013 Jeroen Frijters
+           © 2006-2013 Volker Berlin (i-net software)
+           © 2006 Active Endpoints, Inc
+           © 2010-2011 Karsten Heinrich (i-net software)
+           © 2011 Trevor Bell (Siemens Energy, Inc.)
+           © 2011 Marek Safar
+License: zlib/libpng
+
+Files: external/rx/*
+Copyright: Microsoft Open Technologies, Inc. All rights reserved
+License: Apache-2.0
+Comment:
+  This directory contains an import of Microsoft's Reactive Extensions project:
+  http://rx.codeplex.com/
+  Licensed under Apache-2.0: http://rx.codeplex.com/license
+
+Files: external/debian-snapshot/*
+Copyright: © 2005, 2007-2010 Mirco Bauer <meebey@debian.org>
+           © 2006-2007 Dylan R. E. Moonfire <debian@mfgames.com>
+           © 2006 Sebastian Dröge <slomo@debian.org>
+           © 2010, 2012 Jo Shields <directhex@apebox.org>
+License: GPL
+
+Files: support/*
+Copyright: © 1995-2006 Mark Adler
+           © 1995-2006 Jean-loup Gailly.
+           © 1998-2005 Gilles Vollant
+           © 2004-2006 Jonathan Pryor
+           © 2005 Daniel Drake
+           © 2005-2009 Novell, Inc.
+License: zlib/libpng
+
+Files: support/minizip/*
+Copyright: © 1990-2000 Info-ZIP.  All rights reserved.
+           © 1998-2005 Gilles Vollant
+License: zlib/libpng
+
+License: Apache-2.0
+ On Debian systems the full text of the Apache Software License 2.0 can be
+ found in the `/usr/share/common-licenses/Apache-2.0' file.
+
+License: LGPL-2
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License as published by the Free Software Foundation;
+ version 2 of the License.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+
+ You should have received a copy of the GNU Library General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+
+ On Debian systems the full text of the GNU Library General Public License can be
+ found in the `/usr/share/common-licenses/LGPL-2' file.
+
+License: LGPL-2.1
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation;
+ version 2.1 of the License.
+
+ This library is distributed in the hope that it will be useful, 
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public  
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+ On Debian systems the full text of the GNU Lesser General Public License can be
+ found in the `/usr/share/common-licenses/LGPL-2.1' file.
+
+License: GPL
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or   
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ On Debian systems the full text of the GNU General Public License can be found
+ in the `/usr/share/common-licenses/GPL' file.
+
+License: GPL-2
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 2 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ On Debian systems the full text of the GNU General Public License can be found
+ in the `/usr/share/common-licenses/GPL-2' file.
+
+License: GPL-2+
+ Ths program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ Th is program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ On Debian systems the full text of the GNU General Public License can be found
+ in the `/usr/share/common-licenses/GPL-2' file.
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ 
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: zlib/libpng
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+License: BSD
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the <ORGANIZATION> nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ DAMAGE.
+
+License: Ms-PL
+ This license governs use of the accompanying software. If you use the 
+ software, you accept this license. If you do not accept the license, do not 
+ use the software.
+
+ 1. Definitions
+ The terms "reproduce," "reproduction," "derivative works," and "distribution" 
+ have the same meaning here as under U.S. copyright law.
+ A "contribution" is the original software, or any additions or changes to 
+ the software.
+ A "contributor" is any person that distributes its contribution under this 
+ license.
+ "Licensed patents" are a contributor's patent claims that read directly on its 
+ contribution.
+
+ 2. Grant of Rights
+ (A) Copyright Grant- Subject to the terms of this license, including the 
+ license conditions and limitations in section 3, each contributor grants you 
+ a non-exclusive, worldwide, royalty-free copyright license to reproduce its 
+ contribution, prepare derivative works of its contribution, and distribute 
+ its contribution or any derivative works that you create.
+ (B) Patent Grant- Subject to the terms of this license, including the license 
+ conditions and limitations in section 3, each contributor grants you a 
+ non-exclusive, worldwide, royalty-free license under its licensed patents to 
+ make, have made, use, sell, offer for sale, import, and/or otherwise dispose 
+ of its contribution in the software or derivative works of the 
+ contribution in the software.
+
+ 3. Conditions and Limitations
+ (A) No Trademark License- This license does not grant you rights to use any 
+ contributors' name, logo, or trademarks.
+ (B) If you bring a patent claim against any contributor over patents that you 
+ claim are infringed by the software, your patent license from such 
+ contributor to the software ends automatically.
+ (C) If you distribute any portion of the software, you must retain all 
+ copyright, patent, trademark, and attribution notices that are present in the 
+ software.
+ (D) If you distribute any portion of the software in source code form, you may 
+ do so only under this license by including a complete copy of this license 
+ with your distribution. If you distribute any portion of the software in 
+ compiled or object code form, you may only do so under a license that complies 
+ with this license.
+ (E) The software is licensed "as-is." You bear the risk of using it. The 
+ contributors give no express warranties, guarantees or conditions. You may 
+ have additional consumer rights under your local laws which this license 
+ cannot change. To the extent permitted under your local laws, the contributors 
+ exclude the implied warranties of merchantability, fitness for a particular 
+ purpose and non-infringement.
+
+

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -38,7 +38,32 @@
     "Snippets"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:cpp",
+    "onLanguage:c",
+    "onCommand:extension.pickNativeProcess",
+    "onCommand:extension.pickRemoteNativeProcess",
+    "onCommand:C_Cpp.BuildAndDebugActiveFile",
+    "onCommand:C_Cpp.ConfigurationEditJSON",
+    "onCommand:C_Cpp.ConfigurationEditUI",
+    "onCommand:C_Cpp.ConfigurationSelect",
+    "onCommand:C_Cpp.ConfigurationProviderSelect",
+    "onCommand:C_Cpp.SwitchHeaderSource",
+    "onCommand:C_Cpp.EnableErrorSquiggles",
+    "onCommand:C_Cpp.DisableErrorSquiggles",
+    "onCommand:C_Cpp.ToggleIncludeFallback",
+    "onCommand:C_Cpp.ToggleDimInactiveRegions",
+    "onCommand:C_Cpp.ResetDatabase",
+    "onCommand:C_Cpp.TakeSurvey",
+    "onCommand:C_Cpp.LogDiagnostics",
+    "onCommand:C_Cpp.RescanWorkspace",
+    "onCommand:C_Cpp.VcpkgClipboardInstallSuggested",
+    "onCommand:C_Cpp.VcpkgClipboardOnlineHelpSuggested",
+    "onCommand:C_Cpp.GenerateEditorConfig",
+    "onDebugInitialConfigurations",
+    "onDebugResolve:cppdbg",
+    "onDebugResolve:cppvsdbg",
+    "workspaceContains:/.vscode/c_cpp_properties.json",
+    "onFileSystem:cpptools-schema"
   ],
   "main": "./dist/main",
   "contributes": {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -36,7 +36,14 @@ const disposables: vscode.Disposable[] = [];
 export async function activate(context: vscode.ExtensionContext): Promise<CppToolsApi & CppToolsExtension> {
     let errMsg: string = "";
     const arch: string = os.arch();
-    if (arch !== 'x64' && (process.platform !== 'win32' || (arch !== 'ia32' && arch !== 'arm64')) && (process.platform !== 'linux' || (arch !== 'x64' && arch !== 'arm' && arch !== 'arm64'))) {
+    if (arch !== 'x64' 
+    && 
+    (process.platform !== 'win32' || (arch !== 'ia32' && arch !== 'arm64')) 
+    &&
+    (process.platform !== 'darwin' || arch !== 'arm64') // To support Apple Silicon
+    &&
+    (process.platform !== 'linux' || (arch !== 'x64' && arch !== 'arm' && arch !== 'arm64'))
+    ) {
         errMsg = localize("architecture.not.supported", "Architecture {0} is not supported. ", String(arch));
     } else if (process.platform === 'linux' && fs.existsSync('/etc/alpine-release')) {
         errMsg = localize("apline.containers.not.supported", "Alpine containers are not supported.");


### PR DESCRIPTION
As the standard library for arm64 and x86 in macOS should be identical, I thought that it could be very easy to make this extension support Apple Silicon by just adding one condition for Apple Silicon in its activate() function included in main.ts. Here I just implemented this simple modification and have tried for one week. Luckily, no bug appears. Thus, I decided to open a pull request to let you check if this modification is okay for supporting Apple Silicon.

Thanks!