### PR TITLE
Fix code folding bug

### DIFF
--- a/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
+++ b/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
@@ -29,11 +29,8 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
         const result: vscode.FoldingRange[] = [];
         ranges.ranges.forEach((r: CppFoldingRange) => {
             const foldingRange: vscode.FoldingRange = {
-                start: r.range.start.line,
-                // Move the end range up one, so the end } line isn't folded, because
-                // VS Code doesn't support column-based folding: https://github.com/microsoft/vscode/issues/50840
-                // The behavior matches TypeScript but not VS (which has column-based folding).
-                end: r.range.end.line - 1
+                start: r.range.startLine,
+                end: r.range.endLine
             };
             switch (r.kind) {
                 case FoldingRangeKind.Comment:

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -373,7 +373,7 @@ export enum FoldingRangeKind {
 
 export interface CppFoldingRange {
     kind: FoldingRangeKind;
-    range: Range;
+    range: InputRegion;
 }
 
 export interface GetFoldingRangesResult {


### PR DESCRIPTION
Fixes a code folding bug introduced by: https://github.com/microsoft/vscode-cpptools/pull/7818 

Most of the fix is now on the native side.
