### PR TITLE
Update runtime licenses.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
- 
+The binaries downloaded at runtime after the initial installation are governed
+by the more restrictive proprietary license terms found at [RuntimeLicenses](RuntimeLicenses)
+
 MIT License
 
 Copyright (c) 2020 Microsoft

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-The binaries downloaded at runtime after the initial installation are governed
-by the more restrictive proprietary license terms found at [RuntimeLicenses](RuntimeLicenses).
+Additional binary files may be downloaded at runtime after the initial
+installation; these are governed by the more restrictive proprietary license
+terms found at [RuntimeLicenses](RuntimeLicenses).
 
 MIT License
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 The binaries downloaded at runtime after the initial installation are governed
-by the more restrictive proprietary license terms found at [RuntimeLicenses](RuntimeLicenses)
+by the more restrictive proprietary license terms found at [RuntimeLicenses](RuntimeLicenses).
 
 MIT License
 

--- a/RuntimeLicenses/cpptools-LICENSE.txt
+++ b/RuntimeLicenses/cpptools-LICENSE.txt
@@ -1,190 +1,192 @@
-All VS Marketplace extensions, including this C/C++ Extension for Visual Studio 
-Code, must also be used consistent with the VS Marketplace Terms of Use at 
+All VS Marketplace extensions, including this C/C++ Extension for Visual Studio
+Code, must also be used consistent with the VS Marketplace Terms of Use at
 http://aka.ms/VSMarketplace-TOU
 
 MICROSOFT SOFTWARE LICENSE TERMS
 
-MICROSOFT C/C++ EXTENSION FOR VISUAL STUDIO CODE 
+MICROSOFT C/C++ EXTENSION FOR VISUAL STUDIO CODE
 ________________________________________
-These license terms are an agreement between you and Microsoft Corporation (or 
-one of its affiliates). They apply to the software named above and any 
-Microsoft services or software updates (except to the extent such services or 
-updates are accompanied by new or additional terms, in which case those 
-different terms apply prospectively and do not alter your or Microsoft’s 
-rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE 
-LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT 
+These license terms are an agreement between you and Microsoft Corporation (or
+one of its affiliates). They apply to the software named above and any
+Microsoft services or software updates (except to the extent such services or
+updates are accompanied by new or additional terms, in which case those
+different terms apply prospectively and do not alter your or Microsoft’s
+rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE
+LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT
 THESE TERMS.
 
-1.	INSTALLATION AND USE RIGHTS. 
-a)	General. You may install and use any number of copies of the software 
-only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, 
-Azure DevOps, Team Foundation Server, and successor Microsoft products and 
-services (collectively, the “Visual Studio Products and Services”) to 
-develop and test your applications.
-b)	Third Party Components. The software may include third party components 
-with separate legal notices or governed by other agreements, as may be 
+1.  INSTALLATION AND USE RIGHTS.
+a)  General. You may install and use any number of copies of the software
+only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code,
+Azure DevOps, Team Foundation Server, and successor Microsoft products and
+services to develop and test your applications. Further, you may install, use
+and/or deploy these software copies via a network management system or as part
+of a desktop image within your internal corporate network to develop and test
+your applications.
+b)  Third Party Components. The software may include third party components
+with separate legal notices or governed by other agreements, as may be
 described in the ThirdPartyNotices file(s) accompanying the software.
 
-2.	SCOPE OF LICENSE. The software is licensed, not sold. This agreement 
-only gives you some rights to use the software. Microsoft reserves all other 
-rights.  For clarification Microsoft, or its licensors, retains ownership of 
-all aspects of the software.   Unless applicable law gives you more rights 
-despite this limitation, you may use the software only as expressly permitted 
-in this agreement. In doing so, you must comply with any technical limitations 
-in the software that only allow you to use it in certain ways. For example, if 
-Microsoft technically limits or disables extensibility for the software, you 
-may not extend the software by, among other things, loading or injecting into 
-the software any non-Microsoft add-ins, macros, or packages; modifying the 
-software registry settings; or adding features or functionality equivalent to 
+2.  SCOPE OF LICENSE. The software is licensed, not sold. This agreement
+only gives you some rights to use the software. Microsoft reserves all other
+rights.  For clarification Microsoft, or its licensors, retains ownership of
+all aspects of the software.   Unless applicable law gives you more rights
+despite this limitation, you may use the software only as expressly permitted
+in this agreement. In doing so, you must comply with any technical limitations
+in the software that only allow you to use it in certain ways. For example, if
+Microsoft technically limits or disables extensibility for the software, you
+may not extend the software by, among other things, loading or injecting into
+the software any non-Microsoft add-ins, macros, or packages; modifying the
+software registry settings; or adding features or functionality equivalent to
 that found in Microsoft products and services. You may not:
-a)	work around any technical limitations in the software that only allow 
+a)  work around any technical limitations in the software that only allow
 you to use it in certain ways;
-b)	reverse engineer, decompile or disassemble the software, or otherwise 
-attempt to derive the source code for the software, except and to the extent 
-required by third party licensing terms governing use of certain open source 
+b)  reverse engineer, decompile or disassemble the software, or otherwise
+attempt to derive the source code for the software, except and to the extent
+required by third party licensing terms governing use of certain open source
 components that may be included in the software;
-c)	remove, minimize, block, or modify any notices of Microsoft or its 
+c)  remove, minimize, block, or modify any notices of Microsoft or its
 suppliers in the software;
-d)	use the software in any way that is against the law or to create or 
+d)  use the software in any way that is against the law or to create or
 propagate malware; or
-e)	share, publish, distribute, or lease the software (except for any 
-distributable code, subject to the terms above), provide the software as a 
-stand-alone offering for others to use, or transfer the software or this 
+e)  share, publish, distribute, or lease the software (except for any
+distributable code, subject to the terms above), provide the software as a
+stand-alone offering for others to use, or transfer the software or this
 agreement to any third party.
 
