### PR TITLE
Update lldb-mi.yml to support building ARM64

### DIFF
--- a/Build/lldb-mi/README.md
+++ b/Build/lldb-mi/README.md
@@ -1,0 +1,6 @@
+This folder contains the entitlements needed for the debugger to run on macOS. 
+
+We use the entitlements that the .net runtime uses. See https://github.com/dotnet/runtime/blob/57678512d214af368ff055f358c5106f1aa19ac4/eng/pipelines/common/entitlements.plist
+
+Related Links:
+https://docs.microsoft.com/en-us/dotnet/core/install/macos-notarization-issues#default-entitlements

--- a/Build/lldb-mi/debugger-entitlements.plist
+++ b/Build/lldb-mi/debugger-entitlements.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+      <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+      <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+      <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+      <true/>
+    <key>com.apple.security.cs.debugger</key>
+      <true/>
+    <key>com.apple.security.get-task-allow</key>
+      <true/>
+    <key>com.apple.security.task_for_pid-allow</key>
+      <true/>
+  </dict>
+</plist>

--- a/Build/lldb-mi/lldb-mi-sign.template.yml
+++ b/Build/lldb-mi/lldb-mi-sign.template.yml
@@ -1,0 +1,30 @@
+---
+parameters:
+  archs: ["x86_64", "arm64"]
+
+jobs:
+- job:
+  pool:
+    name: VSEngSS-MicroBuild2022-1ES
+  steps:
+  - checkout: none
+
+  - ${{ each arch in parameters.archs }}:
+    - task: DownloadPipelineArtifact@1
+      displayName: 'Downloading unsigned_lldb-mi_${{ arch }}'
+      inputs:
+        targetPath: '$(Pipeline.Workspace)/Artifacts' 
+        artifactName: 'unsigned_lldb-mi_${{ arch }}'
+
+    - task: MicroBuildSignMacFiles@1
+      displayName: 'ESRP Sign'
+      inputs:
+        SigningTarget: '$(Pipeline.Workspace)\Artifacts\lldb-mi_${{ arch }}.zip'
+        SigningCert: 8023
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish signed LLDB-MI'
+      inputs:
+        targetPath: '$(Pipeline.Workspace)\Artifacts\lldb-mi_${{ arch }}.zip'
+        artifactName: 'lldb-mi_${{ arch }}_zip'
+...

