### PR TITLE
[DRAFT] handle create decl/def request/response

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -70,6 +70,7 @@
     "onCommand:C_Cpp.GoToNextDirectiveInGroup",
     "onCommand:C_Cpp.GoToPrevDirectiveInGroup",
     "onCommand:C_Cpp.CheckForCompiler",
+    "onComamnd:C_Cpp.CreateDeclarationOrDefinition",
     "onCommand:C_Cpp.RunCodeAnalysisOnActiveFile",
     "onCommand:C_Cpp.RunCodeAnalysisOnOpenFiles",
     "onCommand:C_Cpp.RunCodeAnalysisOnAllFiles",
@@ -2787,6 +2788,11 @@
       {
         "command": "C_Cpp.GoToPrevDirectiveInGroup",
         "title": "%c_cpp.command.GoToPrevDirectiveInGroup.title%",
+        "category": "C/C++"
+      },
+      {
+        "command": "C_Cpp.CreateDeclarationOrDefinition",
+        "title": "%c_cpp.command.createDeclarationOrDefinition.title%",
         "category": "C/C++"
       },
       {

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -21,6 +21,7 @@
     "c_cpp.command.generateEditorConfig.title": "Generate EditorConfig contents from VC Format settings",
     "c_cpp.command.GoToNextDirectiveInGroup.title": "Go to next preprocessor directive in conditional group",
     "c_cpp.command.GoToPrevDirectiveInGroup.title": "Go to previous preprocessor directive in conditional group",
+    "c_cpp.command.createDeclarationOrDefinition.title": "Create Declaration/Definition",
     "c_cpp.command.RunCodeAnalysisOnActiveFile.title": "Run Code Analysis on Active File",
     "c_cpp.command.RunCodeAnalysisOnOpenFiles.title": "Run Code Analysis on Open Files",
     "c_cpp.command.RunCodeAnalysisOnAllFiles.title": "Run Code Analysis on All Files",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3610,10 +3610,10 @@ export class DefaultClient implements Client {
             const result: CreateDeclarationOrDefinitionResult = await this.languageClient.sendRequest(CreateDeclarationOrDefinitionRequest, params);
             // TODO: return specific errors info in result.
             if (result.changes) {
-                let workspaceEdit : vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+                const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                 for (const file in result.changes) {
                     const uri: vscode.Uri = vscode.Uri.file(file);
-                    let edits : vscode.TextEdit[] = [];
+                    const edits: vscode.TextEdit[] = [];
                     for (const edit of result.changes[file]) {
                         const range: vscode.Range = new vscode.Range(
                             new vscode.Position(edit.range.start.line, edit.range.start.character),

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -425,6 +425,8 @@ export function registerCommands(): void {
     disposables.push(vscode.commands.registerCommand('C_Cpp.FixAllCodeAnalysisProblems', onFixAllCodeAnalysisProblems));
     disposables.push(vscode.commands.registerCommand('C_Cpp.DisableAllTypeCodeAnalysisProblems', onDisableAllTypeCodeAnalysisProblems));
     disposables.push(vscode.commands.registerCommand('C_Cpp.ShowCodeAnalysisDocumentation', (uri) => vscode.env.openExternal(uri)));
+    disposables.push(vscode.commands.registerCommand('C_Cpp.ClearCodeAnalysisSquiggles', onClearCodeAnalysisSquiggles));
+    disposables.push(vscode.commands.registerCommand('C_Cpp.CreateDeclarationOrDefinition', onCreateDeclarationOrDefinition));
     disposables.push(vscode.commands.registerCommand('cpptools.activeConfigName', onGetActiveConfigName));
     disposables.push(vscode.commands.registerCommand('cpptools.activeConfigCustomVariable', onGetActiveConfigCustomVariable));
     disposables.push(vscode.commands.registerCommand('cpptools.setActiveConfigName', onSetActiveConfigName));
@@ -650,6 +652,10 @@ async function onFixAllCodeAnalysisProblems(version: number, workspaceEdit: vsco
 
 async function onDisableAllTypeCodeAnalysisProblems(code: string, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void> {
     getActiveClient().handleDisableAllTypeCodeAnalysisProblems(code, identifiersAndUris);
+}
+
+async function onCreateDeclarationOrDefinition(uri: vscode.Uri | undefined, line: number | undefined, character: number | undefined): Promise<void> {
+    getActiveClient().handleCreateDeclarationOrDefinition(uri, line, character);
 }
 
 function onAddToIncludePath(path: string): void {


### PR DESCRIPTION
This is a draft that shows handling of creating a "create declaration/definition" request and processing response from language server.