-3.	DATA. 
-a)	Data Collection. The software may collect information about you and 
-your use of the software, and send that to Microsoft. Microsoft may use this 
-information to provide services and improve our products and services. You may 
-opt-out of many of these scenarios, but not all, as described in the product 
-documentation.  There are also some features in the software that may enable 
-you to collect data from users of your applications. If you use these features 
-to enable data collection in your applications, you must comply with applicable 
-law, including providing appropriate notices to users of your applications. You 
-can learn more about data collection and use in the help documentation and the 
-privacy statement at https://aka.ms/privacy. Your use of the software operates 
+3.  DATA.
+a)  Data Collection. The software may collect information about you and
+your use of the software, and send that to Microsoft. Microsoft may use this
+information to provide services and improve our products and services. You may
+opt-out of many of these scenarios, but not all, as described in the product
+documentation.  There are also some features in the software that may enable
+you to collect data from users of your applications. If you use these features
+to enable data collection in your applications, you must comply with applicable
+law, including providing appropriate notices to users of your applications. You
+can learn more about data collection and use in the help documentation and the
+privacy statement at https://aka.ms/privacy. Your use of the software operates
 as your consent to these practices.
-b)	Processing of Personal Data. To the extent Microsoft is a processor or 
-subprocessor of personal data in connection with the software, Microsoft makes 
-the commitments in the European Union General Data Protection Regulation Terms 
-of the Online Services Terms to all customers effective May 25, 2018, at 
+b)  Processing of Personal Data. To the extent Microsoft is a processor or
+subprocessor of personal data in connection with the software, Microsoft makes
+the commitments in the European Union General Data Protection Regulation Terms
+of the Online Services Terms to all customers effective May 25, 2018, at
 https://docs.microsoft.com/en-us/legal/gdpr.
 
-4.	EXPORT RESTRICTIONS. You must comply with all domestic and 
-international export laws and regulations that apply to the software, which 
-include restrictions on destinations, end users, and end use. For further 
+4.  EXPORT RESTRICTIONS. You must comply with all domestic and
+international export laws and regulations that apply to the software, which
+include restrictions on destinations, end users, and end use. For further
 information on export restrictions, visit https://aka.ms/exporting.
 
-5.	SUPPORT SERVICES. Microsoft is not obligated under this agreement to 
-provide any support services for the software. Any support provided is “as 
+5.  SUPPORT SERVICES. Microsoft is not obligated under this agreement to
+provide any support services for the software. Any support provided is “as
 is”, “with all faults”, and without warranty of any kind.
 
-6.	ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may 
-provide for supplements, updates, or third-party applications, is the entire 
+6.  ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may
+provide for supplements, updates, or third-party applications, is the entire
 agreement for the software.
 
-7.	APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the 
-software in the United States or Canada, the laws of the state or province 
-where you live (or, if a business, where your principal place of business is 
-located) govern the interpretation of this agreement, claims for its breach, 
-and all other claims (including consumer protection, unfair competition, and 
-tort claims), regardless of conflict of laws principles. If you acquired the 
-software in any other country, its laws apply. If U.S. federal jurisdiction 
-exists, you and Microsoft consent to exclusive jurisdiction and venue in the 
-federal court in King County, Washington for all disputes heard in court. If 
-not, you and Microsoft consent to exclusive jurisdiction and venue in the 
+7.  APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the
+software in the United States or Canada, the laws of the state or province
+where you live (or, if a business, where your principal place of business is
+located) govern the interpretation of this agreement, claims for its breach,
+and all other claims (including consumer protection, unfair competition, and
+tort claims), regardless of conflict of laws principles. If you acquired the
+software in any other country, its laws apply. If U.S. federal jurisdiction
+exists, you and Microsoft consent to exclusive jurisdiction and venue in the
+federal court in King County, Washington for all disputes heard in court. If
+not, you and Microsoft consent to exclusive jurisdiction and venue in the
 Superior Court of King County, Washington for all disputes heard in court.
 
-8.	CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain 
-legal rights. You may have other rights, including consumer rights, under the 
-laws of your state or country. Separate and apart from your relationship with 
-Microsoft, you may also have rights with respect to the party from which you 
-acquired the software. This agreement does not change those other rights if the 
-laws of your state or country do not permit it to do so. For example, if you 
-acquired the software in one of the below regions, or mandatory country law 
+8.  CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain
+legal rights. You may have other rights, including consumer rights, under the
+laws of your state or country. Separate and apart from your relationship with
+Microsoft, you may also have rights with respect to the party from which you
+acquired the software. This agreement does not change those other rights if the
+laws of your state or country do not permit it to do so. For example, if you
+acquired the software in one of the below regions, or mandatory country law
 applies, then the following provisions apply to you:
-a)	Australia. You have statutory guarantees under the Australian Consumer 
+a)  Australia. You have statutory guarantees under the Australian Consumer
 Law and nothing in this agreement is intended to affect those rights.
-b)	Canada. If you acquired this software in Canada, you may stop receiving 
-updates by turning off the automatic update feature, disconnecting your device 
-from the Internet (if and when you re-connect to the Internet, however, the 
-software will resume checking for and installing updates), or uninstalling the 
-software. The product documentation, if any, may also specify how to turn off 
+b)  Canada. If you acquired this software in Canada, you may stop receiving
+updates by turning off the automatic update feature, disconnecting your device
+from the Internet (if and when you re-connect to the Internet, however, the
+software will resume checking for and installing updates), or uninstalling the
+software. The product documentation, if any, may also specify how to turn off
 updates for your specific device or software.
-c)	Germany and Austria.
-i.	Warranty. The properly licensed software will perform substantially as 
-described in any Microsoft materials that accompany the software. However, 
+c)  Germany and Austria.
+i.  Warranty. The properly licensed software will perform substantially as
+described in any Microsoft materials that accompany the software. However,
 Microsoft gives no contractual guarantee in relation to the licensed software.
-ii.	Limitation of Liability. In case of intentional conduct, gross 
-negligence, claims based on the Product Liability Act, as well as, in case of 
-death or personal or physical injury, Microsoft is liable according to the 
+ii.  Limitation of Liability. In case of intentional conduct, gross
+negligence, claims based on the Product Liability Act, as well as, in case of
+death or personal or physical injury, Microsoft is liable according to the
 statutory law.
-Subject to the foregoing clause ii., Microsoft will only be liable for slight 
-negligence if Microsoft is in breach of such material contractual obligations, 
-the fulfillment of which facilitate the due performance of this agreement, the 
-breach of which would endanger the purpose of this agreement and the compliance 
-with which a party may constantly trust in (so-called "cardinal obligations"). 
-In other cases of slight negligence, Microsoft will not be liable for slight 
+Subject to the foregoing clause ii., Microsoft will only be liable for slight
+negligence if Microsoft is in breach of such material contractual obligations,
+the fulfillment of which facilitate the due performance of this agreement, the
+breach of which would endanger the purpose of this agreement and the compliance
+with which a party may constantly trust in (so-called "cardinal obligations").
+In other cases of slight negligence, Microsoft will not be liable for slight
 negligence.
 
