### PR TITLE
Update loc strings for `tag_parsing_error`

### DIFF
--- a/Extension/i18n/chs/src/nativeStrings.i18n.json
+++ b/Extension/i18n/chs/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "如果已解决所有标头依赖项，则启用错误波形曲线。",
 	"replaced_placeholder_file_record": "已替换占位符文件记录",
 	"tag_parsing_file": "标记分析文件: {0}",
-	"tag_parsing_error": "标记分析遇到错误，但这可能不影响操作。如果在文件中找不到符号，请告诉我们: {0}",
+	"tag_parsing_error": "标记分析错误(除非找不到符号，否则可以忽略此错误):",
 	"reset_timestamp_for": "重置 {0} 的时间戳",
 	"remove_file_failed": "未能删除文件: {0}",
 	"regex_parse_error": "Regex 分析错误 - vscode 模式: {0}，regex: {1}，错误消息: {2}",

--- a/Extension/i18n/cht/src/nativeStrings.i18n.json
+++ b/Extension/i18n/cht/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "如果所有標頭相依性皆已解決，就會啟用錯誤波浪線。",
 	"replaced_placeholder_file_record": "已取代預留位置檔案記錄",
 	"tag_parsing_file": "標籤剖析檔案: {0}",
-	"tag_parsing_error": "標籤剖析發生錯誤，但可能無關緊要。如果找不到檔案中的符號，請通知我們: {0}",
+	"tag_parsing_error": "標籤剖析錯誤 (除非找不到符號，否則可以忽略):",
 	"reset_timestamp_for": "重設 {0} 的時間戳記",
 	"remove_file_failed": "無法移除檔案: {0}",
 	"regex_parse_error": "Regex 剖析錯誤 - vscode 模式: {0}，RegEx: {1}，錯誤訊息: {2}",

--- a/Extension/i18n/csy/src/nativeStrings.i18n.json
+++ b/Extension/i18n/csy/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Podtrhávání chyb vlnovkou se povolí, když se přeloží všechny závislosti hlaviček.",
 	"replaced_placeholder_file_record": "Nahradil se záznam souboru zástupného symbolu.",
 	"tag_parsing_file": "analyzují se značky v souboru: {0}",
-	"tag_parsing_error": "Při analýze značek došlo k chybě, ale je možné, že nebude významná. Dejte nám vědět, pokud se v souboru nepovede najít nějaké symboly: {0}",
+	"tag_parsing_error": "chyba analýzy značka (toto lze ignorovat, pokud se nedají najít symboly):",
 	"reset_timestamp_for": "Resetovat časové razítko pro {0}",
 	"remove_file_failed": "Nepovedlo se odebrat soubor: {0}",
 	"regex_parse_error": "Chyba parsování regulárního výrazu – vzor VS Code: {0}, regulární výraz: {1}, chybová zpráva: {2}",

--- a/Extension/i18n/deu/src/nativeStrings.i18n.json
+++ b/Extension/i18n/deu/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Fehlerwellenlinien sind aktiviert, wenn alle Headerabhängigkeiten aufgelöst werden.",
 	"replaced_placeholder_file_record": "Datensatz für Platzhalterdatei ersetzt",
 	"tag_parsing_file": "Taganalysedatei: {0}",
-	"tag_parsing_error": "Fehler bei der Taganalyse, der jedoch möglicherweise nicht relevant ist. Informieren Sie uns, wenn Symbole in der Datei nicht gefunden werden: {0}",
+	"tag_parsing_error": "Taganalysefehler (dies kann ignoriert werden, es sei denn, Symbole können nicht gefunden werden):",
 	"reset_timestamp_for": "Zeitstempel für \"{0}\" zurücksetzen",
 	"remove_file_failed": "Fehler beim Entfernen der Datei: {0}",
 	"regex_parse_error": "RegEx-Analysefehler – vscode-Muster: {0}, RegEx: {1}, Fehlermeldung: {2}",

--- a/Extension/i18n/esn/src/nativeStrings.i18n.json
+++ b/Extension/i18n/esn/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "El subrayado ondulado de errores se habilita si se resuelven todas las dependencias de encabezado.",
 	"replaced_placeholder_file_record": "Se ha reemplazado el registro del archivo de marcadores de posición",
 	"tag_parsing_file": "Archivo de análisis de etiquetas: {0}",
