### PR TITLE
Add to gcc compiler arg to display colors in gcc output, to generated build tasks.

### DIFF
--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -167,7 +167,7 @@ export class CppBuildTaskProvider implements TaskProvider {
                 CppBuildTaskProvider.CppBuildSourceStr + ": " : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
             const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
             const isWindows: boolean = os.platform() === 'win32';
-            let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', filePath + '.exe', '${file}'] : ['-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
+            let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', filePath + '.exe', '${file}'] : ['-fdiagnostics-color=always', '-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);
             }


### PR DESCRIPTION
Uses `-fdiagnostics-color=always`, which causes gcc colors to be used in VS Code's terminal.  The default is 'auto', but gcc is unable to detect that colorization is supported by the VS Code terminal.

Looking at code from gcc here: https://code.woboq.org/gcc/gcc/diagnostic-color.c.html
... It looks like colors are likely not determined to be supported in the VS Code terminal due to `GetConsoleMode()` failing on Windows, and `isatty()` failing on Linux/Mac.