### PR TITLE
Prevent language service activation for macOS older than 10.12

### DIFF
--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -68,25 +68,44 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     UpdateInsidersAccess();
 
     const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
-    if (settings.intelliSenseEngine === "Disabled") {
-        languageServiceDisabled = true;
-    }
-    let currentIntelliSenseEngineValue: string | undefined = settings.intelliSenseEngine;
-    disposables.push(vscode.workspace.onDidChangeConfiguration(() => {
-        const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
-        if (!reloadMessageShown && settings.intelliSenseEngine !== currentIntelliSenseEngineValue) {
-            if (currentIntelliSenseEngineValue === "Disabled") {
-                // If switching from disabled to enabled, we can continue activation.
-                currentIntelliSenseEngineValue = settings.intelliSenseEngine;
-                languageServiceDisabled = false;
-                LanguageServer.activate();
-            } else {
-                // We can't deactivate or change engines on the fly, so prompt for window reload.
-                reloadMessageShown = true;
-                util.promptForReloadWindowDueToSettingsChange();
-            }
+    let isOldMacOs: boolean = false;
+    if (info.platform === 'darwin') {
+        const releaseParts: string[] = os.release().split(".");
+        if (releaseParts.length >= 1) {
+            // AutoPCH doesn't work for older Mac OS's.
+            isOldMacOs = parseInt(releaseParts[0]) < 16;
         }
-    }));
+    }
+
+    // Read the setting and determine whether we should activate the language server prior to installing callbacks,
+    // to ensure there is no potential race condition. LanguageServer.activate() is called near the end of this
+    // function, to allow any further setup to occur here, prior to activation.
+    const shouldActivateLanguageServer: boolean = (settings.intelliSenseEngine !== "Disabled" && !isOldMacOs);
+
+    if (isOldMacOs) {
+        languageServiceDisabled = true;
+        vscode.window.showErrorMessage(localize("macos.version.deprecated", "This version of the C/C++ extension requires at least macOS version {0}.", "10.12"));
+    } else {
+        if (settings.intelliSenseEngine === "Disabled") {
+            languageServiceDisabled = true;
+        }
+        let currentIntelliSenseEngineValue: string | undefined = settings.intelliSenseEngine;
+        disposables.push(vscode.workspace.onDidChangeConfiguration(() => {
+            const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
+            if (!reloadMessageShown && settings.intelliSenseEngine !== currentIntelliSenseEngineValue) {
+                if (currentIntelliSenseEngineValue === "Disabled") {
+                    // If switching from disabled to enabled, we can continue activation.
+                    currentIntelliSenseEngineValue = settings.intelliSenseEngine;
+                    languageServiceDisabled = false;
+                    LanguageServer.activate();
+                } else {
+                    // We can't deactivate or change engines on the fly, so prompt for window reload.
+                    reloadMessageShown = true;
+                    util.promptForReloadWindowDueToSettingsChange();
+                }
+            }
+        }));
+    }
 
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
         for (let i: number = 0; i < vscode.workspace.workspaceFolders.length; ++i) {
@@ -114,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
         }
     });
 
-    if (settings.intelliSenseEngine !== "Disabled") {
+    if (shouldActivateLanguageServer) {
         await LanguageServer.activate();
     }
 

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
 
     if (isOldMacOs) {
         languageServiceDisabled = true;
-        vscode.window.showErrorMessage(localize("macos.version.deprecated", "This version of the C/C++ extension requires at least macOS version {0}.", "10.12"));
+        vscode.window.showErrorMessage(localize("macos.version.deprecated", "Versions of the C/C++ extension more recent than {0} require at least macOS version {1}.", "1.9.8", "10.12"));
     } else {
         if (settings.intelliSenseEngine === "Disabled") {
             languageServiceDisabled = true;

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -72,7 +72,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (info.platform === 'darwin') {
         const releaseParts: string[] = os.release().split(".");
         if (releaseParts.length >= 1) {
-            // AutoPCH doesn't work for older Mac OS's.
             isOldMacOs = parseInt(releaseParts[0]) < 16;
         }
     }


### PR DESCRIPTION
We build the native components targeting 10.12 as the minimum macOS version.  This change adds an error dialog when installed on a version prior to 10.12.

I'm open to feedback on changes to how this works.  It currently avoids activating the language server but allows the debugger to continue to function.  Though, if I understand correctly, there are known debugger issues on 10.12 / Sierra.

