### PR TITLE
defining platform specific debugger 

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3431,6 +3431,7 @@
       {
         "type": "cppvsdbg",
         "label": "C++ (Windows)",
+        "when": "workspacePlatform == windows",
         "languages": [
           "c",
           "cpp",


### PR DESCRIPTION
bug-fix: https://github.com/microsoft/vscode-cpptools/issues/6862 
The debugger contribution point is supporting a when clause #https://github.com/microsoft/vscode/issues/133146