### PR TITLE
Run and Debug button updates

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -383,7 +383,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 request: config.request,
                 detail: config.detail ? config.detail :
                     config.preLaunchTask ? localize("pre.Launch.Task", "preLaunchTask: {0}", config.preLaunchTask) : undefined,
-                existing: localize("configured.task", TaskConfigStatus.configured),
+                existing: TaskConfigStatus.configured,
                 preLaunchTask: config.preLaunchTask
             }));
             if (existingConfigs) {

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -38,9 +38,9 @@ export enum TaskConfigStatus {
 
 const localizeConfigs = (items: MenuItem[]): MenuItem[] => {
     items.map((item: MenuItem) => {
-        item.detail = (item.detail === TaskConfigStatus.recentlyUsed) ? localize("recently.used.task", TaskConfigStatus.recentlyUsed) :
-            (item.detail === TaskConfigStatus.configured) ? localize("configured.task", TaskConfigStatus.configured) :
-                (item.detail === TaskConfigStatus.detected) ? localize("detected.task", TaskConfigStatus.detected) : item.detail;
+        item.detail = (item.detail === TaskConfigStatus.recentlyUsed) ? localize("recently.used.task", "Recently Used Task") :
+            (item.detail === TaskConfigStatus.configured) ? localize("configured.task", "Configured Task") :
+                (item.detail === TaskConfigStatus.detected) ? localize("detected.task", "Detected Task") : item.detail;
 
     });
     return items;

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -21,12 +21,6 @@ export enum DebuggerEvent {
     launchPlayButton = "launchPlayButton"
 }
 
-export enum TaskConfigStatus {
-    recentlyUsed = "Recently Used Task",
-    configured = "Configured Task", // The tasks that are configured in tasks.json file.
-    detected = "Detected Task"      // The tasks that are available based on detected compilers.
-}
-
 export interface IConfigurationSnippet {
     label: string;
     description: string;

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -409,6 +409,11 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
         }
 
         this.writeEmitter.fire(activeCommand + this.endOfLine);
+
+        // Create the exe folder path if it doesn't exists.
+        const exePath: string | undefined = util.findExePathInArgs(this.args);
+        util.createDirIfNotExistsSync(exePath);
+
         let child: cp.ChildProcess | undefined;
         try {
             child = cp.spawn(command, this.args, this.options ? this.options : {});

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -172,8 +172,7 @@ export class CppBuildTaskProvider implements TaskProvider {
             const isWindows: boolean = os.platform() === 'win32';
             const taskLabel: string = ((appendSourceToName && !compilerPathBase.startsWith(ext.configPrefix)) ?
                 ext.configPrefix : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
-            const filePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
-            const programName: string = isWindows ? filePath + '.exe' : filePath;
+            const programName: string = util.defaultExePath();
             let args: string[] = isCl ? ['/Zi', '/EHsc', '/nologo', '/Fe:', programName, '${file}'] : ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -316,6 +316,16 @@ export function resolveCachePath(input: string | undefined, additionalEnvironmen
     return resolvedPath;
 }
 
+export function defaultExePath(): string {
+    const isWindows: boolean = os.platform() === 'win32';
+    const exePath: string = path.join('${fileDirname}', '${fileBasenameNoExtension}');
+    return isWindows ? exePath + '.exe' : exePath;
+}
+
+export function findExePathInArgs(args: string[]): string | undefined {
+    return args.find((arg: string, index: number) => (arg.includes(".exe") || (index > 0 && args[index - 1] === "-o")));
+}
+
 // Pass in 'arrayResults' if a string[] result is possible and a delimited string result is undesirable.
 // The string[] result will be copied into 'arrayResults'.
 export function resolveVariables(input: string | undefined, additionalEnvironment?: { [key: string]: string | string[] }, arrayResults?: string[]): string {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -476,6 +476,16 @@ export function checkDirectoryExists(dirPath: string): Promise<boolean> {
     });
 }
 
+export function createDirIfNotExistsSync(filePath: string | undefined): void {
+    if (!filePath) {
+        return;
+    }
+    const dirPath: string = path.dirname(filePath);
+    if (!checkDirectoryExistsSync(dirPath)) {
+        fs.mkdirSync(dirPath);
+    }
+}
+
 export function checkFileExistsSync(filePath: string): boolean {
     try {
         return fs.statSync(filePath).isFile();
@@ -1288,3 +1298,4 @@ export function isVsCodeInsiders(): boolean {
         extensionPath.includes(".vscode-exploration") ||
         extensionPath.includes(".vscode-server-exploration");
 }
+


### PR DESCRIPTION
1. extracting the custom exe path, bug fix: https://github.com/microsoft/vscode-cpptools/issues/9082  
2. localization, bug fix: https://github.com/microsoft/vscode-cpptools/issues/9051
3. creating the output directory, if it doesn't exists

== 

Fix the scenario where there is one default task (and only one):
- if there is a debug config in launch.json for the default task, we will pick that config
- if there is no launch.json or there is no config for that task in launch.json, we pick our own default config for that task.

==

removing the duplicate configs, where there is a launch.json available:
- some users kept their launch.json from the past experience, if there is a config already defined in their launch.json, we don't recommend another default config for that specific task to avoid a long list of recommendations for debug config. 