### PR TITLE
Handle "external" include directories

### DIFF
--- a/Extension/bin/common.json
+++ b/Extension/bin/common.json
@@ -18,6 +18,10 @@
       "replace": "-I\n$1"
     },
     {
+      "match": "^[-/]external:I(.*)",
+      "replace": "-I\n$1"
+    },
+    {
       "match": "^/D(.*)",
       "replace": "-D$1"
     },


### PR DESCRIPTION
MSVC supports "external" include directories in the form "-external:I"
rather than the conventional "-I", and some tools generate such includes
in compile_commands.json exports.

See: https://docs.microsoft.com/en-us/cpp/build/reference/external-external-headers-diagnostics

The current language server does not understand the external include
directories, so use the replacement mechanism to rewrite the external
include directories into conventional ones that it can understand.