### PR TITLE
Update minimum version of VS Code

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -11,7 +11,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.63.0"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-cpptools/issues",


### PR DESCRIPTION
Updating to minimum version of VS Code required to handle the --prerelease VSIX attribute.

Addresses error: `ERROR  Pre-release versions are supported by VS Code >=1.63. Current 'engines.vscode' is '^1.61.0'.`