### PR TITLE
Add OneLocBuild to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ browse*.db*
 # ignore exported localization xlf and LCL directories
 Build/loc/LCL
 vscode-extensions-localization-export
+OneLocBuild
 
 # ignore imported localization xlf directory
 vscode-translations-import


### PR DESCRIPTION
Fixes an issue causing our internal localization pipeline to fail.  It looks like some change was made resulting in this directory lingering in our repo after we run the OneLocBuild task.  It then caused a problem for our import script (which intentionally fails when it sees uncommitted changes).