### PR TITLE
Dynamic debug config info

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -75,7 +75,6 @@
     "onCommand:C_Cpp.RunCodeAnalysisOnOpenFiles",
     "onCommand:C_Cpp.RunCodeAnalysisOnAllFiles",
     "onCommand:C_Cpp.ClearCodeAnalysisSquiggles",
-    "onDebugInitialConfigurations",
     "onDebugResolve:cppdbg",
     "onDebugResolve:cppvsdbg",
     "workspaceContains:/.vscode/c_cpp_properties.json",
@@ -2757,7 +2756,6 @@
         "configurationAttributes": {
           "launch": {
             "type": "object",
-            "default": {},
             "required": [
               "program"
             ],
@@ -3432,7 +3430,6 @@
         "configurationAttributes": {
           "launch": {
             "type": "object",
-            "default": {},
             "required": [
               "program",
               "cwd"

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -228,7 +228,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             // logger.showOutputChannel();
         }
 
-        return Promise.resolve(config);    
+        return Promise.resolve(config);
     }
 
     async provideDebugConfigurationsTypeSpecific(type: DebuggerType, folder?: vscode.WorkspaceFolder, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
@@ -302,7 +302,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             // Add the "detail" property to show the compiler path in QuickPickItem.
             // This property will be removed before writing the DebugConfiguration in launch.json.
             newConfig.detail = localize("pre.Launch.Task", "preLaunchTask: {0}", task.name);
-            newConfig.existing = (task.name === DebugConfigurationProvider.recentBuildTaskLableStr)? TaskConfigStatus.recentlyUsed : (task.existing ? TaskConfigStatus.configured : TaskConfigStatus.detected);
+            newConfig.existing = (task.name === DebugConfigurationProvider.recentBuildTaskLableStr) ? TaskConfigStatus.recentlyUsed : (task.existing ? TaskConfigStatus.configured : TaskConfigStatus.detected);
             if (isMacARM64) {
                 // Workaround to build and debug x86_64 on macARM64 by default.
                 // Remove this workaround when native debugging for macARM64 is supported.
@@ -384,7 +384,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
     private isClAvailable(configurationLabel: string): boolean {
         if (configurationLabel.startsWith("C/C++: cl.exe")) {
-            if (!process.env.DevEnvDir|| process.env.DevEnvDir.length === 0) {
+            if (!process.env.DevEnvDir || process.env.DevEnvDir.length === 0) {
                 vscode.window.showErrorMessage(localize("cl.exe.not.available", "{0} build and debug is only usable when VS Code is run from the Developer Command Prompt for VS.", "cl.exe"));
                 return false;
             }
@@ -517,12 +517,11 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     public async buildAndDebug(textEditor: vscode.TextEditor, debugModeOn: boolean = true): Promise<void> {
 
         const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(textEditor.document.uri);
-    
         if (!util.isCppOrCFile(textEditor.document.uri)) {
             vscode.window.showErrorMessage(localize("cannot.build.non.cpp", 'Cannot build and debug because the active file is not a C or C++ source file.'));
             return;
         }
-    
+
         // Get debug configurations for all debugger types.
         let configs: vscode.DebugConfiguration[] = [];
         if (os.platform() === 'win32') {
@@ -530,16 +529,15 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         }
         configs = configs.concat(await this.provideDebugConfigurationsTypeSpecific(DebuggerType.cppdbg, folder));
 
-
         const defaultConfig: vscode.DebugConfiguration[] = configs.filter((config: vscode.DebugConfiguration) => (config.hasOwnProperty("isDefault") && config.isDefault));
         interface MenuItem extends vscode.QuickPickItem {
             configuration: vscode.DebugConfiguration;
         }
-    
+
         const items: MenuItem[] = configs.map<MenuItem>(config => ({ label: config.name, configuration: config, description: config.detail, detail: config.existing }));
-    
+
         let selection: MenuItem | undefined;
-    
+
         if (defaultConfig.length !== 0) {
             selection = { label: defaultConfig[0].name, configuration: defaultConfig[0], description: defaultConfig[0].detail, detail: defaultConfig[0].existing };
         } else {
@@ -556,8 +554,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 placeHolder: (items.length === 0 ? localize("no.compiler.found", "No compiler found") : localize("select.debug.configuration", "Select a debug configuration"))
             });
         }
-    
-        let debuggerEvent: string = DebuggerEvent.launchPlayButton;
+
+        const debuggerEvent: string = DebuggerEvent.launchPlayButton;
         if (!selection) {
             Telemetry.logDebuggerEvent(debuggerEvent, { "debugType": debugModeOn ? "debug" : "run", "folderMode": folder ? "folder" : "singleMode", "cancelled": "true" });
             return; // User canceled it.
@@ -576,8 +574,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             await this.startDebugging(folder, resolvedConfig, debuggerEvent, debugModeOn);
         }
     }
-    
-    private async startDebugging(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration, debuggerEvent: string, debugModeOn: boolean = true) {
+
+    private async startDebugging(folder: vscode.WorkspaceFolder | undefined, configuration: vscode.DebugConfiguration, debuggerEvent: string, debugModeOn: boolean = true): Promise<void> {
 
         const debugType: string = debugModeOn ? "debug" : "run";
         const folderMode: string = folder ? "folder" : "singleMode";
@@ -780,5 +778,3 @@ export class ConfigurationSnippetProvider implements vscode.CompletionItemProvid
         return Promise.resolve(new vscode.CompletionList(items, true));
     }
 }
-
-

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -110,7 +110,6 @@ export class myDebugConfigurationProvider implements vscode.DebugConfigurationPr
         } else {
             return this.resolveDebugConfigurationInternal(folder, config, token);
         }
-
     }
 
     resolveDebugConfigurationInternal(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> | undefined {

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -122,9 +122,11 @@ export class CppDebugConfigurationProvider implements vscode.DebugConfigurationP
     resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> | undefined {
         if (!config || !config.type) {
             this.provideDebugConfigurations(folder).then(configs => {
-                return (!configs || configs.length === 0) ?
-                undefined :
-                this.underlyingDbgConfigProvider.resolveDebugConfiguration(folder, configs[0], token)
+                if (!configs || configs.length === 0) {
+                    return undefined;
+                } else {
+                    this.underlyingDbgConfigProvider.resolveDebugConfiguration(folder, configs[0], token);
+                }
             });
         } else {
             return this.underlyingDbgConfigProvider.resolveDebugConfiguration(folder, config, token);
@@ -136,7 +138,7 @@ export class CppDebugConfigurationProvider implements vscode.DebugConfigurationP
     }
 }
 
-export class UnderlyingDbgConfigProvider{
+export class UnderlyingDbgConfigProvider {
     private type: DebuggerType;
     private assetProvider: IConfigurationAssetProvider;
     // Keep a list of tasks detected by cppBuildTaskProvider.
@@ -151,7 +153,7 @@ export class UnderlyingDbgConfigProvider{
     private async loadDetectedTasks(): Promise<void> {
         if (!UnderlyingDbgConfigProvider.detectedBuildTasks || UnderlyingDbgConfigProvider.detectedBuildTasks.length === 0) {
             UnderlyingDbgConfigProvider.detectedBuildTasks = await cppBuildTaskProvider.getTasks(true);
-        } 
+        }
     }
 
     public static get recentBuildTaskLableStr(): string {

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -11,13 +11,19 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export enum DebuggerType {
     cppvsdbg,
-    cppdbg
+    cppdbg,
+    all
+}
+
+export enum DebuggerEvent {
+    debugPanel = "debugPanel",
+    launchPlayButton = "launchPlayButton"
 }
 
 export enum TaskConfigStatus {
     recentlyUsed = "Recently Used Task",
-    configured = "Configured Task",
-    detected = "Detected Task"
+    configured = "Configured Task", // The tasks that are configured in tasks.json file.
+    detected = "Detected Task"      // The tasks that are available based on detected compilers.
 }
 
 export interface IConfigurationSnippet {

--- a/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
+++ b/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
@@ -26,8 +26,6 @@ abstract class AbstractDebugAdapterDescriptorFactory implements vscode.DebugAdap
 }
 
 export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-    public static DEBUG_TYPE: string = "cppdbg";
-
     constructor(context: vscode.ExtensionContext) {
         super(context);
     }
@@ -42,8 +40,6 @@ export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDes
 }
 
 export class CppvsdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-    public static DEBUG_TYPE: string = "cppvsdbg";
-
     constructor(context: vscode.ExtensionContext) {
         super(context);
     }

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import { AttachPicker, RemoteAttachPicker, AttachItemsProvider } from './attachToProcess';
 import { NativeAttachItemsProviderFactory } from './nativeAttach';
-import { myDebugConfigurationProvider, ConfigurationAssetProviderFactory, ConfigurationSnippetProvider, IConfigurationAssetProvider } from './configurationProvider';
+import { DebugConfigurationProvider, ConfigurationAssetProviderFactory, ConfigurationSnippetProvider, IConfigurationAssetProvider } from './configurationProvider';
 import { CppdbgDebugAdapterDescriptorFactory, CppvsdbgDebugAdapterDescriptorFactory } from './debugAdapterDescriptorFactory';
 import { DebuggerType } from './configurations';
 
@@ -27,16 +27,16 @@ export async function initialize(context: vscode.ExtensionContext): Promise<void
 
     // Register DebugConfigurationProviders for "Run and Debug" in Debug Panel.
     // On windows platforms, the cppvsdbg debugger will also be registered for initial configurations.
-    let cppVsDebugProvider: myDebugConfigurationProvider | null = null;
+    let cppVsDebugProvider: DebugConfigurationProvider | null = null;
     if (os.platform() === 'win32') {
-        cppVsDebugProvider = new myDebugConfigurationProvider(assetProvider, DebuggerType.cppvsdbg);
+        cppVsDebugProvider = new DebugConfigurationProvider(assetProvider, DebuggerType.cppvsdbg);
         disposables.push(vscode.debug.registerDebugConfigurationProvider('cppvsdbg', cppVsDebugProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
     }
-    const cppDebugProvider: myDebugConfigurationProvider = new myDebugConfigurationProvider(assetProvider, DebuggerType.cppdbg);
+    const cppDebugProvider: DebugConfigurationProvider = new DebugConfigurationProvider(assetProvider, DebuggerType.cppdbg);
     disposables.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', cppDebugProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
 
     // Register DebugConfigurationProviders for "Run and Debug" play button.
-    const debugProvider: myDebugConfigurationProvider = new myDebugConfigurationProvider(assetProvider, DebuggerType.all);
+    const debugProvider: DebugConfigurationProvider = new DebugConfigurationProvider(assetProvider, DebuggerType.all);
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.BuildAndDebugFile", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => { await debugProvider.buildAndDebug(textEditor); }));
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.BuildAndRunFile", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => { await debugProvider.buildAndDebug(textEditor, false); }));
 

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -28,10 +28,10 @@ export async function initialize(context: vscode.ExtensionContext): Promise<void
     let cppVsDbgProvider: CppVsDbgConfigProvider | null = null;
     if (os.platform() === 'win32') {
         cppVsDbgProvider = new CppVsDbgConfigProvider(assetProvider);
-        disposables.push(vscode.debug.registerDebugConfigurationProvider('cppvsdbg', new CppDebugConfigurationProvider(cppVsDbgProvider), vscode.DebugConfigurationProviderTriggerKind.Initial));
+        disposables.push(vscode.debug.registerDebugConfigurationProvider('cppvsdbg', new CppDebugConfigurationProvider(cppVsDbgProvider), vscode.DebugConfigurationProviderTriggerKind.Dynamic));
     }
     const cppDbgProvider: CppDbgConfigProvider = new CppDbgConfigProvider(assetProvider);
-    disposables.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', new CppDebugConfigurationProvider(cppDbgProvider), vscode.DebugConfigurationProviderTriggerKind.Initial));
+    disposables.push(vscode.debug.registerDebugConfigurationProvider('cppdbg', new CppDebugConfigurationProvider(cppDbgProvider), vscode.DebugConfigurationProviderTriggerKind.Dynamic));
 
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.BuildAndDebugFile", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => { await buildAndDebug(textEditor, cppVsDbgProvider, cppDbgProvider); }));
 


### PR DESCRIPTION
Modification to "Run and Debug" button in debug panel to make it consistent with our play button:
1. keeping the Debug info in memory and skip writing it in launch.json
2. if the launch.json exists try to read the debug configs to check if the user has modified any debug info
3.Fixes are added for single-mode file debugging, however it is only working for cl.exe builds and msvc debugger for now

Feature  Request: https://github.com/microsoft/vscode-cpptools/issues/8773
