### PR TITLE
Fix rewrite of updateChannel for remote VS Code insiders

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -425,7 +425,7 @@ async function finalizeExtensionActivation(): Promise<void> {
     const packageJson: any = util.getRawPackageJson();
     let writePackageJson: boolean = false;
     const packageJsonPath: string = util.getExtensionFilePath("package.json");
-    if (packageJsonPath.includes(".vscode-insiders") || packageJsonPath.includes(".vscode-exploration")) {
+    if (packageJsonPath.includes(".vscode-insiders") || packageJsonPath.includes(".vscode-server-insiders") || packageJsonPath.includes(".vscode-exploration")) {
         if (packageJson.contributes.configuration.properties['C_Cpp.updateChannel'].default === 'Default') {
             packageJson.contributes.configuration.properties['C_Cpp.updateChannel'].default = 'Insiders';
             writePackageJson = true;

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -425,7 +425,10 @@ async function finalizeExtensionActivation(): Promise<void> {
     const packageJson: any = util.getRawPackageJson();
     let writePackageJson: boolean = false;
     const packageJsonPath: string = util.getExtensionFilePath("package.json");
-    if (packageJsonPath.includes(".vscode-insiders") || packageJsonPath.includes(".vscode-server-insiders") || packageJsonPath.includes(".vscode-exploration")) {
+    if (packageJsonPath.includes(".vscode-insiders") ||
+        packageJsonPath.includes(".vscode-server-insiders") ||
+        packageJsonPath.includes(".vscode-exploration") ||
+        packageJsonPath.includes(".vscode-server-exploration")) {
         if (packageJson.contributes.configuration.properties['C_Cpp.updateChannel'].default === 'Default') {
             packageJson.contributes.configuration.properties['C_Cpp.updateChannel'].default = 'Insiders';
             writePackageJson = true;


### PR DESCRIPTION
The default value of `updateChannel` is rewritten in our package.json, when VS Code Insiders is detected.  That check was failing to detect VS Code Insiders when used in a remote scenario.