### PR TITLE
Update a string.  Also, correct use of "MacOS" to the preferred "macOS"

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -492,7 +492,7 @@
 ## Version 0.26.2: December 2, 2019
 ### Enhancements
 * Reworked how a source file is selected for TU creation when opening a header file. [#2856](https://github.com/microsoft/vscode-cpptools/issues/2856)
-* Updated the default value of the `C_Cpp.intelliSenseCachePath` setting to a path under `XDG_CACHE_HOME` on Linux, or `~/Library/Cache` on MacOS. [#3979](https://github.com/microsoft/vscode-cpptools/issues/3979)
+* Updated the default value of the `C_Cpp.intelliSenseCachePath` setting to a path under `XDG_CACHE_HOME` on Linux, or `~/Library/Cache` on macOS. [#3979](https://github.com/microsoft/vscode-cpptools/issues/3979)
 * Reset memory usage of the IntelliSense process if it grows beyond a threshold. [#4119](https://github.com/microsoft/vscode-cpptools/issues/4119)
 * Add validation that the new symbol name provided to 'Rename Symbol' is a valid identifier. Add the setting `C_Cpp.renameRequiresIdentifier` to allow that verification to be disabled. [#4409](https://github.com/microsoft/vscode-cpptools/issues/4409)
 * Enable setting of breakpoints in CUDA sources.

--- a/Extension/i18n/plk/ui/settings.html.i18n.json
+++ b/Extension/i18n/plk/ui/settings.html.i18n.json
@@ -47,7 +47,7 @@
 	"windows.sdk.version": "Wersja zestawu Windows SDK",
 	"windows.sdk.version.description": "Wersja ścieżki dyrektywy include zestawu Windows SDK, która ma być używana w systemie Windows, np. {0}.",
 	"mac.framework.path": "Ścieżka do platformy Mac",
-	"mac.framework.path.description": "Lista ścieżek do użycia przez aparat IntelliSense podczas wyszukiwania dołączonych nagłówków z platform Mac. Obsługiwane tylko w przypadku konfiguracji dla systemu MacOS.",
+	"mac.framework.path.description": "Lista ścieżek do użycia przez aparat IntelliSense podczas wyszukiwania dołączonych nagłówków z platform Mac. Obsługiwane tylko w przypadku konfiguracji dla systemu macOS.",
 	"one.path.per.line": "Jedna ścieżka na wiersz.",
 	"forced.include": "Wymuszone dołączanie",
 	"forced.include.description": "Lista plików, które powinny zostać uwzględnione przed przetworzeniem każdego innego znaku w pliku źródłowym. Pliki są uwzględniane w podanej kolejności.",

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -102,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
         if (installedPlatformAndArchitecture.platform === 'darwin' && installedPlatformAndArchitecture.architecture === "x64" && arch === "arm64") {
             if (promptForMacArchictureMismatch.Value) {
                 // Display a message specifically referring the user to the ARM64 Mac build on ARM64 Mac.
-                errMsg = localize("native.binaries.mismatch.osx", "This Intel version of the extension has been installed.  Since you are on an Apple Silicon Mac, we recommend installing the Apple Silicon version of the extension.");
+                errMsg = localize("native.binaries.mismatch.osx", "The MacOS Intel version of the extension has been installed.  Since you are on an Apple Silicon Mac, we recommend installing the Apple Silicon version of the extension.");
                 promptForMacArchictureMismatch.Value = false;
                 vscode.window.showErrorMessage(errMsg, downloadLink).then(async (selection) => {
                     if (selection === downloadLink) {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -102,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
         if (installedPlatformAndArchitecture.platform === 'darwin' && installedPlatformAndArchitecture.architecture === "x64" && arch === "arm64") {
             if (promptForMacArchictureMismatch.Value) {
                 // Display a message specifically referring the user to the ARM64 Mac build on ARM64 Mac.
-                errMsg = localize("native.binaries.mismatch.osx", "The MacOS Intel version of the extension has been installed.  Since you are on an Apple Silicon Mac, we recommend installing the Apple Silicon version of the extension.");
+                errMsg = localize("native.binaries.mismatch.osx", "The macOS Intel version of the extension has been installed.  Since you are on an Apple Silicon Mac, we recommend installing the Apple Silicon version of the extension.");
                 promptForMacArchictureMismatch.Value = false;
                 vscode.window.showErrorMessage(errMsg, downloadLink).then(async (selection) => {
                     if (selection === downloadLink) {

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -16,7 +16,7 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 export function GetOSName(processPlatform: string | undefined): string | undefined {
     switch (processPlatform) {
         case "win32": return "Windows";
-        case "darwin": return "MacOS";
+        case "darwin": return "macOS";
         case "linux": return "Linux";
         default: return undefined;
     }


### PR DESCRIPTION
A minor string fix.  `This Intel version of the extension has been installed.` didn't make a lot of sense.  Changed it to: `The macOS Intel version of the extension has been installed.`

Also updated use of "MacOS" in strings, as "macOS" is Apple's preferred casing.

https://en.wikipedia.org/wiki/MacOS