### PR TITLE
Mitigate issue with migrating Insiders to Prerelease

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2749,7 +2749,7 @@ export class DefaultClient implements Client {
         this.model.codeAnalysisTotal.Value = total;
     }
 
-    private doneInitialCustomBrowseConfigurationCheck: Boolean = false;
+    private doneInitialCustomBrowseConfigurationCheck: boolean = false;
 
     private onConfigurationsChanged(cppProperties: configs.CppProperties): void {
         if (!cppProperties.Configurations) {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -62,7 +62,7 @@ class Settings {
         return result;
     }
 
-    protected getWithUndefinedDefault<T>(section: string): T | undefined {
+    public getWithUndefinedDefault<T>(section: string): T | undefined {
         const info: any = this.settings.inspect<T>(section);
         if (info.workspaceFolderValue !== undefined) {
             return info.workspaceFolderValue;

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -577,7 +577,7 @@ export function execChildProcess(process: string, workingDirectory?: string, cha
         child_process.exec(process, { cwd: workingDirectory, maxBuffer: 500 * 1024 }, (error: Error | null, stdout: string, stderr: string) => {
             if (channel) {
                 let message: string = "";
-                let err: Boolean = false;
+                let err: boolean = false;
                 if (stdout && stdout.length > 0) {
                     message += stdout;
                 }
@@ -935,8 +935,8 @@ export function escapeForSquiggles(s: string): string {
     // Replace all \<escape character> with \\<character>, except for \"
     // Otherwise, the JSON.parse result will have the \<escape character> missing.
     let newResults: string = "";
-    let lastWasBackslash: Boolean = false;
-    let lastBackslashWasEscaped: Boolean = false;
+    let lastWasBackslash: boolean = false;
+    let lastBackslashWasEscaped: boolean = false;
     for (let i: number = 0; i < s.length; i++) {
         if (s[i] === '\\') {
             if (lastWasBackslash) {
@@ -1258,7 +1258,7 @@ export function getCppToolsTargetPopulation(): TargetPopulation {
     return TargetPopulation.Internal;
 }
 
-export function isVsCodeInsiders(): Boolean {
+export function isVsCodeInsiders(): boolean {
     return extensionPath.includes(".vscode-insiders") ||
         extensionPath.includes(".vscode-server-insiders") ||
         extensionPath.includes(".vscode-exploration") ||

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -160,4 +160,20 @@ export function UpdateInsidersAccess(): void {
             migratedInsiders.Value = false;
         }
     }
+
+    // Mitigate an issue with VS Code not recognizing a programmatically installed VSIX as Prerelease.
+    // If using VS Code Insiders, and updateChannel is not explicitly set, default to Prerelease.
+    // Only do this once. If the user manually switches to Release, we don't want to switch them back to Prerelease again.
+    if (util.isVsCodeInsiders()) {
+        const insidersMitigationDone: PersistentState<boolean> = new PersistentState<boolean>("CPP.insidersMitigationDone", false);
+        if (!insidersMitigationDone.Value) {
+            if (vscode.workspace.getConfiguration("extensions", null).get<boolean>("autoUpdate")) {
+                const settings: CppSettings = new CppSettings();
+                if (settings.getWithUndefinedDefault<string>("updateChannel") === undefined) {
+                    vscode.commands.executeCommand("workbench.extensions.installExtension", "ms-vscode.cpptools", { installPreReleaseVersion: true });
+                }
+            }
+            insidersMitigationDone.Value = true;
+        }
+    }
 }

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -145,7 +145,7 @@ function sendTelemetry(info: PlatformInformation): void {
 }
 
 export function UpdateInsidersAccess(): void {
-    let installPrerelease: Boolean = false;
+    let installPrerelease: boolean = false;
 
     // Only move them to the new prerelease mechanism if using updateChannel of Insiders.
     const settings: CppSettings = new CppSettings();

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -166,7 +166,7 @@ export function UpdateInsidersAccess(): void {
     // Mitigate an issue with VS Code not recognizing a programmatically installed VSIX as Prerelease.
     // If using VS Code Insiders, and updateChannel is not explicitly set, default to Prerelease.
     // Only do this once. If the user manually switches to Release, we don't want to switch them back to Prerelease again.
-    if (!installPrerelease && util.isVsCodeInsiders()) {
+    if (util.isVsCodeInsiders()) {
         const insidersMitigationDone: PersistentState<boolean> = new PersistentState<boolean>("CPP.insidersMitigationDone", false);
         if (!insidersMitigationDone.Value) {
             if (vscode.workspace.getConfiguration("extensions", null).get<boolean>("autoUpdate")) {


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8704
This works around https://github.com/microsoft/vscode/issues/140949

When existing VS Code Insiders users were updated to 1.8.0 (insiders3) via the `updateChannel` mechanism, the VSIX programmatically downloaded from GitHub was not correctly identified as a Prerelease.  Presumably, this means those users were not subscribed to receive further Prerelease versions.

This mitigation should take effect once those users receive a release version from the marketplace.  If running VS Code Insiders and `updateChannel` had not been modified, they will be subscribed to Prereleases.  This only occurs once, to avoid repeatedly moving the user to Prerelease in case they had manually switched to Release.