### PR TITLE
Add support for Debugging on Alpine

### DIFF
--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -24,6 +24,26 @@ export function buildAndDebugActiveFileStr(): string {
     return ` - ${localize("build.and.debug.active.file", 'Build and debug active file')}`;
 }
 
+/*
+   Separate initialize method for Alpine until we can use the regular 'initialize' method.
+
+   This enables attach and cppdbg for alpine without snippets or 'Build and Debug Active file'
+   since we do not have a language service.
+
+   TODO(LS-alpine): Remove initializeForAlpine
+*/
+export function initializeForAlpine(context: vscode.ExtensionContext): void {
+    const attachItemsProvider: AttachItemsProvider = NativeAttachItemsProviderFactory.Get();
+    const attacher: AttachPicker = new AttachPicker(attachItemsProvider);
+    disposables.push(vscode.commands.registerCommand('extension.pickNativeProcess', () => attacher.ShowAttachEntries()));
+    const remoteAttacher: RemoteAttachPicker = new RemoteAttachPicker();
+    disposables.push(vscode.commands.registerCommand('extension.pickRemoteNativeProcess', (any) => remoteAttacher.ShowAttachEntries(any)));
+
+    disposables.push(vscode.debug.registerDebugAdapterDescriptorFactory(CppdbgDebugAdapterDescriptorFactory.DEBUG_TYPE, new CppdbgDebugAdapterDescriptorFactory(context)));
+
+    vscode.Disposable.from(...disposables);
+}
+
 export function initialize(context: vscode.ExtensionContext): void {
     // Activate Process Picker Commands
     const attachItemsProvider: AttachItemsProvider = NativeAttachItemsProviderFactory.Get();

--- a/Extension/src/packageManager.ts
+++ b/Extension/src/packageManager.ts
@@ -14,7 +14,7 @@ import * as yauzl from 'yauzl';
 import * as mkdirp from 'mkdirp';
 
 import * as util from './common';
-import { PlatformInformation } from './platform';
+import { PlatformInformation, IsAlpine } from './platform';
 import * as Telemetry from './telemetry';
 import { IncomingMessage, ClientRequest } from 'http';
 import { Logger } from './logger';
@@ -521,5 +521,10 @@ export function ArchitecturesMatch(value: IPackage, info: PlatformInformation): 
 }
 
 export function PlatformsMatch(value: IPackage, info: PlatformInformation): boolean {
+    if (IsAlpine()) {
+        // Alpine needs to be explicitly stated in packages list in order to be downloaded.
+        return value.platforms && value.platforms.indexOf("alpine-linux") !== -1;
+    }
+
     return !value.platforms || value.platforms.indexOf(info.platform) !== -1;
 }

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -9,6 +9,7 @@ import * as plist from 'plist';
 import * as fs from 'fs';
 import * as logger from './logger';
 import * as nls from 'vscode-nls';
+import * as util from './common';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -20,6 +21,16 @@ export function GetOSName(processPlatform: string | undefined): string | undefin
         case "linux": return "Linux";
         default: return undefined;
     }
+}
+
+let _isAlpine: boolean | undefined;
+
+export function IsAlpine(): boolean {
+    if (_isAlpine === undefined) {
+        _isAlpine = process.platform === 'linux' && util.checkFileExistsSync('/etc/alpine-release');
+    }
+
+    return _isAlpine;
 }
 
 export class PlatformInformation {


### PR DESCRIPTION
+ @gregg-miskelly 

This enables Debug Launch/Attach for Linux-x64 Alpine.

Addresses debugging scenario for #4827 

Added notes via `TODO(LS-alpine)` when Language Service has alpine support so we can have a full activation instead of a debugger only version.

Tested using `remote-container` with the following configurations:
<details>
<summary>Dockerfile</summary>

```
FROM mcr.microsoft.com/vscode/devcontainers/base:dev-alpine-3.14

RUN apk add --no-cache gdb file g++ clang coreutils
```
</details>

<details>
<summary>devcontainer.json</summary>

```
{
	"name": "Alpine",
	"build": {
		"dockerfile": "Dockerfile",
		// Update 'VARIANT' to pick an Alpine version: 3.11, 3.12, 3.13, 3.14
		"args": { "VARIANT": "3.14" }
	},
	
	// Set *default* container specific settings.json values on container create. 
	"settings": {},

	// Add the IDs of extensions you want installed when the container is created.
	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
	"extensions": [
		"ms-vscode.cpptools"
	],

	// Use 'forwardPorts' to make a list of ports inside the container available locally.
	// "forwardPorts": [],

	// Use 'postCreateCommand' to run commands after the container is created.
	// "postCreateCommand": "uname -a",

	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],

	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
	"remoteUser": "vscode"
}
```

</details>