### PR TITLE
Avoid calling wordexp for Mac 10.15 or older.

### DIFF
--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -253,6 +253,8 @@ export class CppSettings extends Settings {
                     }
                 }
             }
+        } else if (this.forceLegacyCompilerArgs) {
+            return true;
         }
         return super.Section.get<boolean>("legacyCompilerArgsBehavior");
     }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -239,7 +239,23 @@ export class CppSettings extends Settings {
     public get defaultCustomConfigurationVariables(): { [key: string]: string } | undefined { return super.Section.get<{ [key: string]: string }>("default.customConfigurationVariables"); }
     public get useBacktickCommandSubstitution(): boolean | undefined { return super.Section.get<boolean>("debugger.useBacktickCommandSubstitution"); }
     public get codeFolding(): boolean { return super.Section.get<string>("codeFolding") === "Enabled"; }
-    public get legacyCompilerArgsBehavior(): boolean | undefined  { return super.Section.get<boolean>("legacyCompilerArgsBehavior"); }
+    private forceLegacyCompilerArgs: boolean | undefined;
+    public get legacyCompilerArgsBehavior(): boolean | undefined  {
+        if (this.forceLegacyCompilerArgs === undefined) {
+            this.forceLegacyCompilerArgs = false;
+            if (os.platform() === "darwin") {
+                const releaseParts: string[] = os.release().split(".");
+                if (releaseParts.length >= 1) {
+                    // wordexp doesn't work for older Mac OS's.
+                    if (parseInt(releaseParts[0]) < 16) {
+                        this.forceLegacyCompilerArgs = true;
+                        return true;
+                    }
+                }
+            }
+        }
+        return super.Section.get<boolean>("legacyCompilerArgsBehavior");
+    }
 
     public get enhancedColorization(): boolean {
         return super.Section.get<string>("enhancedColorization") === "Enabled"

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -245,7 +245,8 @@ export class CppSettings extends Settings {
             this.forceLegacyCompilerArgs = false;
             if (os.platform() === "darwin") {
                 const releaseParts: string[] = os.release().split(".");
-                // wordexp doesn't work for Mac OS 10.15 (Darwin 15.x) or older.
+                // wordexp doesn't work for Mac OS 10.11 (Darwin 15.x) or older,
+                // given our minimum build target of Mac OS 10.12.
                 if (releaseParts.length >= 1 && parseInt(releaseParts[0]) < 16) {
                     this.forceLegacyCompilerArgs = true;
                     return true;

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -245,12 +245,10 @@ export class CppSettings extends Settings {
             this.forceLegacyCompilerArgs = false;
             if (os.platform() === "darwin") {
                 const releaseParts: string[] = os.release().split(".");
-                if (releaseParts.length >= 1) {
-                    // wordexp doesn't work for older Mac OS's.
-                    if (parseInt(releaseParts[0]) < 16) {
-                        this.forceLegacyCompilerArgs = true;
-                        return true;
-                    }
+                // wordexp doesn't work for Mac OS 10.15 (Darwin 15.x) or older.
+                if (releaseParts.length >= 1 && parseInt(releaseParts[0]) < 16) {
+                    this.forceLegacyCompilerArgs = true;
+                    return true;
                 }
             }
         } else if (this.forceLegacyCompilerArgs) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/9309