### PR TITLE
Run loc pipeline as scheduled, even if no code changes

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -16,6 +16,7 @@ schedules:
   branches:
     include:
     - main
+  always: true
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
This sets the 'always' flag on the schedule to cause the loc pipeline to run as scheduled even if there have been no code changes.  This is necessary to pick up changes to translated strings.