### PR TITLE
remoteProcessPicker: Add machinectl support

### DIFF
--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -131,7 +131,7 @@ export class RemoteAttachPicker {
             outerQuote = "";
         }
 
-        return `${outerQuote}sh -c ${innerQuote}uname && if [ ${parameterBegin}uname${parameterEnd} = ${escapedQuote}Linux${escapedQuote} ] ; ` +
+        return `${outerQuote}/bin/sh -c ${innerQuote}uname && if [ ${parameterBegin}uname${parameterEnd} = ${escapedQuote}Linux${escapedQuote} ] ; ` +
         `then ${PsProcessParser.psLinuxCommand} ; elif [ ${parameterBegin}uname${parameterEnd} = ${escapedQuote}Darwin${escapedQuote} ] ; ` +
         `then ${PsProcessParser.psDarwinCommand}; fi${innerQuote}${outerQuote}`;
     }


### PR DESCRIPTION
Two commits that make remoteProcessPicker work together with machinectl as the pipe transport.

Tested with:

```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "(gdb) Pipe Attach",
            "type": "cppdbg",
            "request": "attach",
            "program": "/usr/lib/systemd/systemd-resolved",
            "processId": "${command:pickRemoteProcess}",
            "pipeTransport": {
                "pipeCwd": "/usr/bin",
                "pipeProgram": "/usr/bin/machinectl",
                "pipeArgs": ["--quiet", "shell", "image"],
                "debuggerPath": "/usr/bin/gdb",
                "quoteArgs": false,
            },
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ],
        }
    ]
}
```

Which correctly shows the llist of processes:

![image](https://user-images.githubusercontent.com/9395011/102696402-e8aff180-4225-11eb-94e3-344513533621.png)
