### PR TITLE
Remove .dylib filtering.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1179,7 +1179,9 @@ function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data
     const lines: string[] = data.split("\n");
     data = "";
     lines.forEach((line: string) => {
-        if (!line.includes(".dylib") && !line.includes("???")) {
+        if (// Temporarily (?) remove .dylib filtering.
+            // !line.includes(".dylib") && 
+            !line.includes("???")) {
             line = line.replace(/^\d+\s+/, ""); // Remove <numbers><spaces> from the start of the line.
             line = line.replace(/std::__1::/g, "std::");  // __1:: is not helpful.
             data += (line + "\n");

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1180,7 +1180,7 @@ function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data
     data = "";
     lines.forEach((line: string) => {
         if (// Temporarily (?) remove .dylib filtering.
-            // !line.includes(".dylib") && 
+            // !line.includes(".dylib") &&
             !line.includes("???")) {
             line = line.replace(/^\d+\s+/, ""); // Remove <numbers><spaces> from the start of the line.
             line = line.replace(/std::__1::/g, "std::");  // __1:: is not helpful.


### PR DESCRIPTION
To potentially get more info in regards to the macOS 10.13 and earlier dynamic library failure: https://github.com/microsoft/vscode-cpptools/issues/6787