### PR TITLE
Send package version to native process

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1250,7 +1250,8 @@ export class DefaultClient implements Client {
                 experimentalFeatures: workspaceSettings.experimentalFeatures,
                 edgeMessagesDirectory: path.join(util.getExtensionFilePath("bin"), "messages", util.getLocaleId()),
                 localizedStrings: localizedStrings,
-                supportCuda: util.supportCuda
+                supportCuda: util.supportCuda,
+                packageVersion: util.packageJson.version
             },
             middleware: createProtocolFilter(allClients),
             errorHandler: {


### PR DESCRIPTION
Add package version to initialization message.

The native process will use the version to determine whether or not a heartbeat should be required from the TypeScript side.  If "-main" is seen in the version string (suggesting a local dev scenario), the heartbeat is not required.  This is intended to avoid having the native process self-terminate because it thinks it's been orphaned, while the TypeScript code is stopped at a break point.