--- a/Build/lldb-mi/lldb-mi.template.yml
+++ b/Build/lldb-mi/lldb-mi.template.yml
@@ -1,0 +1,160 @@
+parameters:
+# Note: Make sure llvm_repo is the same as the one in Extension/cgmanifest.json 
+# 'RepositoryUrl' for llvm-project.
+  llvm_repo: https://github.com/llvm/llvm-project.git
+
+# Note: Make sure llvm_commit is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for llvm-project.
+  llvm_commit: 0d44201451f03ba907cdb268ddddfc3fa38a0ebd
+
+  llvm_build_type: Release
+
+  llvm_arch: x86_64
+
+  llvm_additional_parameters: "-DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_RELOCATABLE_PYTHON=1 -DLLDB_INCLUDE_TESTS=OFF -DLLDB_BUILD_FRAMEWORK=1"
+
+# Note: Make sure lldb_mi_repo is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for lldb-mi.
+  lldb_mi_repo: https://github.com/lldb-tools/lldb-mi.git
+
+# Note: Make sure lldb_mi_commit is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for lldb-mi.
+  lldb_mi_commit: 2388bd74133bc21eac59b2e2bf97f2a30770a315
+
+  lldb_mi_additional_parameters: "-DUSE_LLDB_FRAMEWORK=1"
+
+jobs:
+- job: LLDB_MI_${{ parameters.llvm_arch }}
+  timeoutInMinutes: 360
+  pool:
+    ${{if eq(parameters['llvm_arch'], 'arm64')}}:
+      name: cpptoolsMacM1pool
+    ${{ else }}:
+      vmImage: macOS-latest
+  steps:
+  - task: CmdLine@2
+    displayName: 'Install Dependencies'
+    inputs:
+      script: brew install cmake ninja swig
+    continueOnError: true
+
+  - task: CmdLine@2
+    displayName: 'Make sure buildspace does not exist'
+    inputs:
+      script: rm -rf $(Build.StagingDirectory)/buildspace
+    condition: always()
+
+  - task: CmdLine@2
+    displayName: 'Build LLVM Project'
+    inputs:
+      script: |
+        log_and_exec_cmd() {
+          echo "##[command] $1"
+          $1
+        }
+
+        log_and_exec_cmd "sudo rm -rf /Library/Developer/CommandLineTools"
+        log_and_exec_cmd "sudo xcode-select --switch /Applications/XCode.app"
+
+        log_and_exec_cmd "cd $(Build.StagingDirectory)"
+        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace"
+
+        log_and_exec_cmd "git clone ${{ parameters.llvm_repo }} llvm-project"
+        log_and_exec_cmd "cd llvm-project"
+        log_and_exec_cmd "git checkout ${{ parameters.llvm_commit }}"
+
+        log_and_exec_cmd "./lldb/scripts/macos-setup-codesign.sh"
+
+        log_and_exec_cmd "cd .."
+        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace/llvm-inst"
+        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace/llvm-build"
+        log_and_exec_cmd "cd $(Build.StagingDirectory)/buildspace/llvm-build"
+
+        log_and_exec_cmd "cmake -DLLVM_ENABLE_PROJECTS=clang;lldb -DCMAKE_BUILD_TYPE=${{ parameters.llvm_build_type }} -DCMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/buildspace/llvm-inst/ -DCMAKE_OSX_ARCHITECTURES=${{ parameters.llvm_arch }} ${{ parameters.llvm_additional_parameters }} -GNinja $(Build.StagingDirectory)/llvm-project/llvm"
+        if [[ $? -ne 0 ]]
+        then
+          echo "##[error] cmake llvm failed"
+          cat $(Build.SourcesDirectory)/buildspace/llvm-build/CMakeFiles/CMakeError.log
+          exit 1
+        fi
+
+        log_and_exec_cmd ninja
+        if [[ $? -ne 0 ]]
+        then
+          echo "##[error] ninja failed"
+          exit 1
+        fi
+
+        ### Workaround for https://github.com/llvm/llvm-project/issues/108
+        log_and_exec_cmd "ninja install"
+
+        # Remove conflicting LLDB.framework file.
+        log_and_exec_cmd "rm -rf $(Build.StagingDirectory)/buildspace/llvm-inst/Library/Frameworks/LLDB.framework"
+
+        # Build lldb/sources/API first
+        log_and_exec_cmd "cmake -P $(Build.StagingDirectory)/buildspace/llvm-build/tools/lldb/source/API/cmake_install.cmake"
+        ### End of Workaround
+
+        log_and_exec_cmd "ninja install"
+        if [[ $? -ne 0 ]]
+        then
+          echo "##[error] ninja install failed"
+          exit 1
+        fi
+
+        echo "##[section] Build LLDB-MI"
+        # Download lldb-mi and build it against our custom installation.
+        log_and_exec_cmd "cd $(Build.StagingDirectory)/buildspace"
+        log_and_exec_cmd "git clone ${{ parameters.lldb_mi_repo }} lldb-mi"
+        log_and_exec_cmd "cd lldb-mi"
+        log_and_exec_cmd "git checkout ${{ parameters.lldb_mi_commit }}"
+
+        # Create a separate build directory for building lldb-mi.
+        log_and_exec_cmd "mkdir build"
+        log_and_exec_cmd "cd build"
+        log_and_exec_cmd "cmake -DCMAKE_PREFIX_PATH=$(Build.StagingDirectory)/buildspace/llvm-inst/ -DCMAKE_OSX_ARCHITECTURES=${{ parameters.llvm_arch }} ${{ parameters.lldb_mi_additional_parameters }} -GNinja .."
+        log_and_exec_cmd "ninja"
+        if [[ $? -ne 0 ]]
+        then
+          echo "##[error] ninja failed"
+          exit 1
+        fi
+
+        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/publish"
+        log_and_exec_cmd "cd $(Build.StagingDirectory)/publish"
+
+        log_and_exec_cmd "mkdir -p ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin"
+
+        log_and_exec_cmd "cp $(Build.StagingDirectory)/buildspace/lldb-mi/build/src/lldb-mi ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/."
+
+        # Set rpath for finding LLDB.Framework
+        log_and_exec_cmd "install_name_tool -add_rpath @rpath/LLDB.framework/Versions/A/LLDB ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/lldb-mi"
+
+         # Set rpath for App Store XCode LLDB.Framework
+        log_and_exec_cmd "install_name_tool -add_rpath /Applications/Xcode.app/Contents/SharedFrameworks/ ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/lldb-mi"
+
+        # Set rpath for XCode CLI LLDB.Framework
+        log_and_exec_cmd "install_name_tool -add_rpath /Library/Developer/CommandLineTools/Library/PrivateFrameworks/ ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/lldb-mi"
+
+        # Set rpath next to the lldb-mi executable LLDB.Framework
+        log_and_exec_cmd "install_name_tool -add_rpath @executable_path/. ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/lldb-mi"
+
+        # Add entitlements
+        log_and_exec_cmd "codesign -s - -f --entitlements $(Build.SourcesDirectory)/Build/lldb-mi/debugger-entitlements.plist ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/bin/lldb-mi"
+
+        # Grab NOTICE.TXT
+        cp $(Build.SourcesDirectory)/Build/lldb-mi/NOTICE.TXT ./debugAdapters/lldb-mi_${{ parameters.llvm_arch }}/.
+
+        zip -r $(Build.StagingDirectory)/lldb-mi_${{ parameters.llvm_arch }}.zip ./debugAdapters
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish LLDB-MI'
+    inputs:
+      targetPath: '$(Build.StagingDirectory)/lldb-mi_${{ parameters.llvm_arch }}.zip'
+      artifactName: 'unsigned_lldb-mi_${{ parameters.llvm_arch }}'
+
+  - task: CmdLine@2
+    displayName: 'Clean up'
+    inputs:
+      script: rm -rf $(Build.StagingDirectory)/buildspace
+    condition: always()

