### PR TITLE
Fix issue with invoking commands before cpptools is activated

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -33,7 +33,7 @@ import { createProtocolFilter } from './protocolFilter';
 import { DataBinding } from './dataBinding';
 import minimatch = require("minimatch");
 import * as logger from '../logger';
-import { updateLanguageConfigurations, registerCommands, CppSourceStr } from './extension';
+import { updateLanguageConfigurations, CppSourceStr } from './extension';
 import { SettingsTracker, getTracker } from './settingsTracker';
 import { getTestHook, TestHook } from '../testHook';
 import { getCustomConfigProviders, CustomConfigurationProvider1, isSameProviderExtensionId } from '../LanguageServer/customProviders';
@@ -1004,10 +1004,8 @@ export class DefaultClient implements Client {
                         compilerDefaults = inputCompilerDefaults;
                         this.configuration.CompilerDefaults = compilerDefaults;
 
-                        // Only register file watchers, providers, and the real commands after the extension has finished initializing,
+                        // Only register file watchers and providers after the extension has finished initializing,
                         // e.g. prevents empty c_cpp_properties.json from generation.
-                        registerCommands();
-
                         this.registerFileWatcher();
 
                         this.disposables.push(vscode.languages.registerRenameProvider(this.documentSelector, new RenameProvider(this)));
@@ -3068,6 +3066,7 @@ export class DefaultClient implements Client {
                 next: next
             };
 
+            await this.awaitUntilLanguageClientReady();
             const response: Position | undefined = await this.languageClient.sendRequest(GoToDirectiveInGroupRequest, params);
             if (response) {
                 const p: vscode.Position = new vscode.Position(response.line, response.character);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -276,6 +276,8 @@ export async function activate(): Promise<void> {
     clients.ActiveClient.notifyWhenLanguageClientReady(() => {
         intervalTimer = global.setInterval(onInterval, 2500);
     });
+
+    registerCommands();
 }
 
 export function updateLanguageConfigurations(): void {
@@ -401,14 +403,7 @@ function onInterval(): void {
 /**
  * registered commands
  */
-let commandsRegistered: boolean = false;
-
 export function registerCommands(): void {
-    if (commandsRegistered) {
-        return;
-    }
-
-    commandsRegistered = true;
     disposables.push(vscode.commands.registerCommand('C_Cpp.SwitchHeaderSource', onSwitchHeaderSource));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ResetDatabase', onResetDatabase));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ConfigurationSelect', onSelectConfiguration));

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -76,7 +76,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
             }
         }));
     }
-    LanguageServer.activate();
+    await LanguageServer.activate();
 
     UpdateInsidersAccess();
 


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8785

Adding a missing `await` that was causing us to return from `activate()` before we were fully activated.
Moved registration of commands to within `activate()`.
Added an `await` to one command that was not already waiting for the client to be ready.