### PR TITLE
Disable Insiders update for Mac versions older than 18

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 1.1.4: Janurary 15, 2021
+### Bug Fix
+* Disable the Insiders update channel for Mac versions less than 18 due to bug [#6787](https://github.com/microsoft/vscode-cpptools/issues/6787).
+
 ## Version 1.1.3: December 3, 2020
 ### Bug Fixes
 * Disable the "join Insiders" prompt for Linux CodeSpaces. [#6491](https://github.com/microsoft/vscode-cpptools/issues/6491)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publisher": "ms-vscode",
   "icon": "LanguageCCPP_color_128x.png",
   "readme": "README.md",

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -339,16 +339,25 @@ function realActivation(): void {
             const minimumSupportedVersionForInsidersUpgrades: PackageVersion = abTestSettings.getMinimumVSCodeVersion();
             if (!minimumSupportedVersionForInsidersUpgrades.isMajorMinorPatchGreaterThan(vscodeVersion)) {
                 insiderUpdateEnabled = true;
-                if (settings.updateChannel === 'Default') {
-                    const userVersion: PackageVersion = new PackageVersion(util.packageJson.version);
-                    if (userVersion.suffix === "insiders") {
-                        checkAndApplyUpdate(settings.updateChannel, false);
-                    } else {
-                        suggestInsidersChannel();
+                if (os.platform() === "darwin") {
+                    const releaseParts: string[] = os.release().split(".");
+                    if (releaseParts.length >= 1) {
+                        // 1.2.0-insiders doesn't work with 17.7 or older Mac OS's.
+                        insiderUpdateEnabled = parseInt(releaseParts[0]) >= 18;
                     }
-                } else if (settings.updateChannel === 'Insiders') {
-                    insiderUpdateTimer = global.setInterval(checkAndApplyUpdateOnTimer, insiderUpdateTimerInterval);
-                    checkAndApplyUpdate(settings.updateChannel, false);
+                }
+                if (insiderUpdateEnabled) {
+                    if (settings.updateChannel === 'Default') {
+                        const userVersion: PackageVersion = new PackageVersion(util.packageJson.version);
+                        if (userVersion.suffix === "insiders") {
+                            checkAndApplyUpdate(settings.updateChannel, false);
+                        } else {
+                            suggestInsidersChannel();
+                        }
+                    } else if (settings.updateChannel === 'Insiders') {
+                        insiderUpdateTimer = global.setInterval(checkAndApplyUpdateOnTimer, insiderUpdateTimerInterval);
+                        checkAndApplyUpdate(settings.updateChannel, false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Due to issue https://github.com/microsoft/vscode-cpptools/issues/6787

If 1.1.4 is published, it looks like we'd also need to publish a 1.2.0-insiders2 (or republish 1.2.0-insiders?) afterwards in order for the Insider update mechanism to work correctly since it appears to stop once it encounters the latest non-Insiders.