### PR TITLE
Don't block running a task if it doesn't use the active file

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -95,7 +95,10 @@ export async function getRawJson(path: string | undefined): Promise<any> {
     return rawElement;
 }
 
-export function fileIsCOrCppSource(file: string): boolean {
+export function fileIsCOrCppSource(file?: string): boolean {
+    if (file === undefined) {
+        return false;
+    }
     const fileExtLower: string = path.extname(file).toLowerCase();
     return [".cu", ".c", ".cpp", ".cc", ".cxx", ".c++", ".cp", ".tcc", ".mm", ".ino", ".ipp", ".inl"].some(ext => fileExtLower === ext);
 }


### PR DESCRIPTION
The cppbuild task provider blocked execution of the task if the active file in the editor was not a C/C++ file. This was built on an assumption that users would not remove the active file variable from the tasks we generate for them.

We should allow execution for modified tasks that remove the dependency on the active file for compilation.