-9.	DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR 
-THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR 
-CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES 
-ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+9.  DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR
+THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR
+CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES
+ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR
 PURPOSE, AND NON-INFRINGEMENT.
 
-10.	LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR 
-RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN 
-RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. 
-YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, 
+10.  LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR
+RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN
+RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00.
+YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS,
 SPECIAL, INDIRECT, OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, 
-content (including code) on third party Internet sites, or third party 
-applications; and (b) claims for breach of contract, warranty, guarantee, or 
-condition; strict liability, negligence, or other tort; or any other claim; in 
+This limitation applies to (a) anything related to the software, services,
+content (including code) on third party Internet sites, or third party
+applications; and (b) claims for breach of contract, warranty, guarantee, or
+condition; strict liability, negligence, or other tort; or any other claim; in
 each case to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the 
-possibility of the damages. The above limitation or exclusion may not apply to 
-you because your state, province, or country may not allow the exclusion or 
+It also applies even if Microsoft knew or should have known about the
+possibility of the damages. The above limitation or exclusion may not apply to
+you because your state, province, or country may not allow the exclusion or
 limitation of incidental, consequential, or other damages.
 
-Please note: As this software is distributed in Canada, some of the clauses in 
+Please note: As this software is distributed in Canada, some of the clauses in
 this agreement are provided below in French.
 
-Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans 
+Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans
 ce contrat sont fournies ci-dessous en français.
 
-EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel 
-quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. 
-Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier 
-de droits additionnels en vertu du droit local sur la protection des 
-consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par 
-le droit locale, les garanties implicites de qualité marchande, 
-d’adéquation à un usage particulier et d’absence de contrefaçon sont 
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel
+quel ». Toute utilisation de ce logiciel est à votre seule risque et péril.
+Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier
+de droits additionnels en vertu du droit local sur la protection des
+consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par
+le droit locale, les garanties implicites de qualité marchande,
+d’adéquation à un usage particulier et d’absence de contrefaçon sont
 exclues.
 
-LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES 
-DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une 
-indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. 
-Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y 
-compris les dommages spéciaux, indirects ou accessoires et pertes de 
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES
+DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une
+indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US.
+Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y
+compris les dommages spéciaux, indirects ou accessoires et pertes de
 bénéfices.
 
 Cette limitation concerne:
-•	tout ce qui est relié au logiciel, aux services ou au contenu (y 
-compris le code) figurant sur des sites Internet tiers ou dans des programmes 
+•   tout ce qui est relié au logiciel, aux services ou au contenu (y
+compris le code) figurant sur des sites Internet tiers ou dans des programmes
 tiers; et
-•	les réclamations au titre de violation de contrat ou de garantie, ou 
-au titre de responsabilité stricte, de négligence ou d’une autre faute dans 
+•   les réclamations au titre de violation de contrat ou de garantie, ou
+au titre de responsabilité stricte, de négligence ou d’une autre faute dans
 la limite autorisée par la loi en vigueur.
 
-Elle s’applique également, même si Microsoft connaissait ou devrait 
-connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas 
-l’exclusion ou la limitation de responsabilité pour les dommages indirects, 
-accessoires ou de quelque nature que ce soit, il se peut que la limitation ou 
+Elle s’applique également, même si Microsoft connaissait ou devrait
+connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas
+l’exclusion ou la limitation de responsabilité pour les dommages indirects,
+accessoires ou de quelque nature que ce soit, il se peut que la limitation ou
 l’exclusion ci-dessus ne s’appliquera pas à votre égard.
 
-EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous 
-pourriez avoir d’autres droits prévus par les lois de votre pays. Le 
-présent contrat ne modifie pas les droits que vous confèrent les lois de 
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous
+pourriez avoir d’autres droits prévus par les lois de votre pays. Le
+présent contrat ne modifie pas les droits que vous confèrent les lois de
 votre pays si celles-ci ne le permettent pas.

--- a/RuntimeLicenses/cpptools-srv-LICENSE.txt
+++ b/RuntimeLicenses/cpptools-srv-LICENSE.txt
@@ -1,190 +1,192 @@
-All VS Marketplace extensions, including this C/C++ Extension for Visual Studio 
-Code, must also be used consistent with the VS Marketplace Terms of Use at 
+All VS Marketplace extensions, including this C/C++ Extension for Visual Studio
+Code, must also be used consistent with the VS Marketplace Terms of Use at
 http://aka.ms/VSMarketplace-TOU
 
 MICROSOFT SOFTWARE LICENSE TERMS
 
-MICROSOFT C/C++ EXTENSION FOR VISUAL STUDIO CODE 
+MICROSOFT C/C++ EXTENSION FOR VISUAL STUDIO CODE
 ________________________________________
-These license terms are an agreement between you and Microsoft Corporation (or 
-one of its affiliates). They apply to the software named above and any 
-Microsoft services or software updates (except to the extent such services or 
-updates are accompanied by new or additional terms, in which case those 
-different terms apply prospectively and do not alter your or Microsoft’s 
-rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE 
-LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT 
+These license terms are an agreement between you and Microsoft Corporation (or
+one of its affiliates). They apply to the software named above and any
+Microsoft services or software updates (except to the extent such services or
+updates are accompanied by new or additional terms, in which case those
+different terms apply prospectively and do not alter your or Microsoft’s
+rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE
+LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT
 THESE TERMS.
 
-1.	INSTALLATION AND USE RIGHTS. 
-a)	General. You may install and use any number of copies of the software 
-only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code, 
-Azure DevOps, Team Foundation Server, and successor Microsoft products and 
-services (collectively, the “Visual Studio Products and Services”) to 
-develop and test your applications.
-b)	Third Party Components. The software may include third party components 
-with separate legal notices or governed by other agreements, as may be 
+1.  INSTALLATION AND USE RIGHTS.
+a)  General. You may install and use any number of copies of the software
+only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code,
+Azure DevOps, Team Foundation Server, and successor Microsoft products and
+services to develop and test your applications. Further, you may install, use
+and/or deploy these software copies via a network management system or as part
+of a desktop image within your internal corporate network to develop and test
+your applications.
+b)  Third Party Components. The software may include third party components
+with separate legal notices or governed by other agreements, as may be
 described in the ThirdPartyNotices file(s) accompanying the software.
 