-	"tag_parsing_error": "El análisis de etiquetas encontró un error, pero puede que no tenga importancia. Díganos si no se encuentran los símbolos en el archivo: {0}",
+	"tag_parsing_error": "error de análisis de etiquetas (se puede omitir a menos que no se encuentren símbolos):",
 	"reset_timestamp_for": "Restablecer la marca de tiempo para {0}",
 	"remove_file_failed": "No se pudo quitar el archivo {0}",
 	"regex_parse_error": "Error de análisis de Regex: patrón de vscode: {0}, regex: {1}, mensaje de error: {2}",

--- a/Extension/i18n/fra/src/nativeStrings.i18n.json
+++ b/Extension/i18n/fra/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Les tildes d'erreur sont activés si toutes les dépendances d'en-tête sont résolues.",
 	"replaced_placeholder_file_record": "Enregistrement du fichier d'espace réservé remplacé",
 	"tag_parsing_file": "fichier d'analyse de balises : {0}",
-	"tag_parsing_error": "L'analyse d'étiquettes a rencontré une erreur, mais elle n'a peut-être pas d'incidence. Indiquez-nous si les symboles du fichier sont introuvables : {0}",
+	"tag_parsing_error": "erreur d’analyse des balises (elle peut être ignorée, sauf si les symboles sont introuvables) :",
 	"reset_timestamp_for": "Réinitialiser l'horodatage pour {0}",
 	"remove_file_failed": "La suppression du fichier a échoué : {0}",
 	"regex_parse_error": "Erreur d'analyse de regex - Modèle vscode : {0}, regex : {1}, message d'erreur : {2}",

--- a/Extension/i18n/ita/src/nativeStrings.i18n.json
+++ b/Extension/i18n/ita/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "I segni di revisione per gli errori sono abilitati se vengono risolte tutte le dipendenze dell'intestazione.",
 	"replaced_placeholder_file_record": "Record del file segnaposto sostituito",
 	"tag_parsing_file": "analisi dei tag del file: {0}",
-	"tag_parsing_error": "Si è verificato un errore durante l'analisi dei tag, ma potrebbe non essere rilevante. Specificare se non è stato possibile trovare i simboli nel file: {0}",
+	"tag_parsing_error": "errore di analisi dei tag (questa operazione può essere ignorata a meno che non vengano trovati simboli):",
 	"reset_timestamp_for": "Reimposta il timestamp per {0}",
 	"remove_file_failed": "Non è stato possibile rimuovere il file {0}",
 	"regex_parse_error": "Errore di analisi regex. Criterio vscode: {0}. Regex: {1}. Messaggio di errore: {2}",

--- a/Extension/i18n/jpn/src/nativeStrings.i18n.json
+++ b/Extension/i18n/jpn/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "すべてのヘッダーの依存関係が解決されると、エラーの波線が有効になります。",
 	"replaced_placeholder_file_record": "プレースホルダー ファイル レコードを置換しました",
 	"tag_parsing_file": "ファイルのタグを解析中: {0}",
-	"tag_parsing_error": "タグの解析でエラーが見つかりましたが、問題ない可能性があります。ファイル内のシンボルが見つからない場合は、お問い合わせください。{0}",
+	"tag_parsing_error": "tag parsing error (this can be ignored unless symbols can't be found):",
 	"reset_timestamp_for": "{0} のタイムスタンプのリセット",
 	"remove_file_failed": "ファイルを削除できませんでした: {0}",
 	"regex_parse_error": "RegEx 解析エラー - vscode パターン: {0}、RegEx: {1}、エラー メッセージ: {2}",

--- a/Extension/i18n/kor/src/nativeStrings.i18n.json
+++ b/Extension/i18n/kor/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "모든 헤더 종속성이 확인되면 오류 표시선을 사용할 수 있습니다.",
 	"replaced_placeholder_file_record": "바뀐 자리 표시자 파일 레코드",
 	"tag_parsing_file": "태그 구문 분석 파일: {0}",
-	"tag_parsing_error": "태그 구문 분석에 오류가 발생했지만 중요하지 않을 수 있습니다. 파일에서 기호를 찾을 수 없으면 알려 주세요. {0}",
+	"tag_parsing_error": "태그 구문 분석 오류(기호를 찾을 수 없는 경우 무시할 수 있음):",
 	"reset_timestamp_for": "{0}에 대한 타임스탬프 다시 설정",
 	"remove_file_failed": "파일을 제거하지 못했습니다. {0}",
 	"regex_parse_error": "Regex 구문 분석 오류 - vscode 패턴: {0}, regex: {1}, 오류 메시지: {2}",

