### PR TITLE
Workaround for webViewPanel.postMessage getting dropped.

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1032,7 +1032,7 @@ export class CppProperties {
                             this.settingsPanel.updateConfigUI(configNames,
                                 this.configurationJson.configurations[this.settingsPanel.selectedConfigIndex],
                                 this.getErrorsForConfigUI(this.settingsPanel.selectedConfigIndex));
-                                
+
                             // Need to queue another update due to a VS Code regression bug which may drop the initial update.
                             // It repros with a higher probability in cases that cause a slower load, such as after
                             // switching to a Chinese langauge pack or in the remote scenario.

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1025,14 +1025,21 @@ export class CppProperties {
                         if (this.settingsPanel.selectedConfigIndex >= this.configurationJson.configurations.length) {
                             this.settingsPanel.selectedConfigIndex = this.CurrentConfigurationIndex;
                         }
-                        setTimeout(() => {
-                            if (this.settingsPanel && this.configurationJson) {
-                                this.settingsPanel.updateConfigUI(configNames,
-                                    this.configurationJson.configurations[this.settingsPanel.selectedConfigIndex],
-                                    this.getErrorsForConfigUI(this.settingsPanel.selectedConfigIndex));
+                        const tryUpdate = () => {
+                            if (!this.settingsPanel || !this.configurationJson || this.settingsPanel.firstUpdateReceived) {
+                                return;
                             }
-                        },
-                        500); // Need some delay or the UI can randomly be blank, particularly in the remote scenario.
+                            this.settingsPanel.updateConfigUI(configNames,
+                                this.configurationJson.configurations[this.settingsPanel.selectedConfigIndex],
+                                this.getErrorsForConfigUI(this.settingsPanel.selectedConfigIndex));
+                                
+                            // Need to queue another update due to a VS Code regression bug which may drop the initial update.
+                            // It repros with a higher probability in cases that cause a slower load, such as after
+                            // switching to a Chinese langauge pack or in the remote scenario.
+                            setTimeout(tryUpdate, 500);
+                        };
+                        this.settingsPanel.firstUpdateReceived = false;
+                        tryUpdate();
                     } else {
                         // Parse failed, open json file
                         vscode.workspace.openTextDocument(this.propertiesFile);

--- a/Extension/src/LanguageServer/settingsPanel.ts
+++ b/Extension/src/LanguageServer/settingsPanel.ts
@@ -73,6 +73,9 @@ export class SettingsPanel {
     private static readonly viewType: string = 'settingsPanel';
     private static readonly title: string = 'C/C++ Configurations';
 
+    // Used to workaround a VS Code bug in which webviewPanel.postMessage calls sometimes get dropped.
+    public firstUpdateReceived: boolean = false;
+
     constructor() {
         this.disposable = vscode.Disposable.from(
             this.settingsPanelActivated,
@@ -107,6 +110,8 @@ export class SettingsPanel {
                     vscode.Uri.file(path.join(util.extensionPath, 'out', 'ui'))]
             }
         );
+
+        this.firstUpdateReceived = false;
 
         this.panel.iconPath = vscode.Uri.file(util.getExtensionFilePath("LanguageCCPP_color_128x.png"));
 
@@ -249,6 +254,9 @@ export class SettingsPanel {
                 break;
             case 'knownCompilerSelect':
                 this.knownCompilerSelect();
+                break;
+            case 'firstUpdateReceived':
+                this.firstUpdateReceived = true;
                 break;
         }
     }

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -64,6 +64,9 @@ class SettingsApp {
     private readonly vsCodeApi: VsCodeApi;
     private updating: boolean = false;
 
+    // Used to workaround a VS Code bug in which webviewPanel.postMessage calls sometimes get dropped.
+    private firstUpdateReceived: boolean = false;
+
     constructor() {
         this.vsCodeApi = acquireVsCodeApi();
 
@@ -232,6 +235,12 @@ class SettingsApp {
         switch (message.command) {
             case 'updateConfig':
                 this.updateConfig(message.config);
+
+                if (!this.firstUpdateReceived) {
+                    this.vsCodeApi.postMessage({
+                        command: "firstUpdateReceived"
+                    });
+                }
                 break;
             case 'updateErrors':
                 this.updateErrors(message.errors);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/7641 . Workaround for VS Code regression bug https://github.com/microsoft/vscode/issues/125546 .

VS Code can take up to 6 seconds to respond to the postMessage requests (i.e. it could retry around 10 times).