### PR TITLE
Retry more.

### DIFF
--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -189,7 +189,7 @@ export class PackageManager {
         let success: boolean = false;
         let lastError: any = null;
         let retryCount: number = 0;
-        const MAX_RETRIES: number = 5;
+        const MAX_RETRIES: number = 10;
 
         // Retry the download at most MAX_RETRIES times with 2-32 seconds delay.
         do {
@@ -244,7 +244,7 @@ export class PackageManager {
 
         const buffers: Buffer[] = [];
         return new Promise<void>((resolve, reject) => {
-            let secondsDelay: number = Math.pow(2, delay);
+            let secondsDelay: number = Math.min(Math.pow(2, delay), 32);
             if (secondsDelay === 1) {
                 secondsDelay = 0;
             }


### PR DESCRIPTION
Add more retries. The failure issue today would fix itself if it retried more, but I'm not sure what the ideal retry amount is because the issue stopped reproing. Maybe we could check telemetry afterwards to see if the number of failures decreased.