### PR TITLE
Fix issue with compilerPathIsExplicit not being set properly

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -775,12 +775,11 @@ export class CppProperties {
             configuration.intelliSenseModeIsExplicit = configuration.intelliSenseModeIsExplicit || settings.defaultIntelliSenseMode !== "";
             configuration.cStandardIsExplicit = configuration.cStandardIsExplicit || settings.defaultCStandard !== "";
             configuration.cppStandardIsExplicit = configuration.cppStandardIsExplicit || settings.defaultCppStandard !== "";
-            configuration.compilerPathIsExplicit = false;
             if (!configuration.compileCommands) {
                 // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
                 // don't set a default when compileCommands is in use.
                 configuration.compilerPath = this.updateConfigurationString(configuration.compilerPath, settings.defaultCompilerPath, env, true);
-                configuration.compilerPathIsExplicit = configuration.compilerPath !== undefined;
+                configuration.compilerPathIsExplicit = configuration.compilerPathIsExplicit || settings.defaultCompilerPath !== undefined;
                 if (configuration.compilerPath === undefined) {
                     if (!!this.defaultCompilerPath) {
                         // If no config value yet set for these, pick up values from the defaults, but don't consider them explicit.
@@ -820,6 +819,8 @@ export class CppProperties {
                 } else if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
+                } else {
+                    configuration.compilerPathIsExplicit = false;
                 }
             }
 


### PR DESCRIPTION
I noticed this while investigating another issue.  If there is no `c_cpp_properties.json`, `compilerPathIsExplicit` was being set to true when it should have been set to false.  When this value is true, a Configuration Warning will be displayed if we need to modify the compiler path for some reason (such as failing to query a compiler and falling back to another compiler).  It should be false when using a detected value instead of one that is specified by the user or configuration provider, etc..