### PR TITLE
Add loc for 3 strings

### DIFF
--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -235,5 +235,8 @@
     },
     "unable_to_access_browse_database": "Unable to access browse database. ({0})",
     "default_compiler_path_modified_explicit_intellisense_mode": "IntelliSenseMode was changed because it didn't match the detected compiler.  Consider setting \"compilerPath\" instead.  Set \"compilerPath\" to \"\" to disable detection of system includes and defines.",
-    "clear_code_analysis_squiggles": "Clear code analysis squiggles"
+    "clear_code_analysis_squiggles": "Clear code analysis squiggles",
+    "multiple_locations_note": "(Multiple locations)",
+    "folder_tag": "Folder",
+    "file_tag": "File"
 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/6873

There is a PR on the native side as well.

Previously, we only localized strings on the TypeScript side (as the result of an ID sent from the native side), and didn't have a way to localize these strings.  We've changed how loc works to send all native strings to the native process when initialized.  So, we now have a way to localize these.