### PR TITLE
Deprecate WMIC in favor of `Get-CimInstance`

### DIFF
--- a/Extension/src/Debugger/nativeAttach.ts
+++ b/Extension/src/Debugger/nativeAttach.ts
@@ -290,8 +290,8 @@ export class CimProcessParser {
 
             CimProcessParser.parseLineFromCim(line, currentProcess);
 
-            // Each entry of processes has ProcessId as the last line
-            if (line.lastIndexOf(CimProcessParser.cimPidTitle, 0) === 0) {
+            // Each entry of processes has CommandLine as the last line
+            if (line.lastIndexOf(CimProcessParser.cimCommandLineTitle, 0) === 0) {
                 processEntries.push(currentProcess);
                 currentProcess = new Process("current process", undefined, undefined);
             }
@@ -310,9 +310,13 @@ export class CimProcessParser {
             } else if (key === CimProcessParser.cimPidTitle) {
                 process.pid = value;
             } else if (key === CimProcessParser.cimCommandLineTitle) {
-                const extendedLengthPath: string = '\\??\\';
-                if (value.lastIndexOf(extendedLengthPath, 0) === 0) {
-                    value = value.slice(extendedLengthPath.length);
+                const extendedLengthPathPrefix: string = '\\\\?\\';
+                if (value.lastIndexOf(extendedLengthPathPrefix, 0) === 0) {
+                    value = value.slice(extendedLengthPathPrefix.length);
+                }
+                const ntObjectManagerPathPrefix: string = '\\??\\';
+                if (value.lastIndexOf(ntObjectManagerPathPrefix, 0) === 0) {
+                    value = value.slice(ntObjectManagerPathPrefix.length);
                 }
 
                 process.commandLine = value;

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1327,6 +1327,9 @@ export function normalizeArg(arg: string): string {
     }
 }
 
+/**
+ * Find PowerShell executable from PATH (for Windows only).
+ */
 export function findPowerShell(): string | undefined {
     const dirs: string[] = (process.env.PATH || '').replace(/"+/g, '').split(';').filter(x => x);
     const exts: string[] = (process.env.PATHEXT || '').split(';');

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1327,3 +1327,21 @@ export function normalizeArg(arg: string): string {
     }
 }
 
+export function findPowerShell(): string | undefined {
+    const dirs: string[] = (process.env.PATH || '').replace(/"+/g, '').split(';').filter(x => x);
+    const exts: string[] = (process.env.PATHEXT || '').split(';');
+    const names: string[] = ['pwsh', 'powershell'];
+    for (const name of names) {
+        const candidates: string[] = dirs.reduce<string[]>((paths, dir) => [
+            ...paths, ...exts.map(ext => path.join(dir, name + ext))
+        ], []);
+        for (const candidate of candidates) {
+            try {
+                if (fs.statSync(candidate).isFile()) {
+                    return name;
+                }
+            } catch (e) {
+            }
+        }
+    }
+}

--- a/Extension/test/unitTests/extension.test.ts
+++ b/Extension/test/unitTests/extension.test.ts
@@ -128,21 +128,28 @@ suite("Pick Process Tests", () => {
 
     test('Parse valid CIM output', () => {
         // output from the command used in CimAttachItemsProvider
-        const cimOutput: string = 'Name        : System Idle Process' + os.EOL +
-                           'ProcessId   : 0' + os.EOL +
-                           'CommandLine :' + os.EOL +
-                           '' + os.EOL +
-                           'Name        : WindowsTerminal.exe' + os.EOL +
-                           'ProcessId   : 5112' + os.EOL +
-                           'CommandLine : "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminalPreview_1.12.2931.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe"' + os.EOL +
-                           '' + os.EOL +
-                           'Name        : conhost.exe' + os.EOL +
-                           'ProcessId   : 34560' + os.EOL +
-                           'CommandLine : \\\\?\\C:\\WINDOWS\\system32\\conhost.exe --headless --width 80 --height 30 --signal 0x8e0 --server 0x824' + os.EOL +
-                           '' + os.EOL +
-                           'Name        : conhost.exe' + os.EOL +
-                           'ProcessId   : 33732' + os.EOL +
-                           'CommandLine : \\??\\C:\\WINDOWS\\system32\\conhost.exe 0x4' + os.EOL;
+        const cimOutput: string = String.raw`[
+  {
+    "Name": "System Idle Process",
+    "ProcessId": 0,
+    "CommandLine": null
+  },
+  {
+    "Name": "WindowsTerminal.exe",
+    "ProcessId": 5112,
+    "CommandLine": "\"C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminalPreview_1.12.2931.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe\""
+  },
+  {
+    "Name": "conhost.exe",
+    "ProcessId": 34560,
+    "CommandLine": "\\\\?\\C:\\WINDOWS\\system32\\conhost.exe --headless --width 80 --height 30 --signal 0x8e0 --server 0x824"
+  },
+  {
+    "Name": "conhost.exe",
+    "ProcessId": 33732,
+    "CommandLine": "\\??\\C:\\WINDOWS\\system32\\conhost.exe 0x4"
+  }
+]`;
 
         const parsedOutput: Process[] = CimProcessParser.ParseProcessFromCim(cimOutput);
 
@@ -151,7 +158,7 @@ suite("Pick Process Tests", () => {
         const process3: Process = parsedOutput[2];
         const process4: Process = parsedOutput[3];
 
-        assert.equal(process1.commandLine, '');
+        assert.equal(process1.commandLine, undefined);
         assert.equal(process1.name, 'System Idle Process');
         assert.equal(process1.pid, '0');
 


### PR DESCRIPTION
Add `CimAttachItemsProvider` to retrieve processes with `Get-CimInstance Win32_Process` if powershell is found in `PATH`.

Fixes #8328.