### PR TITLE
Cleanup IsExplicit flags.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2353,7 +2353,7 @@ export class DefaultClient implements Client {
         } else {
             const lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> = new PersistentFolderState<string | undefined>("CPP.lastCustomBrowseConfigurationProviderId", undefined, rootFolder);
             const lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> = new PersistentFolderState<WorkspaceBrowseConfiguration | undefined>("CPP.lastCustomBrowseConfiguration", undefined, rootFolder);
-            if (!this.doneInitialCustomBrowseConfigurationCheck) {
+            if (!this.doneInitialCustomBrowseConfigurationCheck && configurations[params.currentConfiguration].configurationProvider !== undefined) {
                 // Send the last custom browse configuration we received from this provider.
                 // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
                 // Should only execute on launch, for the initial delivery of configurations

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2353,7 +2353,7 @@ export class DefaultClient implements Client {
         } else {
             const lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> = new PersistentFolderState<string | undefined>("CPP.lastCustomBrowseConfigurationProviderId", undefined, rootFolder);
             const lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> = new PersistentFolderState<WorkspaceBrowseConfiguration | undefined>("CPP.lastCustomBrowseConfiguration", undefined, rootFolder);
-            if (!this.doneInitialCustomBrowseConfigurationCheck && configurations[params.currentConfiguration].configurationProvider !== undefined) {
+            if (!this.doneInitialCustomBrowseConfigurationCheck) {
                 // Send the last custom browse configuration we received from this provider.
                 // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
                 // Should only execute on launch, for the initial delivery of configurations

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1204,12 +1204,14 @@ export class CppProperties {
                 }
             }
 
-            for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
-                if ((<any>this.configurationJson.configurations[i]).knownCompilers !== undefined) {
-                    delete (<any>this.configurationJson.configurations[i]).knownCompilers;
+            this.configurationJson.configurations.forEach(e => {
+                if ((<any>e).knownCompilers !== undefined) {
+                    delete (<any>e).knownCompilers;
                     dirty = true;
-                    break;
                 }
+            });
+
+            for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
                 if (this.configurationJson.configurations[i].compilerPathIsExplicit !== undefined) {
                     dirty = true;
                     break;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1859,19 +1859,19 @@ export class CppProperties {
 
         if (this.configurationJson) {
             this.configurationJson.configurations.forEach(e => {
-                savedCompilerPathIsExplicit.push(e.compilerPathIsExplicit !== undefined);
+                savedCompilerPathIsExplicit.push(!!e.compilerPathIsExplicit);
                 if (e.compilerPathIsExplicit !== undefined) {
                     delete e.compilerPathIsExplicit;
                 }
-                savedCStandardIsExplicit.push(e.cStandardIsExplicit !== undefined);
+                savedCStandardIsExplicit.push(!!e.cStandardIsExplicit);
                 if (e.cStandardIsExplicit !== undefined) {
                     delete e.cStandardIsExplicit;
                 }
-                savedCppStandardIsExplicit.push(e.cppStandardIsExplicit !== undefined);
+                savedCppStandardIsExplicit.push(!!e.cppStandardIsExplicit);
                 if (e.cppStandardIsExplicit !== undefined) {
                     delete e.cppStandardIsExplicit;
                 }
-                savedIntelliSenseModeIsExplicit.push(e.intelliSenseModeIsExplicit !== undefined);
+                savedIntelliSenseModeIsExplicit.push(!!e.intelliSenseModeIsExplicit);
                 if (e.intelliSenseModeIsExplicit !== undefined) {
                     delete e.intelliSenseModeIsExplicit;
                 }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1212,19 +1212,10 @@ export class CppProperties {
             });
 
             for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
-                if (this.configurationJson.configurations[i].compilerPathIsExplicit !== undefined) {
-                    dirty = true;
-                    break;
-                }
-                if (this.configurationJson.configurations[i].cStandardIsExplicit !== undefined) {
-                    dirty = true;
-                    break;
-                }
-                if (this.configurationJson.configurations[i].cppStandardIsExplicit !== undefined) {
-                    dirty = true;
-                    break;
-                }
-                if (this.configurationJson.configurations[i].intelliSenseModeIsExplicit !== undefined) {
+                if ((this.configurationJson.configurations[i].compilerPathIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].cStandardIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].cppStandardIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].intelliSenseModeIsExplicit !== undefined)) {
                     dirty = true;
                     break;
                 }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1851,17 +1851,27 @@ export class CppProperties {
     }
 
     private writeToJson(): void {
+        // Set aside IsExplicit values, and restore them after writing.
+        const savedCompilerPathIsExplicit: boolean[] = [];
+        const savedCStandardIsExplicit: boolean[] = [];
+        const savedCppStandardIsExplicit: boolean[] = [];
+        const savedIntelliSenseModeIsExplicit: boolean[] = [];
+
         if (this.configurationJson) {
             this.configurationJson.configurations.forEach(e => {
+                savedCompilerPathIsExplicit.push(e.compilerPathIsExplicit !== undefined);
                 if (e.compilerPathIsExplicit !== undefined) {
                     delete e.compilerPathIsExplicit;
                 }
+                savedCStandardIsExplicit.push(e.cStandardIsExplicit !== undefined);
                 if (e.cStandardIsExplicit !== undefined) {
                     delete e.cStandardIsExplicit;
                 }
+                savedCppStandardIsExplicit.push(e.cppStandardIsExplicit !== undefined);
                 if (e.cppStandardIsExplicit !== undefined) {
                     delete e.cppStandardIsExplicit;
                 }
+                savedIntelliSenseModeIsExplicit.push(e.intelliSenseModeIsExplicit !== undefined);
                 if (e.intelliSenseModeIsExplicit !== undefined) {
                     delete e.intelliSenseModeIsExplicit;
                 }
@@ -1871,6 +1881,15 @@ export class CppProperties {
         console.assert(this.propertiesFile);
         if (this.propertiesFile) {
             fs.writeFileSync(this.propertiesFile.fsPath, jsonc.stringify(this.configurationJson, null, 4));
+        }
+
+        if (this.configurationJson) {
+            for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
+                this.configurationJson.configurations[i].compilerPathIsExplicit = savedCompilerPathIsExplicit[i];
+                this.configurationJson.configurations[i].cStandardIsExplicit = savedCStandardIsExplicit[i];
+                this.configurationJson.configurations[i].cppStandardIsExplicit = savedCppStandardIsExplicit[i];
+                this.configurationJson.configurations[i].intelliSenseModeIsExplicit = savedIntelliSenseModeIsExplicit[i];
+            }
         }
     }
 


### PR DESCRIPTION
This addresses an issue in which a fully default config (no `c_cpp_properties.json`, and no `C_Cpp.default.*` settings) would appear as explicitly set.

These flags are intended to indicate whether a value has been explicitly specified by a user (or config provider, etc.) rather than an automatic default value, so that a Configuration Warning can be suppressed if an automatic default value needs to be corrected.  This change ensures that these flags are always set to false when a new configuration is set up, always set to align with a configuration after it's been read, updated to reflected whether a user-specified `C_Cpp.default` setting was used, and never written to `c_cpp_properties.json`.