-2.	SCOPE OF LICENSE. The software is licensed, not sold. This agreement 
-only gives you some rights to use the software. Microsoft reserves all other 
-rights.  For clarification Microsoft, or its licensors, retains ownership of 
-all aspects of the software.   Unless applicable law gives you more rights 
-despite this limitation, you may use the software only as expressly permitted 
-in this agreement. In doing so, you must comply with any technical limitations 
-in the software that only allow you to use it in certain ways. For example, if 
-Microsoft technically limits or disables extensibility for the software, you 
-may not extend the software by, among other things, loading or injecting into 
-the software any non-Microsoft add-ins, macros, or packages; modifying the 
-software registry settings; or adding features or functionality equivalent to 
+2.  SCOPE OF LICENSE. The software is licensed, not sold. This agreement
+only gives you some rights to use the software. Microsoft reserves all other
+rights.  For clarification Microsoft, or its licensors, retains ownership of
+all aspects of the software.   Unless applicable law gives you more rights
+despite this limitation, you may use the software only as expressly permitted
+in this agreement. In doing so, you must comply with any technical limitations
+in the software that only allow you to use it in certain ways. For example, if
+Microsoft technically limits or disables extensibility for the software, you
+may not extend the software by, among other things, loading or injecting into
+the software any non-Microsoft add-ins, macros, or packages; modifying the
+software registry settings; or adding features or functionality equivalent to
 that found in Microsoft products and services. You may not:
-a)	work around any technical limitations in the software that only allow 
+a)  work around any technical limitations in the software that only allow
 you to use it in certain ways;
-b)	reverse engineer, decompile or disassemble the software, or otherwise 
-attempt to derive the source code for the software, except and to the extent 
-required by third party licensing terms governing use of certain open source 
+b)  reverse engineer, decompile or disassemble the software, or otherwise
+attempt to derive the source code for the software, except and to the extent
+required by third party licensing terms governing use of certain open source
 components that may be included in the software;
-c)	remove, minimize, block, or modify any notices of Microsoft or its 
+c)  remove, minimize, block, or modify any notices of Microsoft or its
 suppliers in the software;
-d)	use the software in any way that is against the law or to create or 
+d)  use the software in any way that is against the law or to create or
 propagate malware; or
-e)	share, publish, distribute, or lease the software (except for any 
-distributable code, subject to the terms above), provide the software as a 
-stand-alone offering for others to use, or transfer the software or this 
+e)  share, publish, distribute, or lease the software (except for any
+distributable code, subject to the terms above), provide the software as a
+stand-alone offering for others to use, or transfer the software or this
 agreement to any third party.
 
-3.	DATA. 
-a)	Data Collection. The software may collect information about you and 
-your use of the software, and send that to Microsoft. Microsoft may use this 
-information to provide services and improve our products and services. You may 
-opt-out of many of these scenarios, but not all, as described in the product 
-documentation.  There are also some features in the software that may enable 
-you to collect data from users of your applications. If you use these features 
-to enable data collection in your applications, you must comply with applicable 
-law, including providing appropriate notices to users of your applications. You 
-can learn more about data collection and use in the help documentation and the 
-privacy statement at https://aka.ms/privacy. Your use of the software operates 
+3.  DATA.
+a)  Data Collection. The software may collect information about you and
+your use of the software, and send that to Microsoft. Microsoft may use this
+information to provide services and improve our products and services. You may
+opt-out of many of these scenarios, but not all, as described in the product
+documentation.  There are also some features in the software that may enable
+you to collect data from users of your applications. If you use these features
+to enable data collection in your applications, you must comply with applicable
+law, including providing appropriate notices to users of your applications. You
+can learn more about data collection and use in the help documentation and the
+privacy statement at https://aka.ms/privacy. Your use of the software operates
 as your consent to these practices.
-b)	Processing of Personal Data. To the extent Microsoft is a processor or 
-subprocessor of personal data in connection with the software, Microsoft makes 
-the commitments in the European Union General Data Protection Regulation Terms 
-of the Online Services Terms to all customers effective May 25, 2018, at 
+b)  Processing of Personal Data. To the extent Microsoft is a processor or
+subprocessor of personal data in connection with the software, Microsoft makes
+the commitments in the European Union General Data Protection Regulation Terms
+of the Online Services Terms to all customers effective May 25, 2018, at
 https://docs.microsoft.com/en-us/legal/gdpr.
 
-4.	EXPORT RESTRICTIONS. You must comply with all domestic and 
-international export laws and regulations that apply to the software, which 
-include restrictions on destinations, end users, and end use. For further 
+4.  EXPORT RESTRICTIONS. You must comply with all domestic and
+international export laws and regulations that apply to the software, which
+include restrictions on destinations, end users, and end use. For further
 information on export restrictions, visit https://aka.ms/exporting.
 
-5.	SUPPORT SERVICES. Microsoft is not obligated under this agreement to 
-provide any support services for the software. Any support provided is “as 
+5.  SUPPORT SERVICES. Microsoft is not obligated under this agreement to
+provide any support services for the software. Any support provided is “as
 is”, “with all faults”, and without warranty of any kind.
 
-6.	ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may 
-provide for supplements, updates, or third-party applications, is the entire 
+6.  ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may
+provide for supplements, updates, or third-party applications, is the entire
 agreement for the software.
 
-7.	APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the 
-software in the United States or Canada, the laws of the state or province 
-where you live (or, if a business, where your principal place of business is 
-located) govern the interpretation of this agreement, claims for its breach, 
-and all other claims (including consumer protection, unfair competition, and 
-tort claims), regardless of conflict of laws principles. If you acquired the 
-software in any other country, its laws apply. If U.S. federal jurisdiction 
-exists, you and Microsoft consent to exclusive jurisdiction and venue in the 
-federal court in King County, Washington for all disputes heard in court. If 
-not, you and Microsoft consent to exclusive jurisdiction and venue in the 
+7.  APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the
+software in the United States or Canada, the laws of the state or province
+where you live (or, if a business, where your principal place of business is
+located) govern the interpretation of this agreement, claims for its breach,
+and all other claims (including consumer protection, unfair competition, and
+tort claims), regardless of conflict of laws principles. If you acquired the
+software in any other country, its laws apply. If U.S. federal jurisdiction
+exists, you and Microsoft consent to exclusive jurisdiction and venue in the
+federal court in King County, Washington for all disputes heard in court. If
+not, you and Microsoft consent to exclusive jurisdiction and venue in the
 Superior Court of King County, Washington for all disputes heard in court.
 