--- a/Build/lldb-mi/lldb-mi.yml
+++ b/Build/lldb-mi/lldb-mi.yml
@@ -1,184 +1,23 @@
 parameters:
-- name: Architecture
-  displayName: Architecture
-  type: string
-  default: x86_64
-
 - name: Build_Type
   displayName: Build Type
   type: string
   default: Release
 
-- name: Build_Machine
-  displayName: Build Machine
-  type: string
-  default: 'macOS-latest'
+stages:
+- stage: Build
+  dependsOn: []
+  jobs:
+  - template: lldb-mi.template.yml
+    parameters:
+      llvm_build_type: ${{ parameters.Build_Type }}
+      llvm_arch: x86_64
+  - template: lldb-mi.template.yml
+    parameters:
+      llvm_build_type: ${{ parameters.Build_Type }}
+      llvm_arch: arm64
 
-variables:
-# Note: Make sure llvm_repo is the same as the one in Extension/cgmanifest.json 
-# 'RepositoryUrl' for llvm-project.
-- name: llvm_repo
-  value: https://github.com/llvm/llvm-project.git
-
-# Note: Make sure llvm_commit is the same as the one in Extension/cgmanifest.json 
-# 'CommitHash' for llvm-project.
-- name: llvm_commit
-  value: 0d44201451f03ba907cdb268ddddfc3fa38a0ebd
-
-- name: llvm_build_type
-  value: ${{parameters.Build_Type}}
-
-- name: llvm_arch
-  value: ${{parameters.Architecture}}
-
-- name: llvm_additional_parameters
-  value: "-DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_RELOCATABLE_PYTHON=1 -DLLDB_INCLUDE_TESTS=OFF -DLLDB_BUILD_FRAMEWORK=1"
-
-# Note: Make sure lldb_mi_repo is the same as the one in Extension/cgmanifest.json 
-# 'CommitHash' for lldb-mi.
-- name: lldb_mi_repo
-  value: https://github.com/lldb-tools/lldb-mi.git
-
-# Note: Make sure lldb_mi_commit is the same as the one in Extension/cgmanifest.json 
-# 'CommitHash' for lldb-mi.
-- name: lldb_mi_commit
-  value: 2388bd74133bc21eac59b2e2bf97f2a30770a315
-
-- name: lldb_mi_additional_parameters
-  value: "-DUSE_LLDB_FRAMEWORK=1"
-
-jobs:
-- job: LLDB_MI
-  timeoutInMinutes: 360
-  pool:
-    ${{if eq(variables['llvm_arch'], 'arm64')}}:
-      name: cpptoolsMacM1pool
-    ${{ else }}:
-      vmImage: macOS-latest
-  steps:
-  - task: CmdLine@2
-    displayName: 'Install Dependencies'
-    inputs:
-      script: brew install cmake ninja swig
-    continueOnError: true
-
-  - task: CmdLine@2
-    displayName: 'Make sure buildspace does not exist'
-    inputs:
-      script: rm -rf $(Build.StagingDirectory)/buildspace
-    condition: always()
-
-  - task: CmdLine@2
-    displayName: 'Build LLVM Project'
-    inputs:
-      script: |
-        log_and_exec_cmd() {
-          echo "##[command] $1"
-          $1
-        }
-
-        log_and_exec_cmd "sudo rm -rf /Library/Developer/CommandLineTools"
-        log_and_exec_cmd "sudo xcode-select --switch /Applications/XCode.app"
-
-        log_and_exec_cmd "cd $(Build.StagingDirectory)"
-        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace"
-
-        log_and_exec_cmd "git clone $(llvm_repo) llvm-project"
-        log_and_exec_cmd "cd llvm-project"
-        log_and_exec_cmd "git checkout $(llvm_commit)"
-
-        log_and_exec_cmd "./lldb/scripts/macos-setup-codesign.sh"
-
-        log_and_exec_cmd "cd .."
-        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace/llvm-inst"
-        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace/llvm-build"
-        log_and_exec_cmd "cd $(Build.StagingDirectory)/buildspace/llvm-build"
-
-        log_and_exec_cmd "cmake -DLLVM_ENABLE_PROJECTS=clang;lldb -DCMAKE_BUILD_TYPE=$(llvm_build_type) -DCMAKE_INSTALL_PREFIX=$(Build.StagingDirectory)/buildspace/llvm-inst/ -DCMAKE_OSX_ARCHITECTURES=$(llvm_arch) $(llvm_additional_parameters) -GNinja $(Build.StagingDirectory)/llvm-project/llvm"
-        if [[ $? -ne 0 ]]
-        then
-          echo "##[error] cmake llvm failed"
-          cat $(Build.SourcesDirectory)/buildspace/llvm-build/CMakeFiles/CMakeError.log
-          exit 1
-        fi
-
-        log_and_exec_cmd ninja
-        if [[ $? -ne 0 ]]
-        then
-          echo "##[error] ninja failed"
-          exit 1
-        fi
-
-        ### Workaround for https://github.com/llvm/llvm-project/issues/108
-        log_and_exec_cmd "ninja install"
-
-        # Remove conflicting LLDB.framework file.
-        log_and_exec_cmd "rm -rf $(Build.StagingDirectory)/buildspace/llvm-inst/Library/Frameworks/LLDB.framework"
-
-        # Build lldb/sources/API first
-        log_and_exec_cmd "cmake -P $(Build.StagingDirectory)/buildspace/llvm-build/tools/lldb/source/API/cmake_install.cmake"
-        ### End of Workaround
-
-        log_and_exec_cmd "ninja install"
-        if [[ $? -ne 0 ]]
-        then
-          echo "##[error] ninja install failed"
-          exit 1
-        fi
-
-        echo "##[section] Build LLDB-MI"
-        # Download lldb-mi and build it against our custom installation.
-        log_and_exec_cmd "cd $(Build.StagingDirectory)/buildspace"
-        log_and_exec_cmd "git clone $(lldb_mi_repo) lldb-mi"
-        log_and_exec_cmd "cd lldb-mi"
-        log_and_exec_cmd "git checkout $(lldb_mi_commit)"
-
-        # Create a separate build directory for building lldb-mi.
-        log_and_exec_cmd "mkdir build"
-        log_and_exec_cmd "cd build"
-        log_and_exec_cmd "cmake -DCMAKE_PREFIX_PATH=$(Build.StagingDirectory)/buildspace/llvm-inst/ -DCMAKE_OSX_ARCHITECTURES=$(llvm_arch) $(lldb_mi_additional_parameters) -GNinja .."
-        log_and_exec_cmd "ninja"
-        if [[ $? -ne 0 ]]
-        then
-          echo "##[error] ninja failed"
-          exit 1
-        fi
-
-        log_and_exec_cmd "mkdir $(Build.StagingDirectory)/publish"
-        log_and_exec_cmd "cd $(Build.StagingDirectory)/publish"
-
-        log_and_exec_cmd "mkdir -p ./debugAdapters/lldb-mi/bin"
-
-        log_and_exec_cmd "cp $(Build.StagingDirectory)/buildspace/lldb-mi/build/src/lldb-mi ./debugAdapters/lldb-mi/bin/."
-
-        # Set rpath for finding LLDB.Framework
-        log_and_exec_cmd "install_name_tool -add_rpath @rpath/LLDB.framework/Versions/A/LLDB ./debugAdapters/lldb-mi/bin/lldb-mi"
-
-         # Set rpath for App Store XCode LLDB.Framework
-        log_and_exec_cmd "install_name_tool -add_rpath /Applications/Xcode.app/Contents/SharedFrameworks/ ./debugAdapters/lldb-mi/bin/lldb-mi"
-
-        # Set rpath for XCode CLI LLDB.Framework
-        log_and_exec_cmd "install_name_tool -add_rpath /Library/Developer/CommandLineTools/Library/PrivateFrameworks/ ./debugAdapters/lldb-mi/bin/lldb-mi"
-
-        # Set rpath next to the lldb-mi executable LLDB.Framework
-        log_and_exec_cmd "install_name_tool -add_rpath @executable_path/. ./debugAdapters/lldb-mi/bin/lldb-mi"
-
-        # Add entitlements
-        log_and_exec_cmd "codesign -s - -f --entitlements $(Build.SourcesDirectory)/Build/lldb-mi/debugger-entitlements.plist ./debugAdapters/lldb-mi/bin/lldb-mi"
-
-        # Grab NOTICE.TXT
-        cp $(Build.SourcesDirectory)/Build/lldb-mi/NOTICE.TXT ./debugAdapters/lldb-mi/.
-
-  # Build can be found at https://dev.azure.com/ms/vscode-cpptools/_build?definitionId=313
-  # Click on the build and select 'Artifacts'
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish LLDB-MI'
-    inputs:
-      targetPath: '$(Build.StagingDirectory)/publish'
-      artifactName: 'lldb-mi'
-
-  - task: CmdLine@2
-    displayName: 'Clean up'
-    inputs:
-      script: rm -rf $(Build.StagingDirectory)/buildspace
-    condition: always()
+- stage: Signing
+  dependsOn: ["Build"]
+  jobs:
+  - template: lldb-mi-sign.template.yml

