### PR TITLE
Use provider ID associated with cached browse config to auto-detect provider

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -881,7 +881,7 @@ export class CppProperties {
                         }
                     } else if (this.lastCustomBrowseConfigurationProviderId !== undefined
                         && !!this.lastCustomBrowseConfigurationProviderId.Value) {
-                        // Use the last configure provider we received a browse config from as the provider ID.
+                        // Use the last configuration provider we received a browse config from as the provider ID.
                         configuration.configurationProvider = this.lastCustomBrowseConfigurationProviderId.Value;
                     }
                 } else if (this.lastCustomBrowseConfigurationProviderId !== undefined) {


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/7542

Uses the provider ID associated with the last received browse config, to auto-detect a config provider, if none is registered.

Fixes an issue with the cached browse config not being removed after switching to a different config (that does not use the same config provider), or a different config provider is auto-detected.