-8.	CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain 
-legal rights. You may have other rights, including consumer rights, under the 
-laws of your state or country. Separate and apart from your relationship with 
-Microsoft, you may also have rights with respect to the party from which you 
-acquired the software. This agreement does not change those other rights if the 
-laws of your state or country do not permit it to do so. For example, if you 
-acquired the software in one of the below regions, or mandatory country law 
+8.  CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain
+legal rights. You may have other rights, including consumer rights, under the
+laws of your state or country. Separate and apart from your relationship with
+Microsoft, you may also have rights with respect to the party from which you
+acquired the software. This agreement does not change those other rights if the
+laws of your state or country do not permit it to do so. For example, if you
+acquired the software in one of the below regions, or mandatory country law
 applies, then the following provisions apply to you:
-a)	Australia. You have statutory guarantees under the Australian Consumer 
+a)  Australia. You have statutory guarantees under the Australian Consumer
 Law and nothing in this agreement is intended to affect those rights.
-b)	Canada. If you acquired this software in Canada, you may stop receiving 
-updates by turning off the automatic update feature, disconnecting your device 
-from the Internet (if and when you re-connect to the Internet, however, the 
-software will resume checking for and installing updates), or uninstalling the 
-software. The product documentation, if any, may also specify how to turn off 
+b)  Canada. If you acquired this software in Canada, you may stop receiving
+updates by turning off the automatic update feature, disconnecting your device
+from the Internet (if and when you re-connect to the Internet, however, the
+software will resume checking for and installing updates), or uninstalling the
+software. The product documentation, if any, may also specify how to turn off
 updates for your specific device or software.
-c)	Germany and Austria.
-i.	Warranty. The properly licensed software will perform substantially as 
-described in any Microsoft materials that accompany the software. However, 
+c)  Germany and Austria.
+i.  Warranty. The properly licensed software will perform substantially as
+described in any Microsoft materials that accompany the software. However,
 Microsoft gives no contractual guarantee in relation to the licensed software.
-ii.	Limitation of Liability. In case of intentional conduct, gross 
-negligence, claims based on the Product Liability Act, as well as, in case of 
-death or personal or physical injury, Microsoft is liable according to the 
+ii.  Limitation of Liability. In case of intentional conduct, gross
+negligence, claims based on the Product Liability Act, as well as, in case of
+death or personal or physical injury, Microsoft is liable according to the
 statutory law.
-Subject to the foregoing clause ii., Microsoft will only be liable for slight 
-negligence if Microsoft is in breach of such material contractual obligations, 
-the fulfillment of which facilitate the due performance of this agreement, the 
-breach of which would endanger the purpose of this agreement and the compliance 
-with which a party may constantly trust in (so-called "cardinal obligations"). 
-In other cases of slight negligence, Microsoft will not be liable for slight 
+Subject to the foregoing clause ii., Microsoft will only be liable for slight
+negligence if Microsoft is in breach of such material contractual obligations,
+the fulfillment of which facilitate the due performance of this agreement, the
+breach of which would endanger the purpose of this agreement and the compliance
+with which a party may constantly trust in (so-called "cardinal obligations").
+In other cases of slight negligence, Microsoft will not be liable for slight
 negligence.
 
-9.	DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR 
-THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR 
-CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES 
-ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+9.  DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR
+THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR
+CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES
+ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR
 PURPOSE, AND NON-INFRINGEMENT.
 
-10.	LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR 
-RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN 
-RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. 
-YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, 
+10.  LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR
+RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN
+RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00.
+YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS,
 SPECIAL, INDIRECT, OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, 
-content (including code) on third party Internet sites, or third party 
-applications; and (b) claims for breach of contract, warranty, guarantee, or 
-condition; strict liability, negligence, or other tort; or any other claim; in 
+This limitation applies to (a) anything related to the software, services,
+content (including code) on third party Internet sites, or third party
+applications; and (b) claims for breach of contract, warranty, guarantee, or
+condition; strict liability, negligence, or other tort; or any other claim; in
 each case to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the 
-possibility of the damages. The above limitation or exclusion may not apply to 
-you because your state, province, or country may not allow the exclusion or 
+It also applies even if Microsoft knew or should have known about the
+possibility of the damages. The above limitation or exclusion may not apply to
+you because your state, province, or country may not allow the exclusion or
 limitation of incidental, consequential, or other damages.
 
-Please note: As this software is distributed in Canada, some of the clauses in 
+Please note: As this software is distributed in Canada, some of the clauses in
 this agreement are provided below in French.
 
-Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans 
+Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans
 ce contrat sont fournies ci-dessous en français.
 
-EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel 
-quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. 
-Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier 
-de droits additionnels en vertu du droit local sur la protection des 
-consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par 
-le droit locale, les garanties implicites de qualité marchande, 
-d’adéquation à un usage particulier et d’absence de contrefaçon sont 
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel
+quel ». Toute utilisation de ce logiciel est à votre seule risque et péril.
+Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier
+de droits additionnels en vertu du droit local sur la protection des
+consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par
+le droit locale, les garanties implicites de qualité marchande,
+d’adéquation à un usage particulier et d’absence de contrefaçon sont
 exclues.
 
-LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES 
-DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une 
-indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. 
-Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y 
-compris les dommages spéciaux, indirects ou accessoires et pertes de 
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES
+DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une
+indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US.
+Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y
+compris les dommages spéciaux, indirects ou accessoires et pertes de
 bénéfices.
 
 Cette limitation concerne:
-•	tout ce qui est relié au logiciel, aux services ou au contenu (y 
-compris le code) figurant sur des sites Internet tiers ou dans des programmes 
+•   tout ce qui est relié au logiciel, aux services ou au contenu (y
+compris le code) figurant sur des sites Internet tiers ou dans des programmes
 tiers; et