--- a/Build/lldb-mi/lldb-mi.yml
+++ b/Build/lldb-mi/lldb-mi.yml
@@ -1,25 +1,72 @@
+parameters:
+- name: Architecture
+  displayName: Architecture
+  type: string
+  default: x86_64
+
+- name: Build_Type
+  displayName: Build Type
+  type: string
+  default: Release
+
+- name: Build_Machine
+  displayName: Build Machine
+  type: string
+  default: 'macOS-latest'
+
 variables:
-  llvm_repo: https://github.com/llvm/llvm-project.git
-  llvm_branch: release/10.x
-  llvm_build_type: Release
-  llvm_arch: x86_64
-  llvm_additional_parameters: "-DLLDB_RELOCATABLE_PYTHON=1 -DLLDB_INCLUDE_TESTS=OFF -DLLDB_BUILD_FRAMEWORK=1"
-  # TODO: fix lldb_mi_repo and lldb_mi_branch (https://github.com/lldb-tools/lldb-mi/pull/37 and https://github.com/lldb-tools/lldb-mi/pull/39)
-  lldb_mi_repo: https://github.com/WardenGnaw/lldb-mi # TODO: Change to lldb-tools
-  lldb_mi_branch: release/cpptools # TODO: Change to main
-  lldb_mi_additional_parameters: "-DUSE_LLDB_FRAMEWORK=1"
+# Note: Make sure llvm_repo is the same as the one in Extension/cgmanifest.json 
+# 'RepositoryUrl' for llvm-project.
+- name: llvm_repo
+  value: https://github.com/llvm/llvm-project.git
+
+# Note: Make sure llvm_commit is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for llvm-project.
+- name: llvm_commit
+  value: 0d44201451f03ba907cdb268ddddfc3fa38a0ebd
+
+- name: llvm_build_type
+  value: ${{parameters.Build_Type}}
+
+- name: llvm_arch
+  value: ${{parameters.Architecture}}
+
+- name: llvm_additional_parameters
+  value: "-DLLDB_USE_SYSTEM_DEBUGSERVER=ON -DLLDB_RELOCATABLE_PYTHON=1 -DLLDB_INCLUDE_TESTS=OFF -DLLDB_BUILD_FRAMEWORK=1"
+
+# Note: Make sure lldb_mi_repo is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for lldb-mi.
+- name: lldb_mi_repo
+  value: https://github.com/lldb-tools/lldb-mi.git
+
+# Note: Make sure lldb_mi_commit is the same as the one in Extension/cgmanifest.json 
+# 'CommitHash' for lldb-mi.
+- name: lldb_mi_commit
+  value: 2388bd74133bc21eac59b2e2bf97f2a30770a315
+
+- name: lldb_mi_additional_parameters
+  value: "-DUSE_LLDB_FRAMEWORK=1"
 
 jobs:
 - job: LLDB_MI
   timeoutInMinutes: 360
   pool:
-    vmImage: 'macOS-latest'
+    ${{if eq(variables['llvm_arch'], 'arm64')}}:
+      name: cpptoolsMacM1pool
+    ${{ else }}:
+      vmImage: macOS-latest
   steps:
   - task: CmdLine@2
     displayName: 'Install Dependencies'
     inputs:
       script: brew install cmake ninja swig
     continueOnError: true
+
+  - task: CmdLine@2
+    displayName: 'Make sure buildspace does not exist'
+    inputs:
+      script: rm -rf $(Build.StagingDirectory)/buildspace
+    condition: always()
 
   - task: CmdLine@2
     displayName: 'Build LLVM Project'
@@ -30,12 +77,15 @@ jobs:
           $1
         }
 
+        log_and_exec_cmd "sudo rm -rf /Library/Developer/CommandLineTools"
+        log_and_exec_cmd "sudo xcode-select --switch /Applications/XCode.app"
+
         log_and_exec_cmd "cd $(Build.StagingDirectory)"
         log_and_exec_cmd "mkdir $(Build.StagingDirectory)/buildspace"
 
         log_and_exec_cmd "git clone $(llvm_repo) llvm-project"
         log_and_exec_cmd "cd llvm-project"
-        log_and_exec_cmd "git checkout $(llvm_branch)"
+        log_and_exec_cmd "git checkout $(llvm_commit)"
 
         log_and_exec_cmd "./lldb/scripts/macos-setup-codesign.sh"
 
