### PR TITLE
Work around issue with incorrect newlines in localized strings

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -41,6 +41,7 @@ steps:
     patVariable: '$(OneLocBuildPat)'
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCPP'
+    lsBuildXLocPackageVersion: '7.0.30510'
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
There is step in the loc pipeline adding `\r`'s to strings.  This change is to revert to a version of that package prior to the introduction of the issue.

This line will need to be removed once the issue has been fixed.
