### PR TITLE
Strip IsExplicit flags if seen in c_cpp_properties.json

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1163,9 +1163,21 @@ export class CppProperties {
             this.configurationJson.configurations.forEach(e => {
                 if ((<any>e).knownCompilers) {
                     delete (<any>e).knownCompilers;
+                    dirty = true;
+                }
+                if ((<any>e).compilerPathIsExplicit) {
                     delete (<any>e).compilerPathIsExplicit;
+                    dirty = true;
+                }
+                if ((<any>e).cStandardIsExplicit) {
                     delete (<any>e).cStandardIsExplicit;
+                    dirty = true;
+                }
+                if ((<any>e).cppStandardIsExplicit) {
                     delete (<any>e).cppStandardIsExplicit;
+                    dirty = true;
+                }
+                if ((<any>e).intelliSenseModeIsExplicit) {
                     delete (<any>e).intelliSenseModeIsExplicit;
                     dirty = true;
                 }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1161,23 +1161,23 @@ export class CppProperties {
             }
 
             this.configurationJson.configurations.forEach(e => {
-                if ((<any>e).knownCompilers) {
+                if ((<any>e).knownCompilers !== undefined) {
                     delete (<any>e).knownCompilers;
                     dirty = true;
                 }
-                if ((<any>e).compilerPathIsExplicit) {
+                if ((<any>e).compilerPathIsExplicit !== undefined) {
                     delete (<any>e).compilerPathIsExplicit;
                     dirty = true;
                 }
-                if ((<any>e).cStandardIsExplicit) {
+                if ((<any>e).cStandardIsExplicit !== undefined) {
                     delete (<any>e).cStandardIsExplicit;
                     dirty = true;
                 }
-                if ((<any>e).cppStandardIsExplicit) {
+                if ((<any>e).cppStandardIsExplicit !== undefined) {
                     delete (<any>e).cppStandardIsExplicit;
                     dirty = true;
                 }
-                if ((<any>e).intelliSenseModeIsExplicit) {
+                if ((<any>e).intelliSenseModeIsExplicit !== undefined) {
                     delete (<any>e).intelliSenseModeIsExplicit;
                     dirty = true;
                 }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1163,6 +1163,10 @@ export class CppProperties {
             this.configurationJson.configurations.forEach(e => {
                 if ((<any>e).knownCompilers) {
                     delete (<any>e).knownCompilers;
+                    delete (<any>e).compilerPathIsExplicit;
+                    delete (<any>e).cStandardIsExplicit;
+                    delete (<any>e).cppStandardIsExplicit;
+                    delete (<any>e).intelliSenseModeIsExplicit;
                     dirty = true;
                 }
             });


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/7100

This change will remove the IsExplicit fields from c_cpp_properties.json when read.  (If they somehow got there due to the user copying them there manually, such as from Log Diagnostics output).  This change currently should have no effect, as these values are always dynamically set based on the fields they relate to.  But, perhaps this change will help rule out these fields from blame for other issues.