### PR TITLE
Add field to activation telemetry for web-based Codespaces

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -276,6 +276,9 @@ function sendActivationTelemetry(): void {
         }
         machineIdPersistentState.Value = vscode.env.machineId;
     }
+    if (vscode.env.uiKind === vscode.UIKind.Web) {
+        activateEvent["WebUI"] = "1";
+    }
     telemetry.logLanguageServerEvent("Activate", activateEvent);
 }
 


### PR DESCRIPTION
Nick Uhlenhuth has telemetry for Codespaces users, but it does not differentiate between web-based and non-web-based.  Since all Web-based users are currently Codespaces users, this might help us distinguish between them.