-•	les réclamations au titre de violation de contrat ou de garantie, ou 
-au titre de responsabilité stricte, de négligence ou d’une autre faute dans 
+•   les réclamations au titre de violation de contrat ou de garantie, ou
+au titre de responsabilité stricte, de négligence ou d’une autre faute dans
 la limite autorisée par la loi en vigueur.
 
-Elle s’applique également, même si Microsoft connaissait ou devrait 
-connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas 
-l’exclusion ou la limitation de responsabilité pour les dommages indirects, 
-accessoires ou de quelque nature que ce soit, il se peut que la limitation ou 
+Elle s’applique également, même si Microsoft connaissait ou devrait
+connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas
+l’exclusion ou la limitation de responsabilité pour les dommages indirects,
+accessoires ou de quelque nature que ce soit, il se peut que la limitation ou
 l’exclusion ci-dessus ne s’appliquera pas à votre égard.
 
-EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous 
-pourriez avoir d’autres droits prévus par les lois de votre pays. Le 
-présent contrat ne modifie pas les droits que vous confèrent les lois de 
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous
+pourriez avoir d’autres droits prévus par les lois de votre pays. Le
+présent contrat ne modifie pas les droits que vous confèrent les lois de
 votre pays si celles-ci ne le permettent pas.

--- a/RuntimeLicenses/vsdbg-LICENSE.txt
+++ b/RuntimeLicenses/vsdbg-LICENSE.txt
@@ -1,191 +1,192 @@
-﻿MICROSOFT SOFTWARE LICENSE TERMS
+﻿All VS Marketplace extensions, including this C/C++ Extension for Visual Studio
+Code, must also be used consistent with the VS Marketplace Terms of Use at
+http://aka.ms/VSMarketplace-TOU
+
+MICROSOFT SOFTWARE LICENSE TERMS
+
 MICROSOFT C/C++ EXTENSION FOR VISUAL STUDIO CODE
+________________________________________
+These license terms are an agreement between you and Microsoft Corporation (or
+one of its affiliates). They apply to the software named above and any
+Microsoft services or software updates (except to the extent such services or
+updates are accompanied by new or additional terms, in which case those
+different terms apply prospectively and do not alter your or Microsoft’s
+rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE
+LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.  BY USING THE SOFTWARE, YOU ACCEPT
+THESE TERMS.
 
-These license terms are an agreement between Microsoft Corporation (or
-based on where you live, one of its affiliates) and you. They apply to
-the software named above. The terms also apply to any
-Microsoft services or updates for the software, except to the extent
-those have additional terms.
+1.  INSTALLATION AND USE RIGHTS.
+a)  General. You may install and use any number of copies of the software
+only with Microsoft Visual Studio, Visual Studio for Mac, Visual Studio Code,
+Azure DevOps, Team Foundation Server, and successor Microsoft products and
+services to develop and test your applications. Further, you may install, use
+and/or deploy these software copies via a network management system or as part
+of a desktop image within your internal corporate network to develop and test
+your applications.
+b)  Third Party Components. The software may include third party components
+with separate legal notices or governed by other agreements, as may be
+described in the ThirdPartyNotices file(s) accompanying the software.
 
-IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
+2.  SCOPE OF LICENSE. The software is licensed, not sold. This agreement
+only gives you some rights to use the software. Microsoft reserves all other
+rights.  For clarification Microsoft, or its licensors, retains ownership of
+all aspects of the software.   Unless applicable law gives you more rights
+despite this limitation, you may use the software only as expressly permitted
+in this agreement. In doing so, you must comply with any technical limitations
+in the software that only allow you to use it in certain ways. For example, if
+Microsoft technically limits or disables extensibility for the software, you
+may not extend the software by, among other things, loading or injecting into
+the software any non-Microsoft add-ins, macros, or packages; modifying the
+software registry settings; or adding features or functionality equivalent to
+that found in Microsoft products and services. You may not:
+a)  work around any technical limitations in the software that only allow
+you to use it in certain ways;
+b)  reverse engineer, decompile or disassemble the software, or otherwise
+attempt to derive the source code for the software, except and to the extent
+required by third party licensing terms governing use of certain open source
+components that may be included in the software;
+c)  remove, minimize, block, or modify any notices of Microsoft or its
+suppliers in the software;
+d)  use the software in any way that is against the law or to create or
+propagate malware; or
+e)  share, publish, distribute, or lease the software (except for any
+distributable code, subject to the terms above), provide the software as a
+stand-alone offering for others to use, or transfer the software or this
+agreement to any third party.
 
-1. INSTALLATION AND USE RIGHTS. You may only use the C/C++ Extension
-   for Visual Studio Code with Visual Studio Code, Visual Studio or
-   Xamarin Studio software to help you develop and test your
-   applications.
+3.  DATA.
+a)  Data Collection. The software may collect information about you and
+your use of the software, and send that to Microsoft. Microsoft may use this
+information to provide services and improve our products and services. You may
+opt-out of many of these scenarios, but not all, as described in the product
+documentation.  There are also some features in the software that may enable
+you to collect data from users of your applications. If you use these features
+to enable data collection in your applications, you must comply with applicable
+law, including providing appropriate notices to users of your applications. You
+can learn more about data collection and use in the help documentation and the
+privacy statement at https://aka.ms/privacy. Your use of the software operates
+as your consent to these practices.
+b)  Processing of Personal Data. To the extent Microsoft is a processor or
+subprocessor of personal data in connection with the software, Microsoft makes
+the commitments in the European Union General Data Protection Regulation Terms
+of the Online Services Terms to all customers effective May 25, 2018, at
+https://docs.microsoft.com/en-us/legal/gdpr.
 
-2. TERMS FOR SPECIFIC COMPONENTS
-   a. Third Party Components. The software may include third party
-   components with separate legal notices or governed by other
-   agreements, as may be described in the ThirdPartyNotices file(s)
-   accompanying the software.
-   b. Package Managers. The software may include package managers, like
-   Nuget, that give you the option to download other Microsoft and third
-   party software packages to use with your application. Those packages
-   are under their own licenses, and not this agreement. Microsoft does
-   not distribute, license or provide any warranties for any of the third
-   party packages.
+4.  EXPORT RESTRICTIONS. You must comply with all domestic and
+international export laws and regulations that apply to the software, which
+include restrictions on destinations, end users, and end use. For further
+information on export restrictions, visit https://aka.ms/exporting.
 
