### PR TITLE
Remove executable check for OpenDebugAD7

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3401,7 +3401,8 @@
         "darwin"
       ],
       "architectures": [
-        "x64"
+        "x64",
+        "arm64"
       ],
       "binaries": [
         "./debugAdapters/bin/OpenDebugAD7"

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -263,7 +263,7 @@ async function downloadAndInstallPackages(info: PlatformInformation): Promise<vo
 }
 
 function makeBinariesExecutable(): Promise<void> {
-    return util.allowExecution(util.getDebugAdaptersPath("OpenDebugAD7"));
+    return util.allowExecution(util.getDebugAdaptersPath("bin/OpenDebugAD7"));
 }
 
 function packageMatchesPlatform(pkg: IPackage, info: PlatformInformation): boolean {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -209,9 +209,6 @@ async function offlineInstallation(info: PlatformInformation): Promise<void> {
     setInstallationStage('cleanUpUnusedBinaries');
     await cleanUpUnusedBinaries(info);
 
-    setInstallationStage('makeBinariesExecutable');
-    await makeBinariesExecutable();
-
     setInstallationStage('makeOfflineBinariesExecutable');
     await makeOfflineBinariesExecutable(info);
 
@@ -226,9 +223,6 @@ async function onlineInstallation(info: PlatformInformation): Promise<void> {
     setInstallationType(InstallationType.Online);
 
     await downloadAndInstallPackages(info);
-
-    setInstallationStage('makeBinariesExecutable');
-    await makeBinariesExecutable();
 
     setInstallationStage('rewriteManifest');
     await rewriteManifest();
@@ -260,10 +254,6 @@ async function downloadAndInstallPackages(info: PlatformInformation): Promise<vo
         setInstallationStage('installPackages');
         await packageManager.InstallPackages(progress);
     });
-}
-
-function makeBinariesExecutable(): Promise<void> {
-    return util.allowExecution(util.getDebugAdaptersPath("bin/OpenDebugAD7"));
 }
 
 function packageMatchesPlatform(pkg: IPackage, info: PlatformInformation): boolean {


### PR DESCRIPTION
The makeExecutable check for OpenDebugAD7 is not needed anymore because this script was used to launch for Mono. Mono was removed for usage of .NET 5 instead.