### PR TITLE
Remove [Log] editor.wordWrap "off" default.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3953,9 +3953,6 @@
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
         "editor.semanticHighlighting.enabled": true
-      },
-      "[Log]": {
-        "editor.wordWrap": "off"
       }
     },
     "semanticTokenTypes": [


### PR DESCRIPTION
I believe this was added for the C/C++: Peek References console, but that doesn't appear to be used any more, and it causes build output to not be visible when running CMake Tools to build.