### PR TITLE
Build and debug as x86_64 on Apple Silicon (macOS ARM64) by default

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -195,7 +195,7 @@ export class CppConfigurationProvider implements vscode.DebugConfigurationProvid
                 newConfig.console = "externalTerminal";
             }
             const isWindows: boolean = platform === 'win32';
-            const isMacARM64: boolean = (platform === 'macOS' && architecture === 'arm64');
+            const isMacARM64: boolean = (platform === 'darwin' && architecture === 'arm64');
             const exeName: string = path.join("${fileDirname}", "${fileBasenameNoExtension}");
             newConfig.program = isWindows ? exeName + ".exe" : exeName;
             // Add the "detail" property to show the compiler path in QuickPickItem.

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -137,6 +137,7 @@ export class CppConfigurationProvider implements vscode.DebugConfigurationProvid
 
         const platformInfo: PlatformInformation = await PlatformInformation.GetPlatformInformation();
         const platform: string = platformInfo.platform;
+        const architecture: string = platformInfo.architecture;
 
         // Import the existing configured tasks from tasks.json file.
         const configuredBuildTasks: CppBuildTask[] = await cppBuildTaskProvider.getJsonTasks();
@@ -193,13 +194,19 @@ export class CppConfigurationProvider implements vscode.DebugConfigurationProvid
             } else {
                 newConfig.console = "externalTerminal";
             }
-            const exeName: string = path.join("${fileDirname}", "${fileBasenameNoExtension}");
             const isWindows: boolean = platform === 'win32';
+            const isMacARM64: boolean = (platform === 'macOS' && architecture === 'arm64');
+            const exeName: string = path.join("${fileDirname}", "${fileBasenameNoExtension}");
             newConfig.program = isWindows ? exeName + ".exe" : exeName;
             // Add the "detail" property to show the compiler path in QuickPickItem.
             // This property will be removed before writing the DebugConfiguration in launch.json.
             newConfig.detail = localize("pre.Launch.Task", "preLaunchTask: {0}", task.name);
             newConfig.existing = task.existing ? TaskConfigStatus.configured : TaskConfigStatus.detected;
+            if (isMacARM64) {
+                // Workaround to build and debug x86_64 on macARM64 by default.
+                // Remove this workaround when native debugging for macARM64 is supported.
+                newConfig.targetArchtecture = "x86_64";
+            }
             if (task.isDefault) {
                 newConfig.isDefault = true;
             }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -166,7 +166,7 @@ export class CppBuildTaskProvider implements TaskProvider {
             const isMacARM64: boolean = (os.platform() === 'darwin' && os.arch() === 'arm64');
             const taskLabel: string = ((appendSourceToName && !compilerPathBase.startsWith(ext.CppSourceStr)) ?
                 ext.CppSourceStr + ": " : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
-            const filePath = path.join('${fileDirname}', '${fileBasenameNoExtension}');
+            const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
             const programName: string = isWindows ? filePath + '.exe' : filePath;
             let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', programName, '${file}'] : ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
             if (isMacARM64) {

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -163,7 +163,7 @@ export class CppBuildTaskProvider implements TaskProvider {
 
         if (!definition) {
             const isWindows: boolean = os.platform() === 'win32';
-            const isMacARM64: boolean = (os.platform() === 'macOS' && os.architecture() === 'arm64');
+            const isMacARM64: boolean = (os.platform() === 'darwin' && os.arch() === 'arm64');
             const taskLabel: string = ((appendSourceToName && !compilerPathBase.startsWith(ext.CppSourceStr)) ?
                 ext.CppSourceStr + ": " : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
             const filePath = path.join('${fileDirname}', '${fileBasenameNoExtension}');

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -162,11 +162,18 @@ export class CppBuildTaskProvider implements TaskProvider {
         }
 
         if (!definition) {
+            const isWindows: boolean = os.platform() === 'win32';
+            const isMacARM64: boolean = (os.platform() === 'macOS' && os.architecture() === 'arm64');
             const taskLabel: string = ((appendSourceToName && !compilerPathBase.startsWith(ext.CppSourceStr)) ?
                 ext.CppSourceStr + ": " : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
-            const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
-            const isWindows: boolean = os.platform() === 'win32';
-            let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', filePath + '.exe', '${file}'] : ['-fdiagnostics-color=always', '-g', '${file}', '-o', filePath + (isWindows ? '.exe' : '')];
+            const filePath = path.join('${fileDirname}', '${fileBasenameNoExtension}');
+            const programName: string = isWindows ? filePath + '.exe' : filePath;
+            let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', programName, '${file}'] : ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
+            if (isMacARM64) {
+                // Workaround to build and debug x86_64 on macARM64 by default.
+                // Remove this workaround when native debugging for macARM64 is supported.
+                args.push('--target=x86_64-apple-darwin-gnu');
+            }
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);
             }


### PR DESCRIPTION
This is a workaround (https://github.com/microsoft/vscode-cpptools/issues/8755) until https://github.com/microsoft/vscode-cpptools/issues/7035 is resolved.