### PR TITLE
Update Theme extension image previews to work in the store

### DIFF
--- a/Themes/README.md
+++ b/Themes/README.md
@@ -10,11 +10,11 @@ VS Code has since provided an API for semantic colorization. The C/C++ Extension
 
 Light Theme
 
-![Light Theme example](https://github.com/Microsoft/vscode-cpptools/raw/main/Themes/assets/light.png)
+![Light Theme example](https://raw.githubusercontent.com/microsoft/vscode-cpptools/main/Themes/assets/light.png)
 
 Dark Theme
 
-![Dark Theme example](https://github.com/Microsoft/vscode-cpptools/raw/main/Themes/assets/dark.png)
+![Dark Theme example](https://raw.githubusercontent.com/microsoft/vscode-cpptools/main/Themes/assets/dark.png)
 
 ## Contributing
 


### PR DESCRIPTION
Currently, they show as broken images:
![image](https://user-images.githubusercontent.com/6440374/129462179-1dfc0b3d-a5b7-468f-9327-bd02ce1c4ab8.png)
