### PR TITLE
Fix issue with deactivation when not real-activated

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1291,23 +1291,24 @@ function handleMacCrashFileRead(err: NodeJS.ErrnoException | undefined | null, d
 }
 
 export function deactivate(): Thenable<void> {
-    if (realActivationOccurred) {
-        clients.timeTelemetryCollector.clear();
-        console.log("deactivating extension");
-        telemetry.logLanguageServerEvent("LanguageServerShutdown");
-        clearInterval(intervalTimer);
-        clearInterval(insiderUpdateTimer);
-        disposables.forEach(d => d.dispose());
-        languageConfigurations.forEach(d => d.dispose());
-        ui.dispose();
-        if (taskProvider) {
-            taskProvider.dispose();
-        }
-        if (codeActionProvider) {
-            codeActionProvider.dispose();
-        }
-        return clients.dispose();
+    if (!realActivationOccurred) {
+        return Promise.resolve();
     }
+    clients.timeTelemetryCollector.clear();
+    console.log("deactivating extension");
+    telemetry.logLanguageServerEvent("LanguageServerShutdown");
+    clearInterval(intervalTimer);
+    clearInterval(insiderUpdateTimer);
+    disposables.forEach(d => d.dispose());
+    languageConfigurations.forEach(d => d.dispose());
+    ui.dispose();
+    if (taskProvider) {
+        taskProvider.dispose();
+    }
+    if (codeActionProvider) {
+        codeActionProvider.dispose();
+    }
+    return clients.dispose();
 }
 
 export function isFolderOpen(): boolean {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1291,21 +1291,23 @@ function handleMacCrashFileRead(err: NodeJS.ErrnoException | undefined | null, d
 }
 
 export function deactivate(): Thenable<void> {
-    clients.timeTelemetryCollector.clear();
-    console.log("deactivating extension");
-    telemetry.logLanguageServerEvent("LanguageServerShutdown");
-    clearInterval(intervalTimer);
-    clearInterval(insiderUpdateTimer);
-    disposables.forEach(d => d.dispose());
-    languageConfigurations.forEach(d => d.dispose());
-    ui.dispose();
-    if (taskProvider) {
-        taskProvider.dispose();
+    if (realActivationOccurred) {
+        clients.timeTelemetryCollector.clear();
+        console.log("deactivating extension");
+        telemetry.logLanguageServerEvent("LanguageServerShutdown");
+        clearInterval(intervalTimer);
+        clearInterval(insiderUpdateTimer);
+        disposables.forEach(d => d.dispose());
+        languageConfigurations.forEach(d => d.dispose());
+        ui.dispose();
+        if (taskProvider) {
+            taskProvider.dispose();
+        }
+        if (codeActionProvider) {
+            codeActionProvider.dispose();
+        }
+        return clients.dispose();
     }
-    if (codeActionProvider) {
-        codeActionProvider.dispose();
-    }
-    return clients.dispose();
 }
 
 export function isFolderOpen(): boolean {


### PR DESCRIPTION
Adds a check for real activation in `deactivate`.  This addresses: https://github.com/microsoft/vscode-cpptools/issues/8354

Since this occurred only on shutdown, I don't think there was any impact other than an error message in the `Log (Extension Host)` channel, that lingers on relaunch.