### PR TITLE
Move initialization of TimeTelemetryCollector

### DIFF
--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -23,7 +23,7 @@ export class ClientCollection {
     private defaultClient: cpptools.Client;
     private activeClient: cpptools.Client;
     private activeDocument?: vscode.TextDocument;
-    public timeTelemetryCollector: TimeTelemetryCollector;
+    public timeTelemetryCollector: TimeTelemetryCollector = new TimeTelemetryCollector();
 
     public get ActiveClient(): cpptools.Client { return this.activeClient; }
     public get Names(): ClientKey[] {
@@ -62,8 +62,6 @@ export class ClientCollection {
 
         this.disposables.push(vscode.workspace.onDidChangeWorkspaceFolders(e => this.onDidChangeWorkspaceFolders(e)));
         this.disposables.push(vscode.workspace.onDidCloseTextDocument(d => this.onDidCloseTextDocument(d)));
-
-        this.timeTelemetryCollector = new TimeTelemetryCollector();
     }
 
     public activeDocumentChanged(document: vscode.TextDocument): void {


### PR DESCRIPTION
Might address: https://github.com/microsoft/vscode-cpptools/issues/6981

Since the repro is dereferencing 'clients', it would have to be after the ClientCollection was constructed (or else that would be undefined).  In that case, timeTelemetryCollector would already have been initialized.  So, I have no confidence that moving the initialization of timeTelemetryCollector will make any difference.
