### PR TITLE
Add action workflows for 'enhancement' label

### DIFF
--- a/.github/workflows/enhancement-closer-no-milestone.yml
+++ b/.github/workflows/enhancement-closer-no-milestone.yml
@@ -1,0 +1,30 @@
+name: Enhancement Closer (no milestone)
+on:
+  schedule:
+    - cron: 50 11 * * * # Run at 11:50 AM UTC (3:50 AM PST, 4:50 AM PDT)
+  workflow_dispatch:
+   inputs:
+     readonly:
+       description: "readonly: Specify true or 1 to prevent changes from being commited to GitHub"
+       default: false
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+      - name: Install Actions
+        run: cd ./.github/actions && npm install --production && cd ../..
+      - name: Stale Closer
+        uses: ./.github/actions/StaleCloser
+        with:
+          readonly: ${{ github.event.inputs.readonly }}
+          labels: enhancement
+          ignoreLabels: debugger,internal,Feature Request
+          addLabels: more votes needed
+          closeDays: 60
+          maximumVotes: 2
+          closeComment: "This feature request is being closed due to insufficient upvotes.  When enough upvotes are received, this issue will be eligible for our backlog."
+          setMilestoneId: 30
+          ignoreMilestoneNames: "*"

--- a/.github/workflows/enhancement-closer-triage.yml
+++ b/.github/workflows/enhancement-closer-triage.yml
@@ -1,0 +1,30 @@
+name: Enhancement Closer (Triage)
+on:
+  schedule:
+    - cron: 40 11 * * * # Run at 11:40 AM UTC (3:40 AM PST, 4:40 AM PDT)
+  workflow_dispatch:
+   inputs:
+     readonly:
+       description: "readonly: Specify true or 1 to prevent changes from being commited to GitHub"
+       default: false
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+      - name: Install Actions
+        run: cd ./.github/actions && npm install --production && cd ../..
+      - name: Stale Closer
+        uses: ./.github/actions/StaleCloser
+        with:
+          readonly: ${{ github.event.inputs.readonly }}
+          labels: enhancement
+          ignoreLabels: debugger,internal,Feature Request
+          addLabels: more votes needed
+          closeDays: 60
+          maximumVotes: 2
+          closeComment: "This feature request is being closed due to insufficient upvotes.  When enough upvotes are received, this issue will be eligible for our backlog."
+          milestoneName: Triage
+          milestoneId: 30

--- a/.github/workflows/enhancement-reopener.yml
+++ b/.github/workflows/enhancement-reopener.yml
@@ -1,0 +1,31 @@
+name: Enhancement Reopener
+on:
+  schedule:
+    - cron: 20 12 * * * # Run at 12:20 PM UTC (4:20 AM PST, 5:20 AM PDT)
+  workflow_dispatch:
+   inputs:
+     readonly:
+       description: "readonly: Specify true or 1 to prevent changes from being commited to GitHub"
+       default: false
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+      - name: Install Actions
+        run: cd ./.github/actions && npm install --production && cd ../..
+      - name: Run Reopener
+        uses: ./.github/actions/Reopener
+        with:
+          readonly: ${{ github.event.inputs.readonly }}
+          alsoApplyToOpenIssues: true
+          reopenComment: This feature request has received enough votes to be added to our backlog.
+          labels: enhancement
+          minimumVotes: 3
+          ignoreLabels: debugger,internal,Feature Request
+          milestoneId: 30
+          milestoneName: Triage
+          setMilestoneId: 28
+          removeLabels: more votes needed


### PR DESCRIPTION
Adds action workflows to treat the label `enhancement` the same as `Feature Request` with regards to tracking votes, automatically closing and reopening.

Ignores issues with `Feature Request` label, to ensure it doesn't apply to the same issues as those workflows if both labels were set.  Otherwise, these are identical to the current workflows for `Feature Request`.
