### PR TITLE
implement addNodeAddonIncludePaths

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1106,7 +1106,7 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%c_cpp.configuration.addNodeAddonIncludePaths.description%",
-          "scope": "machine-overridable"
+          "scope": "resource"
         },
         "C_Cpp.renameRequiresIdentifier": {
           "type": "boolean",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1106,7 +1106,7 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%c_cpp.configuration.addNodeAddonIncludePaths.description%",
-          "scope": "resource"
+          "scope": "application"
         },
         "C_Cpp.renameRequiresIdentifier": {
           "type": "boolean",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1102,6 +1102,12 @@
           "markdownDescription": "%c_cpp.configuration.vcpkg.enabled.markdownDescription%",
           "scope": "resource"
         },
+        "C_Cpp.addNodeAddonIncludePaths": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "%c_cpp.configuration.addNodeAddonIncludePaths.description%",
+          "scope": "machine-overridable"
+        },
         "C_Cpp.renameRequiresIdentifier": {
           "type": "boolean",
           "default": true,

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -160,6 +160,7 @@
     "c_cpp.configuration.enhancedColorization.description": "If enabled, code is colorized based on IntelliSense. This setting only applies if intelliSenseEngine is set to \"Default\".",
     "c_cpp.configuration.codeFolding.description": "If enabled, code folding ranges are provided by the language server.",
     "c_cpp.configuration.vcpkg.enabled.markdownDescription": "Enable integration services for the [vcpkg dependency manager](https://aka.ms/vcpkg/).",
+    "c_cpp.configuration.addNodeAddonIncludePaths.description": "Add include paths from nan and node-addon-api when they're dependencies.",
     "c_cpp.configuration.renameRequiresIdentifier.description": "If true, 'Rename Symbol' will require a valid C/C++ identifier.",
     "c_cpp.configuration.debugger.useBacktickCommandSubstitution.description": "If true, debugger shell command substitution will use obsolete backtick (`).",
     "c_cpp.contributes.views.cppReferencesView.title": "C/C++: Other references results",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1367,6 +1367,11 @@ export class DefaultClient implements Client {
                             this.semanticTokensProvider = undefined;
                         }
                     }
