### PR TITLE
Rework how cancelation is processed for semantic tokens and folding operations

### DIFF
--- a/Extension/src/LanguageServer/Providers/documentFormattingEditProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentFormattingEditProvider.ts
@@ -36,6 +36,10 @@ export class DocumentFormattingEditProvider implements vscode.DocumentFormatting
                     }
                 }
             };
+            // We do not currently pass the CancellationToken to sendRequest
+            // because there is not currently cancellation logic for formatting
+            // in the native process. Formatting is currently done directly in
+            // message handling thread.
             const textEdits: any = await this.client.languageClient.sendRequest(FormatDocumentRequest, params);
             const results: vscode.TextEdit[] = [];
             textEdits.forEach((textEdit: any) => {

--- a/Extension/src/LanguageServer/Providers/documentRangeFormattingEditProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentRangeFormattingEditProvider.ts
@@ -36,6 +36,10 @@ export class DocumentRangeFormattingEditProvider implements vscode.DocumentRange
                     }
                 }
             };
+            // We do not currently pass the CancellationToken to sendRequest
+            // because there is not currently cancellation logic for formatting
+            // in the native process. Formatting is currently done directly in
+            // message handling thread.
             const textEdits: any = await this.client.languageClient.sendRequest(FormatRangeRequest, params);
             const result: vscode.TextEdit[] = [];
             textEdits.forEach((textEdit: any) => {

--- a/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
@@ -56,7 +56,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         }
         return documentSymbols;
     }
-    public async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
+    public async provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
         if (!this.client.TrackedDocuments.has(document)) {
             processDelayedDidOpen(document);
         }
@@ -64,7 +64,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             const params: GetDocumentSymbolRequestParams = {
                 uri: document.uri.toString()
             };
-            const symbols: LocalizeDocumentSymbol[] = await this.client.languageClient.sendRequest(GetDocumentSymbolRequest, params);
+            const symbols: LocalizeDocumentSymbol[] = await this.client.languageClient.sendRequest(GetDocumentSymbolRequest, params, token);
             const resultSymbols: vscode.DocumentSymbol[] = this.getChildrenSymbols(symbols);
             return resultSymbols;
         });

--- a/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
+++ b/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
@@ -15,14 +15,11 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
     }
     async provideFoldingRanges(document: vscode.TextDocument, context: vscode.FoldingContext,
         token: vscode.CancellationToken): Promise<vscode.FoldingRange[] | undefined> {
-        const id: number = ++DefaultClient.abortRequestId;
         const params: GetFoldingRangesParams = {
-            id: id,
             uri: document.uri.toString()
         };
         await this.client.awaitUntilLanguageClientReady();
-        token.onCancellationRequested(e => this.client.abortRequest(id));
-        const ranges: GetFoldingRangesResult = await this.client.languageClient.sendRequest(GetFoldingRangesRequest, params);
+        const ranges: GetFoldingRangesResult = await this.client.languageClient.sendRequest(GetFoldingRangesRequest, params, token);
         if (ranges.canceled) {
             return undefined;
         }

--- a/Extension/src/LanguageServer/Providers/onTypeFormattingEditProvider.ts
+++ b/Extension/src/LanguageServer/Providers/onTypeFormattingEditProvider.ts
@@ -36,6 +36,10 @@ export class OnTypeFormattingEditProvider implements vscode.OnTypeFormattingEdit
                     }
                 }
             };
