### PR TITLE
Change default for autocompleteAddParentheses

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1160,7 +1160,7 @@
         },
         "C_Cpp.autocompleteAddParentheses": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%c_cpp.configuration.autocompleteAddParentheses.description%",
           "scope": "resource"
         }


### PR DESCRIPTION
Deals with https://github.com/microsoft/vscode-cpptools/issues/7199 .

Also, it prevents users from getting annoyed by `function()()` when they're too used to typing the `(` really fast after a function. TypeScript/JavaScript also has their similar feature disabled by default.