### PR TITLE
Fix issue with inactive regions disappearing when switching files

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -608,7 +608,7 @@ export interface Client {
     onDidChangeSettings(event: vscode.ConfigurationChangeEvent, isFirstClient: boolean): { [key: string]: string };
     onDidOpenTextDocument(document: vscode.TextDocument): void;
     onDidCloseTextDocument(document: vscode.TextDocument): void;
-    onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void;
+    onDidChangeVisibleTextEditor(editor: vscode.TextEditor): void;
     onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void;
     onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void>;
     updateCustomConfigurations(requestingProvider?: CustomConfigurationProvider1): Thenable<void>;
@@ -1496,15 +1496,13 @@ export class DefaultClient implements Client {
         return changedSettings;
     }
 
-    public onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
+    public onDidChangeVisibleTextEditor(editor: vscode.TextEditor): void {
         const settings: CppSettings = new CppSettings(this.RootUri);
         if (settings.dimInactiveRegions) {
             // Apply text decorations to inactive regions
-            for (const e of editors) {
-                const valuePair: DecorationRangesPair | undefined = this.inactiveRegionsDecorations.get(e.document.uri.toString());
-                if (valuePair) {
-                    e.setDecorations(valuePair.decoration, valuePair.ranges); // VSCode clears the decorations when the text editor becomes invisible
-                }
+            const valuePair: DecorationRangesPair | undefined = this.inactiveRegionsDecorations.get(editor.document.uri.toString());
+            if (valuePair) {
+                editor.setDecorations(valuePair.decoration, valuePair.ranges); // VSCode clears the decorations when the text editor becomes invisible
             }
         }
     }
@@ -2997,7 +2995,7 @@ class NullClient implements Client {
     onDidChangeSettings(event: vscode.ConfigurationChangeEvent, isFirstClient: boolean): { [key: string]: string } { return {}; }
     onDidOpenTextDocument(document: vscode.TextDocument): void { }
     onDidCloseTextDocument(document: vscode.TextDocument): void { }
-    onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void { }
+    onDidChangeVisibleTextEditor(editor: vscode.TextEditor): void { }
     onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void { }
     onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void> { return Promise.resolve(); }
     updateCustomConfigurations(requestingProvider?: CustomConfigurationProvider1): Thenable<void> { return Promise.resolve(); }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -432,7 +432,7 @@ function onDidChangeTextEditorSelection(event: vscode.TextEditorSelectionChangeE
     clients.ActiveClient.selectionChanged(Range.create(event.selections[0].start, event.selections[0].end));
 }
 
-export function processDelayedDidOpen(document: vscode.TextDocument): void {
+export function processDelayedDidOpen(document: vscode.TextDocument): boolean {
     const client: Client = clients.getClientFor(document.uri);
     if (client) {
         // Log warm start.
@@ -466,16 +466,21 @@ export function processDelayedDidOpen(document: vscode.TextDocument): void {
                 if (!languageChanged) {
                     finishDidOpen(document);
                 }
+                return true;
             }
         }
     }
+    return false;
 }
 
 function onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
     // Process delayed didOpen for any visible editors we haven't seen before
     editors.forEach(editor => {
         if ((editor.document.uri.scheme === "file") && (editor.document.languageId === "c" || editor.document.languageId === "cpp" || editor.document.languageId === "cuda-cpp")) {
-            processDelayedDidOpen(editor.document);
+            if (!processDelayedDidOpen(editor.document)) {
+                const client: Client = clients.getClientFor(editor.document.uri);
+                client.onDidChangeVisibleTextEditor(editor);
+            }
         }
     });
 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8206

I'm not sure when this got disconnected, but `client.onDidChangeVisibleTextEditors` was no longer getting called.

Slightly refactored the code to avoid calling `client.onDidChangeVisibleTextEditors` if visibility triggered a deferred didOpen.