### PR TITLE
Suppress incorrect warnings on Mac M1

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -107,13 +107,18 @@ async function makeBinariesExecutable(): Promise<void> {
         commonBinaries.forEach(binary => promises.push(util.allowExecution(util.getExtensionFilePath(binary))));
         if (process.platform === "darwin") {
             const macBinaries: string[] = [
-                "./debugAdapters/lldb-mi/bin/lldb-mi",
-                "./debugAdapters/lldb/bin/debugserver",
-                "./debugAdapters/lldb/bin/lldb-mi",
-                "./debugAdapters/lldb/bin/lldb-argdumper",
-                "./debugAdapters/lldb/bin/lldb-launcher"
+                "./debugAdapters/lldb-mi/bin/lldb-mi"
             ];
             macBinaries.forEach(binary => promises.push(util.allowExecution(util.getExtensionFilePath(binary))));
+            if (os.arch() === "x64") {
+                const oldMacBinaries: string[] = [
+                    "./debugAdapters/lldb/bin/debugserver",
+                    "./debugAdapters/lldb/bin/lldb-mi",
+                    "./debugAdapters/lldb/bin/lldb-argdumper",
+                    "./debugAdapters/lldb/bin/lldb-launcher"
+                ];
+                oldMacBinaries.forEach(binary => promises.push(util.allowExecution(util.getExtensionFilePath(binary))));
+            }
         }
     }
     await Promise.all(promises);

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -49,7 +49,6 @@ export class PlatformInformation {
     public static GetArchitecture(): string {
         const arch: string = os.arch();
         switch (arch) {
-            case "x64":
             case "arm64":
             case "arm":
                 return arch;
@@ -57,11 +56,7 @@ export class PlatformInformation {
             case "ia32":
                 return "x86";
             default:
-                if (os.platform() === "win32") {
-                    return "x86";
-                } else {
-                    return "x64";
-                }
+                return "x64";
         }
     }
 


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8756

Also fixes an issue in which x64 win32 was always being identified as x86 in telemetry.