### PR TITLE
Use new modal w/ detail dialog for compiler list in Walkthrough

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -11,7 +11,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.58.0"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-cpptools/issues",
@@ -3026,7 +3026,7 @@
     "@types/plist": "^3.0.2",
     "@types/semver": "^7.1.0",
     "@types/tmp": "^0.1.0",
-    "@types/vscode": "1.57.0",
+    "@types/vscode": "1.58.0",
     "@types/which": "^1.3.2",
     "@types/yauzl": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1423,7 +1423,7 @@ export class DefaultClient implements Client {
                         const newLoggingLevelLogged: boolean = !!newLoggingLevel && newLoggingLevel !== "None" && newLoggingLevel !== "Error";
                         if (oldLoggingLevelLogged || newLoggingLevelLogged) {
                             const out: logger.Logger = logger.getOutputChannelLogger();
-                            out.appendLine(localize({ key: "loggingLevel.changed", comment: ["{0} is the setting name 'loggingLevel', {1} is a string value such as 'Debug'"]}, "{0} has changed to: {1}", "loggingLevel", changedSettings["loggingLevel"]));
+                            out.appendLine(localize({ key: "loggingLevel.changed", comment: ["{0} is the setting name 'loggingLevel', {1} is a string value such as 'Debug'"] }, "{0} has changed to: {1}", "loggingLevel", changedSettings["loggingLevel"]));
                         }
                     }
                     const settings: CppSettings = new CppSettings();
@@ -2786,20 +2786,26 @@ export class DefaultClient implements Client {
             vscode.window.showInformationMessage(localize("no.compilers.found", "No C++ compilers were found on your system. For your platform, we recommend installing {0} using the instructions in the editor.", compilerName), { modal: true });
         } else {
             const header: string = localize("compilers.found", "We found the following C++ compiler(s) on your system:");
-            let message: string = header + "\n";
+            let message: string = "";
             const settings: CppSettings = new CppSettings(this.RootUri);
             const pathSeparator: string | undefined = settings.preferredPathSeparator;
+            let isFirstLine: boolean = true;
             compilers.forEach(compiler => {
-                if (pathSeparator !== "Forward Slash") {
-                    message += "\n" + compiler.path.replace(/\//g, '\\');
+                if (isFirstLine) {
+                    isFirstLine = false;
                 } else {
-                    message += "\n" + compiler.path.replace(/\\/g, '/');
+                    message += "\n";
+                }
+                if (pathSeparator !== "Forward Slash") {
+                    message += compiler.path.replace(/\//g, '\\');
+                } else {
+                    message += compiler.path.replace(/\\/g, '/');
                 }
             });
             if (compilers.length > 1) {
                 message += "\n\n" + localize("compilers.found.message", "You can specify which compiler to use in your project's IntelliSense Configuration.");
             }
-            vscode.window.showInformationMessage(message, { modal: true });
+            vscode.window.showInformationMessage(header, { modal: true, detail: message });
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2785,7 +2785,8 @@ export class DefaultClient implements Client {
             const compilerName: string = process.platform === "win32" ? "MSVC" : (process.platform === "darwin" ? "Clang" : "GCC");
             vscode.window.showInformationMessage(localize("no.compilers.found", "No C++ compilers were found on your system. For your platform, we recommend installing {0} using the instructions in the editor.", compilerName), { modal: true });
         } else {
-            const header: string = localize("compilers.found", "We found the following C++ compiler(s) on your system:");
+            const header: string = localize("compilers.found", "We found the following C++ compiler(s) on your system.")
+                + "\n" + localize("compilers.found.message", "You can specify which compiler to use in your project's IntelliSense Configuration.");
             let message: string = "";
             const settings: CppSettings = new CppSettings(this.RootUri);
             const pathSeparator: string | undefined = settings.preferredPathSeparator;
@@ -2802,9 +2803,6 @@ export class DefaultClient implements Client {
                     message += compiler.path.replace(/\\/g, '/');
                 }
             });
-            if (compilers.length > 1) {
-                message += "\n\n" + localize("compilers.found.message", "You can specify which compiler to use in your project's IntelliSense Configuration.");
-            }
             vscode.window.showInformationMessage(header, { modal: true, detail: message });
         }
     }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2785,8 +2785,7 @@ export class DefaultClient implements Client {
             const compilerName: string = process.platform === "win32" ? "MSVC" : (process.platform === "darwin" ? "Clang" : "GCC");
             vscode.window.showInformationMessage(localize("no.compilers.found", "No C++ compilers were found on your system. For your platform, we recommend installing {0} using the instructions in the editor.", compilerName), { modal: true });
         } else {
-            const header: string = localize("compilers.found", "We found the following C++ compiler(s) on your system.")
-                + "\n" + localize("compilers.found.message", "You can specify which compiler to use in your project's IntelliSense Configuration.");
+            const header: string = localize("compilers.found", "We found the following C++ compilers on your system. Choose a compiler in your project's IntelliSense Configuration.");
             let message: string = "";
             const settings: CppSettings = new CppSettings(this.RootUri);
             const pathSeparator: string | undefined = settings.preferredPathSeparator;

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -289,10 +289,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
   integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
-"@types/vscode@1.57.0":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.57.0.tgz#cc648e0573b92f725cd1baf2621f8da9f8bc689f"
-  integrity sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==
+"@types/vscode@1.58.0":
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.0.tgz#91662aa27197c750df314e0d27de4b23512ebe59"
+  integrity sha512-enznxcBi4uYt20LWal09E0+VKEHZlq9PZawTu/mpWCVCFWWbiyR8HNI1ikBP1Ypqv8b3A/0md3DY1jcx+oQ8kQ==
 
 "@types/which@^1.3.2":
   version "1.3.2"


### PR DESCRIPTION
VS Code added a new modal dialog which displays details less prominently than the main message.  This change switches to using that UI for the detected compiler list that can be displayed via the Getting Started walkthrough.

It was (on Windows):
![image](https://user-images.githubusercontent.com/49173979/127290327-7c60f109-7e4a-47e9-b059-32678357226b.png)

It's now (on Windows):
![image](https://user-images.githubusercontent.com/49173979/127556489-9b948040-6080-4d3d-9fbb-cbc52ba05cc0.png)
