### PR TITLE
Relax field requirements for custom configs

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2396,9 +2396,11 @@ export class DefaultClient implements Client {
 
     private isSourceFileConfigurationItem(input: any, providerVersion: Version): input is SourceFileConfigurationItem {
         // IntelliSenseMode and standard are optional for version 5+.
-        let areOptionalsValid: boolean = true;
+        let areOptionalsValid: boolean = false;
         if (providerVersion < Version.v5) {
             areOptionalsValid = util.isString(input.configuration.intelliSenseMode) && util.isString(input.configuration.standard);
+        } else {
+            areOptionalsValid = util.isOptionalString(input.configuration.intelliSenseMode) && util.isOptionalString(input.configuration.standard);
         }
         return (input && (util.isString(input.uri) || util.isUri(input.uri)) &&
             input.configuration &&

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2395,12 +2395,10 @@ export class DefaultClient implements Client {
     }
 
     private isSourceFileConfigurationItem(input: any, providerVersion: Version): input is SourceFileConfigurationItem {
-        // IntelliSenseMode and standard are optional for version 5+. However, they are required when compilerPath is not defined.
-        let areOptionalsValid: boolean = false;
-        if (providerVersion < Version.v5 || input.configuration.compilerPath === undefined) {
+        // IntelliSenseMode and standard are optional for version 5+.
+        let areOptionalsValid: boolean = true;
+        if (providerVersion < Version.v5) {
             areOptionalsValid = util.isString(input.configuration.intelliSenseMode) && util.isString(input.configuration.standard);
-        } else if (util.isString(input.configuration.compilerPath)) {
-            areOptionalsValid = util.isOptionalString(input.configuration.intelliSenseMode) && util.isOptionalString(input.configuration.standard);
         }
         return (input && (util.isString(input.uri) || util.isUri(input.uri)) &&
             input.configuration &&
@@ -2468,12 +2466,11 @@ export class DefaultClient implements Client {
     private configurationLogging: Map<string, string> = new Map<string, string>();
 
     private isWorkspaceBrowseConfiguration(input: any): boolean {
-        const areOptionalsValid: boolean = (input.compilerPath === undefined && util.isString(input.standard)) ||
-            (util.isString(input.compilerPath) && util.isOptionalString(input.standard));
-        return areOptionalsValid &&
-        util.isArrayOfString(input.browsePath) &&
-        util.isOptionalString(input.compilerArgs) &&
-        util.isOptionalString(input.windowsSdkVersion);
+        return util.isArrayOfString(input.browsePath) &&
+            util.isOptionalString(input.compilerPath) &&
+            util.isOptionalString(input.standard) &&
+            util.isOptionalString(input.compilerArgs) &&
+            util.isOptionalString(input.windowsSdkVersion);
     }
 
     private sendCustomBrowseConfiguration(config: any, providerId?: string, timeoutOccured?: boolean): void {


### PR DESCRIPTION
This change removes the requirement that standard and intelliSenseMode must be set in a custom config (file or browse) if the compilerPath is not set.  