### PR TITLE
Fix issue with cpptools restarting when it should not

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -746,6 +746,7 @@ export interface Client {
     onInterval(): void;
     dispose(): void;
     addFileAssociations(fileAssociations: string, languageId: string): void;
+    sendAllSettings(): void;
     sendDidChangeSettings(settings: any): void;
 }
 
@@ -3319,5 +3320,6 @@ class NullClient implements Client {
         this.stringEvent.dispose();
     }
     addFileAssociations(fileAssociations: string, languageId: string): void { }
+    sendAllSettings(): void { }
     sendDidChangeSettings(settings: any): void { }
 }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1481,15 +1481,15 @@ export class DefaultClient implements Client {
                     languageClientCrashedNeedsRestart = true;
                     telemetry.logLanguageServerEvent("languageClientCrash");
                     if (languageClientCrashTimes.length < 5) {
-                        allClients.recreateClients(true);
+                        allClients.recreateClients();
                     } else {
                         const elapsed: number = languageClientCrashTimes[languageClientCrashTimes.length - 1] - languageClientCrashTimes[0];
                         if (elapsed <= 3 * 60 * 1000) {
                             vscode.window.showErrorMessage(localize('server.crashed2', "The language server crashed 5 times in the last 3 minutes. It will not be restarted."));
-                            allClients.recreateClients(false);
+                            allClients.recreateClients(true);
                         } else {
                             languageClientCrashTimes.shift();
-                            allClients.recreateClients(true);
+                            allClients.recreateClients();
                         }
                     }
                     return CloseAction.DoNotRestart;

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -25,7 +25,7 @@ export class ClientCollection {
     private activeDocument?: vscode.TextDocument;
     public timeTelemetryCollector: TimeTelemetryCollector = new TimeTelemetryCollector();
 
-    // This is a one-time switch to a mode that suppressed launching of the cpptools client process.
+    // This is a one-time switch to a mode that suppresses launching of the cpptools client process.
     private useFailsafeMode: boolean = false;
 
     public get ActiveClient(): cpptools.Client { return this.activeClient; }
@@ -274,17 +274,14 @@ export class ClientCollection {
     }
 
     public createClient(folder?: vscode.WorkspaceFolder, deactivated?: boolean): cpptools.Client {
-        const newClient: cpptools.Client = this.useFailsafeMode ? cpptools.createNullClient() :  cpptools.createClient(this, folder);
+        const newClient: cpptools.Client = this.useFailsafeMode ? cpptools.createNullClient() : cpptools.createClient(this, folder);
         if (deactivated) {
             newClient.deactivate(); // e.g. prevent the current config from switching.
         }
         const key: string = folder ? util.asFolder(folder.uri) : defaultClientKey;
         this.languageClients.set(key, newClient);
-        if (!this.useFailsafeMode) {
-            getCustomConfigProviders().forEach(provider => newClient.onRegisterCustomConfigurationProvider(provider));
-            const defaultClient: cpptools.DefaultClient = <cpptools.DefaultClient>newClient;
-            defaultClient.sendAllSettings();
-        }
+        getCustomConfigProviders().forEach(provider => newClient.onRegisterCustomConfigurationProvider(provider));
+        newClient.sendAllSettings();
         return newClient;
     }
 

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -25,6 +25,9 @@ export class ClientCollection {
     private activeDocument?: vscode.TextDocument;
     public timeTelemetryCollector: TimeTelemetryCollector = new TimeTelemetryCollector();
 
+    // This is a one-time switch to a mode that suppressed launching of the cpptools client process.
+    private useFailsafeMode: boolean = false;
+
     public get ActiveClient(): cpptools.Client { return this.activeClient; }
     public get Names(): ClientKey[] {
         const result: ClientKey[] = [];
@@ -104,22 +107,21 @@ export class ClientCollection {
     /**
      * creates a new client to replace one that crashed.
      */
-    public async recreateClients(transferFileOwnership: boolean): Promise<void> {
+    public async recreateClients(switchToFailsafeMode?: boolean): Promise<void> {
 
         // Swap out the map, so we are not changing it while iterating over it.
         const oldLanguageClients: Map<string, cpptools.Client> = this.languageClients;
         this.languageClients = new Map<string, cpptools.Client>();
 
+        if (switchToFailsafeMode) {
+            this.useFailsafeMode = true;
+        }
+
         for (const pair of oldLanguageClients) {
             const client: cpptools.Client = pair[1];
 
-            let newClient: cpptools.Client;
-            if (transferFileOwnership) {
-                newClient = this.createClient(client.RootFolder, true);
-                client.TrackedDocuments.forEach(document => this.transferOwnership(document, client));
-            } else {
-                newClient = cpptools.createNullClient();
-            }
+            const newClient: cpptools.Client = this.createClient(client.RootFolder, true);
+            client.TrackedDocuments.forEach(document => this.transferOwnership(document, client));
 
             if (this.activeClient === client) {
                 // It cannot be undefined. If there is an active document, we activate it later.
@@ -272,15 +274,17 @@ export class ClientCollection {
     }
 
     public createClient(folder?: vscode.WorkspaceFolder, deactivated?: boolean): cpptools.Client {
-        const newClient: cpptools.Client = cpptools.createClient(this, folder);
+        const newClient: cpptools.Client = this.useFailsafeMode ? cpptools.createNullClient() :  cpptools.createClient(this, folder);
         if (deactivated) {
             newClient.deactivate(); // e.g. prevent the current config from switching.
         }
         const key: string = folder ? util.asFolder(folder.uri) : defaultClientKey;
         this.languageClients.set(key, newClient);
-        getCustomConfigProviders().forEach(provider => newClient.onRegisterCustomConfigurationProvider(provider));
-        const defaultClient: cpptools.DefaultClient = <cpptools.DefaultClient>newClient;
-        defaultClient.sendAllSettings();
+        if (!this.useFailsafeMode) {
+            getCustomConfigProviders().forEach(provider => newClient.onRegisterCustomConfigurationProvider(provider));
+            const defaultClient: cpptools.DefaultClient = <cpptools.DefaultClient>newClient;
+            defaultClient.sendAllSettings();
+        }
         return newClient;
     }
 


### PR DESCRIPTION
This is a follow up my previous fix which was incomplete (didn't write the new clients to the languageClients map), leading to subsequent operations triggering launch of cpptools.  This change adds a state variable to ensure that any potential creation of clients is prevented once in this failsafe state.