### PR TITLE
Output the cppbuild command used. Fix D warnings.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix #include completion not sorting _ last. [#3465](https://github.com/microsoft/vscode-cpptools/issues/3465)
 * Fix crash when certain JavaScript files are parsed as C++. [#3858](https://github.com/microsoft/vscode-cpptools/issues/3858)
 * Fix IntelliSense squiggle about not being able to assign to an object of its own type. [#3883](https://github.com/microsoft/vscode-cpptools/issues/3883)
-* Fix hover and Find All References for template function overloads. [#4044[(https://github.com/microsoft/vscode-cpptools/issues/4044), [#4249](https://github.com/microsoft/vscode-cpptools/issues/4249)
+* Fix hover and Find All References for template function overloads. [#4044](https://github.com/microsoft/vscode-cpptools/issues/4044), [#4249](https://github.com/microsoft/vscode-cpptools/issues/4249)
 * Fix the Outline view for nested namespaces. [#4456](https://github.com/microsoft/vscode-cpptools/issues/4456)
 * Fix Outline view with`"**/.*"` in `files.exclude`. [#4602](https://github.com/microsoft/vscode-cpptools/issues/4602)
 * Fix the Outline view for nested structs/classes. [#4781](https://github.com/microsoft/vscode-cpptools/issues/4871)

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -379,7 +379,7 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
                     if (is_cl) {
                         // cl.exe, header info may not appear if /nologo is used.
                         if (_stderr) {
-                            splitWriteEmitter(_stderr); // compiler header info and command line D warnings
+                            splitWriteEmitter(_stderr); // compiler header info and command line D warnings (e.g. when /MTd and /MDd are both used)
                         }
                         splitWriteEmitter(stdout); // linker header info and potentially compiler C warnings
                     }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -370,6 +370,7 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
                 this.writeEmitter.fire(line + this.endOfLine);
             }
         };
+        this.writeEmitter.fire(activeCommand + this.endOfLine);
         try {
             const result: number = await new Promise<number>((resolve, reject) => {
                 cp.exec(activeCommand, this.options, (_error, stdout, _stderr) => {
@@ -391,10 +392,15 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
                         this.writeEmitter.fire(localize("build_finished_with_warnings", "Build finished with warning(s)") + dot + this.endOfLine);
                         splitWriteEmitter(_stderr);
                         resolve(0);
-                    } else if (stdout && stdout.includes("warning C")) { // cl.exe
+                    } else if (stdout && stdout.includes("warning C")) { // cl.exe, compiler warnings
                         telemetry.logLanguageServerEvent("cppBuildTaskWarnings");
                         this.writeEmitter.fire(localize("build_finished_with_warnings", "Build finished with warning(s)") + dot + this.endOfLine);
                         splitWriteEmitter(stdout);
+                        resolve(0);
+                    } else if (_stderr && _stderr.includes("warning D")) { // cl.exe, command line warnings
+                        telemetry.logLanguageServerEvent("cppBuildTaskWarnings");
+                        this.writeEmitter.fire(localize("build_finished_with_warnings", "Build finished with warning(s)") + dot + this.endOfLine);
+                        splitWriteEmitter(_stderr);
                         resolve(0);
                     } else {
                         if (stdout) {

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -166,7 +166,7 @@ export class CppBuildTaskProvider implements TaskProvider {
                 CppBuildTaskProvider.CppBuildSourceStr + ": " : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
             const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
             const isWindows: boolean = os.platform() === 'win32';
-            let args: string[] = isCl ? ['/Zi', '/EHsc', '/Fe:', filePath + '.exe', '${file}'] : ['-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
+            let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', filePath + '.exe', '${file}'] : ['-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/6647 .
Also fixes "D" command line warnings with cl.exe.
Move the build result message to the end.
Handle the /nologo case and always shows the logo/header if it exists (but default to use /nologo).