### PR TITLE
Update Windows Debugger Packages

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # C/C++ for Visual Studio Code Change Log
 
-## Version 1.5.0: July 9, 2021
+## Version 1.5.1: July 9, 2021
 ### Bug Fixes
 * cppvsdbg Debugging becomes no-op between 1.4.1 and 1.5.0 [#7808](https://github.com/microsoft/vscode-cpptools/issues/7808)
 

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Change Log
 
+## Version 1.5.0: July 9, 2021
+### Bug Fixes
+* cppvsdbg Debugging becomes no-op between 1.4.1 and 1.5.0 [#7808](https://github.com/microsoft/vscode-cpptools/issues/7808)
+
 ## Version 1.5.0: July 8, 2021
 ### New Feature
 * Add the "Inline macro" code action. [#4183](https://github.com/microsoft/vscode-cpptools/issues/4183)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools",
   "displayName": "C/C++",
   "description": "C/C++ IntelliSense, debugging, and code browsing.",
-  "version": "1.5.0-main",
+  "version": "1.5.1-main",
   "publisher": "ms-vscode",
   "icon": "LanguageCCPP_color_128x.png",
   "readme": "README.md",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3106,7 +3106,7 @@
     },
     {
       "description": "Visual Studio Windows Debugger",
-      "url": "https://go.microsoft.com/fwlink/?linkid=2167487",
+      "url": "https://go.microsoft.com/fwlink/?linkid=2167539",
       "platforms": [
         "win32"
       ],
@@ -3117,11 +3117,11 @@
       "binaries": [
         "./debugAdapters/vsdbg/bin/vsdbg.exe"
       ],
-      "integrity": "BACAD3BC69C548FA5CEC0B15109C8628CB45D0F622F1F6C635A23C29B0B042E1"
+      "integrity": "3E71A1FDD78FBD9FD46ADEE0DF1283349363078B273CAE765978ACF1BA9C2DB1"
     },
     {
       "description": "Visual Studio Windows ARM64 Debugger",
-      "url": "https://go.microsoft.com/fwlink/?linkid=2167488",
+      "url": "https://go.microsoft.com/fwlink/?linkid=2167648",
       "platforms": [
         "win32"
       ],
@@ -3131,7 +3131,7 @@
       "binaries": [
         "./debugAdapters/vsdbg/bin/vsdbg.exe"
       ],
-      "integrity": "64325BABDC9B51E7D51111788083BE91C3CC36DEC80145687D9AB6F988F9071F"
+      "integrity": "698BA3D45B925F998AACE9ED387ADE4927FFE569860408570FD074DD0CD56252"
     }
   ]
 }


### PR DESCRIPTION
Fixes: `FATAL ERROR: Failed to initialize dispatcher with error 8ede0007`

Addresses #7808