### PR TITLE
Use setTextDocumentLanguage to temporarily set language ID for CUDA sources, and headers

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1993,7 +1993,6 @@ export class DefaultClient implements Client {
     }
 
     private async setTemporaryTextDocumentLanguage(params: SetTemporaryTextDocumentLanguageParams): Promise<void> {
-        // const uri: vscode.Uri = vscode.Uri.file(params.path);
         const languageId: string = params.isC ? "c" : (params.isCuda ? "cuda-cpp" : "cpp");
         const document: vscode.TextDocument = await vscode.workspace.openTextDocument(params.path);
         if (!!document && document.languageId !== languageId) {


### PR DESCRIPTION
There is a PR on the native side for the bulk of this change.

Adds a new protocol message from the native side which invokes `vscode.languages.setTextDocumentLanguage`.