### PR TITLE
Update to latest XLoc package version for OneLocBuild

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -42,7 +42,6 @@ steps:
     patVariable: '$(OneLocBuildPat)'
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCPP'
-    lsBuildXLocPackageVersion: '7.0.30510'
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
We had been pinned to an older version, due to a bug that was corrupting our newlines.  That has since been fixed.  This change removes the pinned version requirement.