### PR TITLE
Fix an issue with validating browse configs

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2477,7 +2477,7 @@ export class DefaultClient implements Client {
         return util.isArrayOfString(input.browsePath) &&
             util.isOptionalString(input.compilerPath) &&
             util.isOptionalString(input.standard) &&
-            util.isOptionalString(input.compilerArgs) &&
+            util.isOptionalArrayOfString(input.compilerArgs) &&
             util.isOptionalString(input.windowsSdkVersion);
     }
 


### PR DESCRIPTION
Fix an issue preventing validation/receipt of browse configs from custom config providers.  This looks to have been an issue since 1.2.0.