### PR TITLE
Separate "investigate costing" and "investigate" for debugger issue workflows

### DIFF
--- a/.github/workflows/investigate-closer-debugger.yml
+++ b/.github/workflows/investigate-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/StaleCloser
         with:
           readonly: ${{ github.event.inputs.readonly }}
-          labels: "investigate,debugger"
+          labels: investigate,debugger
           ignoreLabels: language service,internal
           closeDays: 180
           closeComment: "This issue has been closed automatically because it has not had recent activity."

--- a/.github/workflows/investigate-costing-closer-debugger.yml
+++ b/.github/workflows/investigate-costing-closer-debugger.yml
@@ -1,4 +1,4 @@
-name: Investigate closer - debugger
+name: Investigate Costing closer - debugger
 on:
   schedule:
     - cron: 10 11 * * * # Run at 11:10 AM UTC (3:10 AM PST, 4:10 AM PDT)
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/StaleCloser
         with:
           readonly: ${{ github.event.inputs.readonly }}
-          labels: "investigate,debugger"
+          labels: "investigate: costing,debugger"
           ignoreLabels: language service,internal
           closeDays: 180
           closeComment: "This issue has been closed automatically because it has not had recent activity."


### PR DESCRIPTION
The initial query to get issues for "investigate" and "investigate: costing" returned 0 results because the search needs to be mutually exclusive. So separate these queries into their own workflows.