--- a/Extension/i18n/plk/src/nativeStrings.i18n.json
+++ b/Extension/i18n/plk/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Zygzaki sygnalizujące błędy są włączane, jeśli zostaną rozwiązane wszystkie zależności nagłówka.",
 	"replaced_placeholder_file_record": "Zamieniono rekord pliku zastępczego",
 	"tag_parsing_file": "plik analizowania tagów: {0}",
-	"tag_parsing_error": "Podczas analizowania tagów wystąpił błąd, ale może on nie być istotny. Poinformuj nas, jeśli nie można odnaleźć symboli w pliku: {0}",
+	"tag_parsing_error": "błąd analizy tagu (można go zignorować, chyba że nie można odnaleźć symboli):",
 	"reset_timestamp_for": "Resetuj znacznik czasu dla {0}",
 	"remove_file_failed": "Nie można usunąć pliku: {0}",
 	"regex_parse_error": "Błąd analizy wyrażenia regularnego — wzorzec vscode: {0}, wyrażenie regularne: {1}, komunikat o błędzie: {2}",

--- a/Extension/i18n/ptb/src/nativeStrings.i18n.json
+++ b/Extension/i18n/ptb/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Os rabiscos de erro serão habilitados se todas as dependências de cabeçalho forem resolvidas.",
 	"replaced_placeholder_file_record": "Registro de arquivo de espaço reservado substituído",
 	"tag_parsing_file": "arquivo de análise de marca: {0}",
-	"tag_parsing_error": "A análise de tag encontrou um erro, mas isso pode não ser relevante. Informe-nos caso não seja possível encontrar os símbolos no arquivo: {0}",
+	"tag_parsing_error": "erro de análise de marca (isso pode ser ignorado, a menos que não seja possível encontrar símbolos):",
 	"reset_timestamp_for": "Redefinir carimbo de data/hora para {0}",
 	"remove_file_failed": "Falha ao remover o arquivo: {0}",
 	"regex_parse_error": "Erro de análise de regex – padrão vscode: {0}, regex: {1}, mensagem de erro: {2}",

--- a/Extension/i18n/rus/src/nativeStrings.i18n.json
+++ b/Extension/i18n/rus/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Волнистые линии для ошибок включены, если разрешены все зависимости заголовка.",
 	"replaced_placeholder_file_record": "Запись файла-прототипа заменена",
 	"tag_parsing_file": "файл анализа тегов: {0}",
-	"tag_parsing_error": "Обнаружена ошибка при анализе тегов, но она может быть неважной. Сообщите нам, если не удастся найти символы в файле: {0}",
+	"tag_parsing_error": "tag parsing error (this can be ignored unless symbols can't be found):",
 	"reset_timestamp_for": "Сброс метки времени для {0}",
 	"remove_file_failed": "Не удалось удалить файл: {0}",
 	"regex_parse_error": "Ошибка анализа регулярного выражения — шаблон VS Code: {0}, регулярное выражение: {1}, сообщение об ошибке: {2}",

--- a/Extension/i18n/trk/src/nativeStrings.i18n.json
+++ b/Extension/i18n/trk/src/nativeStrings.i18n.json
@@ -81,7 +81,7 @@
 	"error_squiggles_enabled_if_all_headers_resolve": "Tüm üst bilgi bağımlılıkları çözümlenmişse hata ilişkilendirmeleri etkinleştirilir.",
 	"replaced_placeholder_file_record": "Yer tutucu dosya kaydı değiştirildi",
 	"tag_parsing_file": "etiket ayrıştırma dosyası: {0}",
-	"tag_parsing_error": "Etiket ayrıştırma bir hatayla karşılaştı ancak bu önemli bir sorun olmayabilir. Dosyadaki semboller bulunamıyorsa bize bildirin: {0}",
+	"tag_parsing_error": "etiket ayrıştırma hatası (simgeler bulunamadığı takdirde bu hata yoksayılabilir):",
 	"reset_timestamp_for": "{0} için zaman damgasını sıfırla",
 	"remove_file_failed": "{0} dosyası kaldırılamadı",
 	"regex_parse_error": "Normal ifade ayrıştırma hatası - vscode deseni: {0}, normal ifade: {1}, hata iletisi: {2}",


### PR DESCRIPTION
This string was changed to no longer require a param (`{0}`).  I'm not sure what happens when a param is specified and not provided, so I figured I would pull in the updated loc strings ASAP.
