### PR TITLE
Fix issue with recovery from cpptools crash when using multiroot

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -689,6 +689,7 @@ export interface Client {
     RootPath: string;
     RootRealPath: string;
     RootUri?: vscode.Uri;
+    RootFolder?: vscode.WorkspaceFolder;
     Name: string;
     TrackedDocuments: Set<vscode.TextDocument>;
     onDidChangeSettings(event: vscode.ConfigurationChangeEvent, isFirstClient: boolean): { [key: string]: string };

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1483,15 +1483,15 @@ export class DefaultClient implements Client {
                     languageClientCrashedNeedsRestart = true;
                     telemetry.logLanguageServerEvent("languageClientCrash");
                     if (languageClientCrashTimes.length < 5) {
-                        allClients.forEach(client => { allClients.replace(client, true); });
+                        allClients.recreateClients(true);
                     } else {
                         const elapsed: number = languageClientCrashTimes[languageClientCrashTimes.length - 1] - languageClientCrashTimes[0];
                         if (elapsed <= 3 * 60 * 1000) {
                             vscode.window.showErrorMessage(localize('server.crashed2', "The language server crashed 5 times in the last 3 minutes. It will not be restarted."));
-                            allClients.forEach(client => { allClients.replace(client, false); });
+                            allClients.recreateClients(false);
                         } else {
                             languageClientCrashTimes.shift();
-                            allClients.forEach(client => { allClients.replace(client, true); });
+                            allClients.recreateClients(true);
                         }
                     }
                     return CloseAction.DoNotRestart;

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -193,6 +193,10 @@ export class ClientCollection {
                 }
             });
 
+            // Note: VS Code currently reloads the extension whenever the primary (first) workspace folder is added or removed.
+            // So the following handling of changes to defaultClient are likely unnecessary, unless the behavior of
+            // VS Code changes. The handling of changes to activeClient are still needed.
+
             if (oldDefaultClient) {
                 const uri: vscode.Uri | undefined = oldDefaultClient.RootUri;
                 // uri will be set.

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -115,14 +115,13 @@ export class ClientCollection {
 
             let newClient: cpptools.Client;
             if (transferFileOwnership) {
-                newClient = this.createClient(client.RootFolder);
+                newClient = this.createClient(client.RootFolder, true);
                 client.TrackedDocuments.forEach(document => this.transferOwnership(document, client));
             } else {
                 newClient = cpptools.createNullClient();
             }
 
             if (this.activeClient === client) {
-                this.activeClient.deactivate();
                 // It cannot be undefined. If there is an active document, we activate it later.
                 this.activeClient = newClient;
             }
@@ -228,6 +227,7 @@ export class ClientCollection {
                     // The user removed the last workspace folder. Create a new default defaultClient/activeClient
                     // using the same approach as used in the constructor.
                     this.defaultClient = cpptools.createClient(this);
+                    this.activeClient.deactivate();
                     this.languageClients.set(defaultClientKey, this.defaultClient);
                     this.activeClient = this.defaultClient;
                 }

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -203,6 +203,9 @@ export class ClientCollection {
                 if (uri) {
                     this.defaultClient = this.getClientFor(uri);
                     needNewDefaultClient = this.defaultClient === oldDefaultClient;
+                    if (needNewDefaultClient) {
+                        needNewActiveClient = this.activeClient === oldDefaultClient;
+                    }
                 }
                 oldDefaultClient.dispose();
             } else {

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -163,13 +163,7 @@ export class ClientCollection {
                     client.TrackedDocuments.forEach(document => this.transferOwnership(document, client));
 
                     if (this.activeClient === client) {
-                        if (this.activeDocument) {
-                            // Need to make a different client the active client.
-                            this.activeClient = this.getClientFor(this.activeDocument.uri);
-                            this.activeClient.activeDocumentChanged(this.activeDocument);
-                        } else {
-                            needNewActiveClient = true;
-                        }
+                        needNewActiveClient = true;
                     }
 
                     // Defer selecting a new default client until all adds and removes have been processed.
@@ -192,6 +186,12 @@ export class ClientCollection {
                     defaultClient.sendAllSettings();
                 }
             });
+
+            if (needNewActiveClient && this.activeDocument) {
+                this.activeClient = this.getClientFor(this.activeDocument.uri);
+                this.activeClient.activeDocumentChanged(this.activeDocument);
+                needNewActiveClient = false;
+            }
 
             // Note: VS Code currently reloads the extension whenever the primary (first) workspace folder is added or removed.
             // So the following handling of changes to defaultClient are likely unnecessary, unless the behavior of


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8762

When recovering from the cpptools process crashing (which should hopefully be rare), the process of recreating client objects per workspace would skip clients that were not tracking any associated files.

In `ClientCollection.replace()`, the client objects had been getting opportunistically created in `getClientFor`, but no call was incurred if not the active client and no files were tracked.  This fix makes client creation somewhat more explicit, with a call to `getClientForFolder`.  (I moved client creation into this subroutine to keep that consolidated.)

Also fixed an issue with `defaultClient` not being reset causing the original (broken) client instance to linger and be used for files not associated with a workspace.