### PR TITLE
Fix issue with multiple didOpen

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -432,10 +432,10 @@ export function processDelayedDidOpen(document: vscode.TextDocument): void {
     const client: Client = clients.getClientFor(document.uri);
     if (client) {
         // Log warm start.
-        clients.timeTelemetryCollector.setDidOpenTime(document.uri);
         if (clients.checkOwnership(client, document)) {
             if (!client.TrackedDocuments.has(document)) {
                 // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
+                clients.timeTelemetryCollector.setDidOpenTime(document.uri);
                 client.TrackedDocuments.add(document);
                 const finishDidOpen = (doc: vscode.TextDocument) => {
                     client.provideCustomConfiguration(doc.uri, undefined);


### PR DESCRIPTION
Added a check to didOpen in the protocolFilter to avoid handling didOpen for a file that is already being tracked, since it's possible that we may have received onDidChangeVisibleTextEditors and considered this a 'delayedOpen' prior to receiving a didOpen.

Fixed placement of telemetry tracking didOpen.