+            // We do not currently pass the CancellationToken to sendRequest
+            // because there is not currently cancellation logic for formatting
+            // in the native process. Formatting is currently done directly in
+            // message handling thread.
             const textEdits: any[] = await this.client.languageClient.sendRequest(FormatOnTypeRequest, params);
             const result: vscode.TextEdit[] = [];
             textEdits.forEach((textEdit) => {

--- a/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
+++ b/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
@@ -19,18 +19,15 @@ export class SemanticTokensProvider implements vscode.DocumentSemanticTokensProv
     public async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
         await this.client.awaitUntilLanguageClientReady();
         const uriString: string = document.uri.toString();
-        // First check the token cache to see if we already have results for that file and version
+        // First check the semantic token cache to see if we already have results for that file and version
         const cache: [number, vscode.SemanticTokens] | undefined = this.tokenCaches.get(uriString);
         if (cache && cache[0] === document.version) {
             return cache[1];
         } else {
-            token.onCancellationRequested(_e => this.client.abortRequest(id));
-            const id: number = ++DefaultClient.abortRequestId;
             const params: GetSemanticTokensParams = {
-                id: id,
                 uri: uriString
             };
-            const tokensResult: GetSemanticTokensResult = await this.client.languageClient.sendRequest(GetSemanticTokensRequest, params);
+            const tokensResult: GetSemanticTokensResult = await this.client.languageClient.sendRequest(GetSemanticTokensRequest, params, token);
             if (tokensResult.canceled) {
                 throw new vscode.CancellationError();
             } else {
@@ -38,8 +35,8 @@ export class SemanticTokensProvider implements vscode.DocumentSemanticTokensProv
                     throw new vscode.CancellationError();
                 } else {
                     const builder: vscode.SemanticTokensBuilder = new vscode.SemanticTokensBuilder(this.client.semanticTokensLegend);
-                    tokensResult.tokens.forEach((token) => {
-                        builder.push(token.line, token.character, token.length, token.type, token.modifiers);
+                    tokensResult.tokens.forEach((semanticToken) => {
+                        builder.push(semanticToken.line, semanticToken.character, semanticToken.length, semanticToken.type, semanticToken.modifiers);
                     });
                     const tokens: vscode.SemanticTokens = builder.build();
                     this.tokenCaches.set(uriString, [tokensResult.fileVersion, tokens]);

--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -17,7 +17,7 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
             query: query
         };
 
-        const symbols: LocalizeSymbolInformation[] = await this.client.languageClient.sendRequest(GetSymbolInfoRequest, params);
+        const symbols: LocalizeSymbolInformation[] = await this.client.languageClient.sendRequest(GetSymbolInfoRequest, params, token);
         const resultSymbols: vscode.SymbolInformation[] = [];
 
         // Convert to vscode.Command array

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -416,7 +416,6 @@ interface TextEdit {
 
 export interface GetFoldingRangesParams {
     uri: string;
-    id: number;
 }
 
 export enum FoldingRangeKind {
@@ -436,13 +435,8 @@ export interface GetFoldingRangesResult {
     ranges: CppFoldingRange[];
 }
 
-interface AbortRequestParams {
-    id: number;
-}
-
 export interface GetSemanticTokensParams {
     uri: string;
-    id: number;
 }
 
 interface SemanticToken {
@@ -572,7 +566,6 @@ const FinishedRequestCustomConfig: NotificationType<string, void> = new Notifica
 const FindAllReferencesNotification: NotificationType<FindAllReferencesParams, void> = new NotificationType<FindAllReferencesParams, void>('cpptools/findAllReferences');
 const RenameNotification: NotificationType<RenameParams, void> = new NotificationType<RenameParams, void>('cpptools/rename');
 const DidChangeSettingsNotification: NotificationType<DidChangeConfigurationParams, void> = new NotificationType<DidChangeConfigurationParams, void>('cpptools/didChangeSettings');
-const AbortRequestNotification: NotificationType<AbortRequestParams, void> = new NotificationType<AbortRequestParams, void>('cpptools/abortRequest');
 const CodeAnalysisNotification: NotificationType<CodeAnalysisScope, void> = new NotificationType<CodeAnalysisScope, void>('cpptools/runCodeAnalysis');
 
 // Notifications from the server
@@ -791,8 +784,6 @@ export class DefaultClient implements Client {
     ];
     public semanticTokensLegend: vscode.SemanticTokensLegend | undefined;
 
-    public static abortRequestId: number = 0;
-
     public static referencesParams: RenameParams | FindAllReferencesParams | undefined;
     public static referencesRequestPending: boolean = false;
     public static referencesPendingCancellations: ReferencesCancellationState[] = [];
@@ -954,7 +945,7 @@ export class DefaultClient implements Client {
                                     uri: document.uri.toString()
                                 };
 
-                                const commands: CodeActionCommand[] = await this.client.languageClient.sendRequest(GetCodeActionsRequest, params);
+                                const commands: CodeActionCommand[] = await this.client.languageClient.sendRequest(GetCodeActionsRequest, params, token);
                                 const resultCodeActions: vscode.CodeAction[] = [];
 
                                 // Convert to vscode.CodeAction array
@@ -3231,13 +3222,6 @@ export class DefaultClient implements Client {
 
     public setReferencesCommandMode(mode: refs.ReferencesCommandMode): void {
         this.model.referencesCommandMode.Value = mode;
-    }
-
-    public abortRequest(id: number): void {
-        const params: AbortRequestParams = {
-            id: id
-        };
-        languageClient.sendNotification(AbortRequestNotification, params);
     }
 }
 


### PR DESCRIPTION
When implementing support for semantic tokens and code folding, I had failed to leverage the existing mechanism for cancelling those requests (which is possible when a cancellation token is passed to calls to `sendRequest`).  We can also leverage this for other operations that involve `sendRequest`.  When invoked as part of a provider, the cancellation token passed to the provider can be passed through.

There is a corresponding PR for changes to the native process.