@@ -81,12 +131,12 @@ jobs:
         log_and_exec_cmd "cd $(Build.StagingDirectory)/buildspace"
         log_and_exec_cmd "git clone $(lldb_mi_repo) lldb-mi"
         log_and_exec_cmd "cd lldb-mi"
-        log_and_exec_cmd "git checkout $(lldb_mi_branch)"
+        log_and_exec_cmd "git checkout $(lldb_mi_commit)"
 
         # Create a separate build directory for building lldb-mi.
         log_and_exec_cmd "mkdir build"
         log_and_exec_cmd "cd build"
-        log_and_exec_cmd "cmake -DCMAKE_PREFIX_PATH=$(Build.StagingDirectory)/buildspace/llvm-inst/ $(lldb_mi_additional_parameters) -GNinja .."
+        log_and_exec_cmd "cmake -DCMAKE_PREFIX_PATH=$(Build.StagingDirectory)/buildspace/llvm-inst/ -DCMAKE_OSX_ARCHITECTURES=$(llvm_arch) $(lldb_mi_additional_parameters) -GNinja .."
         log_and_exec_cmd "ninja"
         if [[ $? -ne 0 ]]
         then
@@ -113,6 +163,9 @@ jobs:
         # Set rpath next to the lldb-mi executable LLDB.Framework
         log_and_exec_cmd "install_name_tool -add_rpath @executable_path/. ./debugAdapters/lldb-mi/bin/lldb-mi"
 
+        # Add entitlements
+        log_and_exec_cmd "codesign -s - -f --entitlements $(Build.SourcesDirectory)/Build/lldb-mi/debugger-entitlements.plist ./debugAdapters/lldb-mi/bin/lldb-mi"
+
         # Grab NOTICE.TXT
         cp $(Build.SourcesDirectory)/Build/lldb-mi/NOTICE.TXT ./debugAdapters/lldb-mi/.
 
@@ -123,3 +176,9 @@ jobs:
     inputs:
       targetPath: '$(Build.StagingDirectory)/publish'
       artifactName: 'lldb-mi'
+
+  - task: CmdLine@2
+    displayName: 'Clean up'
+    inputs:
+      script: rm -rf $(Build.StagingDirectory)/buildspace
+    condition: always()


### PR DESCRIPTION
This PR enables building lldb-mi for ARM64 and adds signing to both binaries. 

We also hardcode the commit we build from llvm-project and lldb-mi.