### PR TITLE
Fix code action warning.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -813,7 +813,8 @@ export class DefaultClient implements Client {
                                             title: title,
                                             command: command.command,
                                             arguments: command.arguments
-                                        }
+                                        },
+                                        kind: vscode.CodeActionKind.QuickFix
                                     };
                                     resultCodeActions.push(vscodeCodeAction);
                                 });


### PR DESCRIPTION
Fix for [exthost] [warning] ms-vscode.cpptools - Code actions of kind 'quickfix 'requested but returned code action does not have a 'kind'. Code action will be dropped. Please set 'CodeAction.kind'.