### PR TITLE
Add repository info to extension pack

### DIFF
--- a/ExtensionPack/package.json
+++ b/ExtensionPack/package.json
@@ -16,6 +16,11 @@
     "categories": [
         "Extension Packs"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/microsoft/vscode-cpptools.git",
+        "directory": "ExtensionPack"
+    },
     "keywords": [
         "C",
         "C++",


### PR DESCRIPTION
This allows users to get linked to the repository through the Visual Studio Code Marketplace or when locally viewing the extension.
