### PR TITLE
Add link to Discussions board

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Discussion or question
     url: https://github.com/microsoft/vscode-cpptools/discussions/new

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Discussion or question
     url: https://github.com/microsoft/vscode-cpptools/discussions/new
-    about: Please to go our Discussions board to start a discussion or to ask a question.
+    about: Please use our Discussions board to start a discussion or to ask a question.

--- a/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion or question
+    url: https://github.com/microsoft/vscode-cpptools/discussions/new
+    about: Please to go our Discussions board to start a discussion or to ask a question.


### PR DESCRIPTION
This adds a new link option to start a Discussion thread from the "new issues" template options.