### PR TITLE
Fix issue with `updateCustomConfigurations` failing to refresh config of active file

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -295,6 +295,7 @@ interface CompileCommandsPaths extends WorkspaceFolderParams {
 
 interface QueryTranslationUnitSourceParams extends WorkspaceFolderParams {
     uri: string;
+    ignoreExisting: boolean;
 }
 
 interface QueryTranslationUnitSourceResult {
@@ -700,7 +701,7 @@ export interface Client {
     onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void>;
     updateCustomConfigurations(requestingProvider?: CustomConfigurationProvider1): Thenable<void>;
     updateCustomBrowseConfiguration(requestingProvider?: CustomConfigurationProvider1): Thenable<void>;
-    provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string): Promise<void>;
+    provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string, replaceExisting?: boolean): Promise<void>;
     logDiagnostics(): Promise<void>;
     rescanFolder(): Promise<void>;
     toggleReferenceResultsView(): void;
@@ -1813,7 +1814,7 @@ export class DefaultClient implements Client {
                 diagnosticsCollectionCodeAnalysis.clear();
             }
             this.trackedDocuments.forEach(document => {
-                this.provideCustomConfiguration(document.uri, undefined);
+                this.provideCustomConfiguration(document.uri, undefined, true);
             });
         });
     }
@@ -1942,7 +1943,7 @@ export class DefaultClient implements Client {
         await this.notifyWhenLanguageClientReady(() => this.languageClient.sendNotification(RescanFolderNotification));
     }
 
-    public async provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string): Promise<void> {
+    public async provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string, replaceExisting?: boolean): Promise<void> {
         const onFinished: () => void = () => {
             if (requestFile) {
                 this.languageClient.sendNotification(FinishedRequestCustomConfig, requestFile);
@@ -1966,6 +1967,7 @@ export class DefaultClient implements Client {
 
             const params: QueryTranslationUnitSourceParams = {
                 uri: docUri.toString(),
+                ignoreExisting: !!replaceExisting,
                 workspaceFolderUri: this.RootPath
             };
             const response: QueryTranslationUnitSourceResult = await this.languageClient.sendRequest(QueryTranslationUnitSourceRequest, params);
@@ -3271,7 +3273,7 @@ class NullClient implements Client {
     onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void> { return Promise.resolve(); }
     updateCustomConfigurations(requestingProvider?: CustomConfigurationProvider1): Thenable<void> { return Promise.resolve(); }
     updateCustomBrowseConfiguration(requestingProvider?: CustomConfigurationProvider1): Thenable<void> { return Promise.resolve(); }
-    provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string): Promise<void> { return Promise.resolve(); }
+    provideCustomConfiguration(docUri: vscode.Uri, requestFile?: string, replaceExisting?: boolean): Promise<void> { return Promise.resolve(); }
     logDiagnostics(): Promise<void> { return Promise.resolve(); }
     rescanFolder(): Promise<void> { return Promise.resolve(); }
     toggleReferenceResultsView(): void { }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/8974
(Requires native side change as well)

This change adds a field to `QueryTranslationUnitSourceParams` to cause it to ignore existing custom configurations or TU's when requesting a source file path (potentially associated with a header) to request a custom configuration for.  (Normally, existance of either of those would imply it's unnecessary to request new custom configuration for the file).

This change works around a race condition in which clearing of custom configurations causes a reset of the active TU.  If that reset completes too quickly, the subsequent `didChangeCustomConfigurations` for that file gets ignored due to the TU already existing.

We will continue to clear all custom configurations in `updateCustomConfigurations`, not try to replace them, as it's possible the configuration provider may no longer provide configurations for some files.  The new param is currently only used to work around this issue.