### PR TITLE
Add crash count telemetry.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1106,10 +1106,10 @@ function reportMacCrashes(): void {
                         fs.readFile(path.resolve(crashFolder, filename), 'utf8', (err, data) => {
                             if (err) {
                                 // Try again?
-                                fs.readFile(path.resolve(crashFolder, filename), 'utf8', handleCrashFileRead);
+                                fs.readFile(path.resolve(crashFolder, filename), 'utf8', handleMacCrashFileRead);
                                 return;
                             }
-                            handleCrashFileRead(err, data);
+                            handleMacCrashFileRead(err, data);
                         });
                     }, 5000);
                 });
@@ -1122,7 +1122,8 @@ function reportMacCrashes(): void {
 
 let previousMacCrashData: string;
 let previousMacCrashCount: number = 0;
-function logCrashTelemetry(data: string): void {
+
+function logMacCrashTelemetry(data: string): void {
     const crashObject: { [key: string]: string } = {};
     const crashCountObject: { [key: string]: number } = {};
     crashObject["CrashingThreadCallStack"] = data;
@@ -1132,9 +1133,9 @@ function logCrashTelemetry(data: string): void {
     telemetry.logLanguageServerEvent("MacCrash", crashObject, crashCountObject);
 }
 
-function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data: string): void {
+function handleMacCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data: string): void {
     if (err) {
-        return logCrashTelemetry("readFile: " + err.code);
+        return logMacCrashTelemetry("readFile: " + err.code);
     }
 
     // Extract the crashing process version, because the version might not match
@@ -1151,7 +1152,7 @@ function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data
     const crashStart: string = " Crashed:";
     let startCrash: number = data.indexOf(crashStart);
     if (startCrash < 0) {
-        return logCrashTelemetry("No crash start");
+        return logMacCrashTelemetry("No crash start");
     }
     startCrash += crashStart.length + 1; // Skip past crashStart.
     let endCrash: number = data.indexOf("Thread ", startCrash);
@@ -1159,7 +1160,7 @@ function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data
         endCrash = data.length - 1; // Not expected, but just in case.
     }
     if (endCrash <= startCrash) {
-        return logCrashTelemetry("No crash end");
+        return logMacCrashTelemetry("No crash end");
     }
     data = data.substr(startCrash, endCrash - startCrash);
 
@@ -1197,7 +1198,7 @@ function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data
         data = data.substr(0, 8189) + "...";
     }
 
-    logCrashTelemetry(data);
+    logMacCrashTelemetry(data);
 }
 
 export function deactivate(): Thenable<void> {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -151,10 +151,6 @@ function isMissingIncludeDiagnostic(diagnostic: vscode.Diagnostic): boolean {
  * activate: set up the extension for language services
  */
 export function activate(activationEventOccurred: boolean): void {
-    const str: string = `
-`;
-    logCrashTelemetry(str);
-    logCrashTelemetry(str);
     if (realActivationOccurred) {
         return; // Occurs if multiple delayed commands occur before the real commands are registered.
     }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -151,6 +151,10 @@ function isMissingIncludeDiagnostic(diagnostic: vscode.Diagnostic): boolean {
  * activate: set up the extension for language services
  */
 export function activate(activationEventOccurred: boolean): void {
+    const str: string = `
+`;
+    logCrashTelemetry(str);
+    logCrashTelemetry(str);
     if (realActivationOccurred) {
         return; // Occurs if multiple delayed commands occur before the real commands are registered.
     }
@@ -1120,10 +1124,16 @@ function reportMacCrashes(): void {
     }
 }
 
+let previousMacCrashData: string;
+let previousMacCrashCount: number = 0;
 function logCrashTelemetry(data: string): void {
     const crashObject: { [key: string]: string } = {};
+    const crashCountObject: { [key: string]: number } = {};
     crashObject["CrashingThreadCallStack"] = data;
-    telemetry.logLanguageServerEvent("MacCrash", crashObject, undefined);
+    previousMacCrashCount = data === previousMacCrashData ? previousMacCrashCount + 1 : 0;
+    previousMacCrashData = data;
+    crashCountObject["CrashCount"] = previousMacCrashCount;
+    telemetry.logLanguageServerEvent("MacCrash", crashObject, crashCountObject);
 }
 
 function handleCrashFileRead(err: NodeJS.ErrnoException | undefined | null, data: string): void {


### PR DESCRIPTION
To differentiate between 1 time crashes (on shutdown, temporary code) and repeated crashes that don't go away. Also, enables us to tell fix what the max crash count is, i.e. a fast repeated crash should hit the 10 limit in 3 minutes, while periodic crashing could generate > 10 over a longer session, or if there's a bug (like https://github.com/microsoft/vscode-cpptools/issues/6724).