-3. DATA.
-   a. Data Collection. The software may collect information about you and
-   your use of the software, and send that to Microsoft. Microsoft may
-   use this information to provide services and improve our products and
-   services. You may opt-out of many of these scenarios, but not all, as
-   described in the product documentation.  There are also some features
-   in the software that may enable you and Microsoft to collect data from
-   users of your applications. If you use these features, you must comply
-   with applicable law, including providing appropriate notices to users
-   of your applications together with a copy of Microsoft’s privacy
-   statement. Our privacy statement is located at
-   https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more
-   about data collection and use in the help documentation and our
-   privacy statement. Your use of the software operates as your consent
-   to these practices.
-   b. Processing of Personal Data. To the extent Microsoft is a processor
-   or subprocessor of personal data in connection with the software,
-   Microsoft makes the commitments in the European Union General Data
-   Protection Regulation Terms of the Online Services Terms to all
-   customers effective May 25, 2018, at
-   http://go.microsoft.com/?linkid=9840733.
+5.  SUPPORT SERVICES. Microsoft is not obligated under this agreement to
+provide any support services for the software. Any support provided is “as
+is”, “with all faults”, and without warranty of any kind.
 
-4. SCOPE OF LICENSE. The software is licensed, not sold. This
-   agreement only gives you some rights to use the software. Microsoft
-   reserves all other rights. Unless applicable law gives you more rights
-   despite this limitation, you may use the software only as expressly
-   permitted in this agreement. In doing so, you must comply with any
-   technical limitations in the software that only allow you to use it in
-   certain ways. You may not
-      *  work around any technical limitations in the software;
-      *  reverse engineer, decompile or disassemble the software, or attempt
-         to derive the source code for the software, except and to the extent
-         required by third party licensing terms governing use of certain open
-         source components that may be included with the software;
-      *  remove, minimize, block or modify any notices of Microsoft or its
-         suppliers in the software;
-      *  use the software in any way that is against the law; or
-      *  share, publish, rent, or lease the software, or provide the software
-         as a stand-alone hosted solution for others to use.
+6.  ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may
+provide for supplements, updates, or third-party applications, is the entire
+agreement for the software.
 
-5. EXPORT RESTRICTIONS. You must comply with all domestic and
-   international export laws and regulations that apply to the software,
-   which include restrictions on destinations, end users and end use.
-   For further information on export restrictions, visit
-   (aka.ms/exporting).
+7.  APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the
+software in the United States or Canada, the laws of the state or province
+where you live (or, if a business, where your principal place of business is
+located) govern the interpretation of this agreement, claims for its breach,
+and all other claims (including consumer protection, unfair competition, and
+tort claims), regardless of conflict of laws principles. If you acquired the
+software in any other country, its laws apply. If U.S. federal jurisdiction
+exists, you and Microsoft consent to exclusive jurisdiction and venue in the
+federal court in King County, Washington for all disputes heard in court. If
+not, you and Microsoft consent to exclusive jurisdiction and venue in the
+Superior Court of King County, Washington for all disputes heard in court.
 
-6. SUPPORT SERVICES. Because this software is “as is,” we may not
-provide support services for it.
+8.  CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain
+legal rights. You may have other rights, including consumer rights, under the
+laws of your state or country. Separate and apart from your relationship with
+Microsoft, you may also have rights with respect to the party from which you
+acquired the software. This agreement does not change those other rights if the
+laws of your state or country do not permit it to do so. For example, if you
+acquired the software in one of the below regions, or mandatory country law
+applies, then the following provisions apply to you:
+a)  Australia. You have statutory guarantees under the Australian Consumer
+Law and nothing in this agreement is intended to affect those rights.
+b)  Canada. If you acquired this software in Canada, you may stop receiving
+updates by turning off the automatic update feature, disconnecting your device
+from the Internet (if and when you re-connect to the Internet, however, the
+software will resume checking for and installing updates), or uninstalling the
+software. The product documentation, if any, may also specify how to turn off
+updates for your specific device or software.
+c)  Germany and Austria.
+i.  Warranty. The properly licensed software will perform substantially as
+described in any Microsoft materials that accompany the software. However,
+Microsoft gives no contractual guarantee in relation to the licensed software.
+ii.  Limitation of Liability. In case of intentional conduct, gross
+negligence, claims based on the Product Liability Act, as well as, in case of
+death or personal or physical injury, Microsoft is liable according to the
+statutory law.
+Subject to the foregoing clause ii., Microsoft will only be liable for slight
+negligence if Microsoft is in breach of such material contractual obligations,
+the fulfillment of which facilitate the due performance of this agreement, the
+breach of which would endanger the purpose of this agreement and the compliance
+with which a party may constantly trust in (so-called "cardinal obligations").
+In other cases of slight negligence, Microsoft will not be liable for slight
+negligence.
 
-7. ENTIRE AGREEMENT. This agreement, and the terms for supplements,
-   updates, Internet-based services and support services that you use,
-   are the entire agreement for the software and support services.
+9.  DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR
+THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR
+CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES
+ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, AND NON-INFRINGEMENT.
 
-8. APPLICABLE LAW.  If you acquired the software in the United
-   States, Washington law applies to interpretation of and claims for
-   breach of this agreement, and the laws of the state where you live
-   apply to all other claims. If you acquired the software in any other
-   country, its laws apply.
+10.  LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR
+RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN
+RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00.
+YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS,
+SPECIAL, INDIRECT, OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services,
+content (including code) on third party Internet sites, or third party
+applications; and (b) claims for breach of contract, warranty, guarantee, or
+condition; strict liability, negligence, or other tort; or any other claim; in
+each case to the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the
+possibility of the damages. The above limitation or exclusion may not apply to
+you because your state, province, or country may not allow the exclusion or
+limitation of incidental, consequential, or other damages.
 
-9. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes
-   certain legal rights. You may have other rights, including consumer
-   rights, under the laws of your state or country. Separate and apart
-   from your relationship with Microsoft, you may also have rights with
-   respect to the party from which you acquired the software. This
-   agreement does not change those other rights if the laws of your state
-   or country do not permit it to do so. For example, if you acquired the
-   software in one of the below regions, or mandatory country law
-   applies, then the following provisions apply to you:
+Please note: As this software is distributed in Canada, some of the clauses in
+this agreement are provided below in French.
 
