### PR TITLE
Add cgmanifest for debugger components

### DIFF
--- a/Extension/cgmanifest.json
+++ b/Extension/cgmanifest.json
@@ -1,0 +1,24 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                    "RepositoryUrl": "https://github.com/llvm/llvm-project",
+                    "CommitHash": "0d44201451f03ba907cdb268ddddfc3fa38a0ebd"
+                },
+                "DevelopmentDependency": true
+            }
+        },
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                    "RepositoryUrl": "https://github.com/lldb-tools/lldb-mi",
+                    "CommitHash": "2388bd74133bc21eac59b2e2bf97f2a30770a315"
+                }
+            }
+        }
+    ],
+    "Version": 1
+}


### PR DESCRIPTION
This PR adds in a cgmanifest.json file to comply with Component
Governance Compliance.

This adds two registrations to llvm-project and lldb-mi as components as
they are packaged and published with the macOS version of the VS Code
C/C++ Extension.