+                    // if addNodeAddonIncludePaths was turned on but no includes have been found yet then 1) presume that nan
+                    // or node-addon-api was installed so prompt for reload.
+                    if (changedSettings["addNodeAddonIncludePaths"] && settings.addNodeAddonIncludePaths && this.configuration.nodeAddonIncludesFound() === 0) {
+                        util.promptForReloadWindowDueToSettingsChange();
+                    }
                 }
                 this.configuration.onDidChangeSettings();
                 telemetry.logLanguageServerEvent("CppSettingsChange", changedSettings, undefined);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -404,8 +404,8 @@ export class CppProperties {
 
         const pathToNode: string = which.sync("node");
         const nodeAddonMap: { [dependency: string]: string } = {
-            "nan": `${pathToNode} --no-warnings -e "require('nan')"`,
-            "node-addon-api": `${pathToNode} --no-warnings -p "require('node-addon-api').include"`
+            "nan": `"${pathToNode}" --no-warnings -e "require('nan')"`,
+            "node-addon-api": `"${pathToNode}" --no-warnings -p "require('node-addon-api').include"`
         };
 
         if (!error) {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -322,10 +322,6 @@ export class CppProperties {
             configuration.includePath = [defaultFolder];
         }
 
-        if (settings.addNodeAddonIncludePaths) {
-            configuration.includePath = configuration.includePath.concat(this.nodeAddonIncludes);
-        }
-
         // browse.path is not set by default anymore. When it is not set, the includePath will be used instead.
         if (isUnset(settings.defaultDefines)) {
             configuration.defines = (process.platform === 'win32') ? ["_DEBUG", "UNICODE", "_UNICODE"] : [];
@@ -701,7 +697,8 @@ export class CppProperties {
 
             configuration.includePath = this.updateConfigurationStringArray(configuration.includePath, settings.defaultIncludePath, env);
             if (settings.addNodeAddonIncludePaths) {
-                configuration.includePath = this.updateConfigurationStringArray(configuration.includePath, this.nodeAddonIncludes, env);
+                const includePath: string[] = configuration.includePath || [];
+                configuration.includePath = includePath.concat(this.nodeAddonIncludes.filter(i => includePath.indexOf(i) < 0));
             }
             configuration.defines = this.updateConfigurationStringArray(configuration.defines, settings.defaultDefines, env);
             configuration.macFrameworkPath = this.updateConfigurationStringArray(configuration.macFrameworkPath, settings.defaultMacFrameworkPath, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -406,9 +406,10 @@ export class CppProperties {
             .then(pdj => {pdjFound = true; return JSON.parse(pdj); })
             .catch(e => (error = e));
 
+        const pathToNode: string = which.sync("node");
         const nodeAddonMap: { [dependency: string]: string } = {
-            "nan": "node --no-warnings -e \"require('nan')\"",
-            "node-addon-api": "node --no-warnings -p \"require('node-addon-api').include\""
+            "nan": `${pathToNode} --no-warnings -e "require('nan')"`,
+            "node-addon-api": `${pathToNode} --no-warnings -p "require('node-addon-api').include"`
         };
 
         if (!error) {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -141,6 +141,7 @@ export class CppSettings extends Settings {
     public get preferredPathSeparator(): string | undefined { return super.Section.get<string>("preferredPathSeparator"); }
     public get updateChannel(): string | undefined { return super.Section.get<string>("updateChannel"); }
     public get vcpkgEnabled(): boolean | undefined { return super.Section.get<boolean>("vcpkg.enabled"); }
+    public get addNodeAddonIncludePaths(): boolean | undefined { return super.Section.get<boolean>("addNodeAddonIncludePaths"); }
     public get renameRequiresIdentifier(): boolean | undefined { return super.Section.get<boolean>("renameRequiresIdentifier"); }
     public get defaultIncludePath(): string[] | undefined { return super.Section.get<string[]>("default.includePath"); }
     public get defaultDefines(): string[] | undefined { return super.Section.get<string[]>("default.defines"); }


### PR DESCRIPTION
This PR addresses the common cases for #4854 by adding the include paths specified by `nan` and `node-addon-api` when they are listed as dependencies in package.json. This was the first time I've looked at vscode-cpptools code and it's also the first time I've written any typescript, so suggestions about how I can improve in either area are welcome.

I haven't changed the changelog nor even looked at adding a specific test pending feedback. Afaict, it passes the unit tests and integration tests but I don't see any positive feedback to be sure.

I modified the insiders branch, so that is the target for this PR. Not sure whether that's the regular practice or not.

Questions:

- Is "machine-overridable" the correct scope [package.json 1109](https://github.com/microsoft/vscode-cpptools/compare/insiders...bmacnaughton:node-addon-includes?expand=1#diff-62bdf835c36931e2307d4d55bb2f11bcfef5e8dc5714ef35b7d5ae81bc5a10bcR1109)
- should it check `settings.addNodeAddonIncludePaths` or just concat an empty array [configuration.ts 327](https://github.com/microsoft/vscode-cpptools/compare/insiders...bmacnaughton:node-addon-includes?expand=1#diff-9b32cba7ca4094f68784eb207728f8c4dd5aa6f0a3aa601c01c55fec735b589eR327)
- mapping the dependencies to commands uses an inline definition. not sure the best practices for this [configuration.ts 398](https://github.com/microsoft/vscode-cpptools/compare/insiders...bmacnaughton:node-addon-includes?expand=1#diff-9b32cba7ca4094f68784eb207728f8c4dd5aa6f0a3aa601c01c55fec735b589eR327).
- `pfs` (fs/promises) is defined at the top of the file but only used one place [configuration.ts 408](https://github.com/microsoft/vscode-cpptools/compare/insiders...bmacnaughton:node-addon-includes?expand=1#diff-9b32cba7ca4094f68784eb207728f8c4dd5aa6f0a3aa601c01c55fec735b589eR327). prefer it locally scoped?
- the include path loop uses a labeled loop. I didn't see those anywhere else; it could be replaced with an if-level. [configuration.ts 414](https://github.com/microsoft/vscode-cpptools/compare/insiders...bmacnaughton:node-addon-includes?expand=1#diff-9b32cba7ca4094f68784eb207728f8c4dd5aa6f0a3aa601c01c55fec735b589eR327)

Obviously, you're welcome to change names, wording, etc. or ask me to do so.