-   a. Australia. You have statutory guarantees under the Australian
-      Consumer Law and nothing in this agreement is intended to affect those
-      rights.
+Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans
+ce contrat sont fournies ci-dessous en français.
 
-   b. Canada. If you acquired this software in Canada, you may stop
-      receiving updates by turning off the automatic update feature,
-      disconnecting your device from the Internet (if and when you re-
-      connect to the Internet, however, the software will resume checking
-      for and installing updates), or uninstalling the software. The product
-      documentation, if any, may also specify how to turn off updates for
-      your specific device or software.
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel
+quel ». Toute utilisation de ce logiciel est à votre seule risque et péril.
+Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier
+de droits additionnels en vertu du droit local sur la protection des
+consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par
+le droit locale, les garanties implicites de qualité marchande,
+d’adéquation à un usage particulier et d’absence de contrefaçon sont
+exclues.
 
-   c. Germany and Austria.
-      (i)   Warranty. The properly licensed software will perform
-            substantially as described in any Microsoft materials that accompany
-            the software. However, Microsoft gives no contractual guarantee in
-            relation to the licensed software.
-      (ii)  Limitation of Liability. In case of intentional conduct, gross
-            negligence, claims based on the Product Liability Act, as well as, in
-            case of death or personal or physical injury, Microsoft is liable
-            according to the statutory law.
-            Subject to the foregoing clause (ii), Microsoft will only be liable
-            for slight negligence if Microsoft is in breach of such material
-            contractual obligations, the fulfillment of which facilitate the due
-            performance of this agreement, the breach of which would endanger the
-            purpose of this agreement and the compliance with which a party may
-            constantly trust in (so-called "cardinal obligations"). In other cases
-            of slight negligence, Microsoft will not be liable for slight
-            negligence.
-
-10. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS-IS.” YOU
-   BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES,
-   GUARANTEES OR CONDITIONS. TO THE EXTENT PERMITTED UNDER YOUR LOCAL
-   LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-
-11. LIMITATION ON AND EXCLUSION OF DAMAGES. YOU CAN RECOVER FROM
-   MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU
-   CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST
-   PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-
-   This limitation applies to (a) anything related to the software,
-   services, content (including code) on third party Internet sites, or
-   third party applications; and (b) claims for breach of contract,
-   breach of warranty, guarantee or condition, strict liability,
-   negligence, or other tort to the extent permitted by applicable law.
-
-   It also applies even if Microsoft knew or should have known about the
-   possibility of the damages. The above limitation or exclusion may not
-   apply to you because your country may not allow the exclusion or
-   limitation of incidental, consequential or other damages.
-
-Please note: As this software is distributed in Quebec, Canada, some
-of the clauses in this agreement are provided below in French.
-
-Remarque : Ce logiciel étant distribué au Québec, Canada, certaines
-des clauses dans ce contrat sont fournies ci-dessous en français.
-
-EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert
-« tel quel ». Toute utilisation de ce logiciel est à votre seule
-risque et péril. Microsoft n’accorde aucune autre garantie
-expresse. Vous pouvez bénéficier de droits additionnels en vertu du
-droit local sur la protection des consommateurs, que ce contrat ne
-peut modifier. La ou elles sont permises par le droit locale, les
-garanties implicites de qualité marchande, d’adéquation à un
-usage particulier et d’absence de contrefaçon sont exclues.
-
-LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ
-POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses
-fournisseurs une indemnisation en cas de dommages directs uniquement
-à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune
-indemnisation pour les autres dommages, y compris les dommages
-spéciaux, indirects ou accessoires et pertes de bénéfices.
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES
+DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une
+indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US.
+Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y
+compris les dommages spéciaux, indirects ou accessoires et pertes de
+bénéfices.
 
 Cette limitation concerne:
+•   tout ce qui est relié au logiciel, aux services ou au contenu (y
+compris le code) figurant sur des sites Internet tiers ou dans des programmes
+tiers; et
+•   les réclamations au titre de violation de contrat ou de garantie, ou
+au titre de responsabilité stricte, de négligence ou d’une autre faute dans
+la limite autorisée par la loi en vigueur.
 
-   *  tout ce qui est relié au logiciel, aux services ou au contenu (y
-      compris le code) figurant sur des sites Internet tiers ou dans des
-      programmes tiers ; et
-   *  les réclamations au titre de violation de contrat ou de garantie,
-      ou au titre de responsabilité stricte, de négligence ou d’une
-      autre faute dans la limite autorisée par la loi en vigueur.
+Elle s’applique également, même si Microsoft connaissait ou devrait
+connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas
+l’exclusion ou la limitation de responsabilité pour les dommages indirects,
+accessoires ou de quelque nature que ce soit, il se peut que la limitation ou
+l’exclusion ci-dessus ne s’appliquera pas à votre égard.
 
-Elle s’applique également, même si Microsoft connaissait ou
-devrait connaître l’éventualité d’un tel dommage. Si votre pays
-n’autorise pas l’exclusion ou la limitation de responsabilité
-pour les dommages indirects, accessoires ou de quelque nature que ce
-soit, il se peut que la limitation ou l’exclusion ci-dessus ne
-s’appliquera pas à votre égard.
-
-EFFET JURIDIQUE. Le présent contrat décrit certains droits
-juridiques. Vous pourriez avoir d’autres droits prévus par les lois
-de votre pays. Le présent contrat ne modifie pas les droits que vous
-confèrent les lois de votre pays si celles-ci ne le permettent pas.
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous
+pourriez avoir d’autres droits prévus par les lois de votre pays. Le
+présent contrat ne modifie pas les droits que vous confèrent les lois de
+votre pays si celles-ci ne le permettent pas.


### PR DESCRIPTION
Fix for the legal issue mentioned at thread https://github.com/microsoft/vscode-cpptools/issues/6350, in particular
`Further, you may install, use and/or deploy these software copies via a network management system or as part of a desktop image within your internal corporate network to develop and test your applications.`
Also adds a reference to the RuntimeLicenses in License.md. Fixes https://github.com/microsoft/vscode-cpptools/issues/5784