### PR TITLE
Revert XLoc tools to working version

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -42,6 +42,7 @@ steps:
     patVariable: '$(OneLocBuildPat)'
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCPP'
+    lsBuildXLocPackageVersion: '7.0.30510'
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
Our loc contact was mistaken about this issue having been addressed.  We still need to pin to a specific version of XLoc tools to avoid issues with unwanted LFs in our localized strings.