### PR TITLE
Fix a formatting bug

### DIFF
--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -712,8 +712,16 @@ export class CppSettings extends Settings {
                         return true;
                     }
                 }
-                if (editorConfigSettings.root?.toLowerCase() === "true") {
-                    return true;
+                if (editorConfigSettings.root !== undefined) {
+                    if (typeof editorConfigSettings.root === "boolean") {
+                        if (editorConfigSettings.root) {
+                            return true;
+                        }
+                    } else if (typeof editorConfigSettings.root === "string") {
+                        if (editorConfigSettings.root.toLowerCase() === "true") {
+                            return true;
+                        }
+                    }
                 }
             } else {
                 const clangFormatPath1: string = path.join(parentPath, ".clang-format");


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8900

The values in `.editorConfig` files are case insensitive.  However, if a lower case `true` or `false` is specified for a boolean property, it's treated as a boolean type (so no string functions are available on it) even as a property of an 'any' object.

This change handles the potential for `root` to be either of string or boolean type.
