### PR TITLE
Add InlayHintsProvider and Display hints

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -11,7 +11,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.65.0"
   },
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-cpptools/issues",
@@ -4481,7 +4481,7 @@
     "@types/plist": "^3.0.2",
     "@types/semver": "^7.1.0",
     "@types/tmp": "^0.1.0",
-    "@types/vscode": "1.60.0",
+    "@types/vscode": "1.65.0",
     "@types/which": "^1.3.2",
     "@types/yauzl": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -27,9 +27,11 @@ interface GetInlayHintsResult {
     inlayHints: CppInlayHint[];
 }
 
-// TODO: either use separate lists or filter
-type InlayHintsCacheEntry = { FileVersion: number, 
-    TypeHints: vscode.InlayHint[], ParameterHints: vscode.InlayHint[] }
+type InlayHintsCacheEntry = {
+    FileVersion: number;
+    TypeHints: vscode.InlayHint[];
+    ParameterHints: vscode.InlayHint[];
+};
 
 const GetInlayHintsRequest: RequestType<GetInlayHintsParams, GetInlayHintsResult, void, void> =
     new RequestType<GetInlayHintsParams, GetInlayHintsResult, void, void>('cpptools/getInlayHints');
@@ -45,8 +47,8 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
         this.onDidChangeInlayHints = this.onDidChangeInlayHintsEvent.event;
     }
 
-    public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range, token: vscode.CancellationToken)
-        : Promise<vscode.InlayHint[] | undefined> {
+    public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range, token: vscode.CancellationToken):
+    Promise<vscode.InlayHint[] | undefined> {
         await this.client.awaitUntilLanguageClientReady();
         const uriString: string = document.uri.toString();
 
@@ -59,13 +61,20 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
         // Get new results from the language server
         const params: GetInlayHintsParams = { uri: uriString };
         const inlayHintsResult: GetInlayHintsResult = await this.client.languageClient.sendRequest(GetInlayHintsRequest, params, token);
-        if (!inlayHintsResult.canceled && inlayHintsResult.fileVersion === openFileVersions.get(uriString)) {
-            const cacheEntry: InlayHintsCacheEntry | undefined = this.createCacheEntry(inlayHintsResult);
-            if (cacheEntry) { 
-                this.cache.set(uriString, cacheEntry);
-                return this.getHintsBasedOnSettings(cacheEntry);
+        if (!inlayHintsResult.canceled) {
+            if (inlayHintsResult.fileVersion === openFileVersions.get(uriString)) {
+                const cacheEntry: InlayHintsCacheEntry | undefined = this.createCacheEntry(inlayHintsResult);
+                if (cacheEntry) {
+                    this.cache.set(uriString, cacheEntry);
+                    return this.getHintsBasedOnSettings(cacheEntry);
+                } else {
+                    // Force another request because file versions do not match.
+                    // TODO: verify this works when data is available.
+                    this.onDidChangeInlayHintsEvent.fire();
+                }
             }
         }
+        return undefined;
     }
 
     public invalidateFile(uri: string): void {
@@ -73,7 +82,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
         this.onDidChangeInlayHintsEvent.fire();
     }
 
-    private getVsCodeInlayHintKind(hintKind: CppInlayHintKind): vscode.InlayHintKind | undefined {
+    private CppToVsCodeInlayHintKind(hintKind: CppInlayHintKind): vscode.InlayHintKind | undefined {
         switch (hintKind) {
             case CppInlayHintKind.Type:
                 return vscode.InlayHintKind.Type;
@@ -86,16 +95,18 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
     }
 
     private createCacheEntry(results: GetInlayHintsResult): InlayHintsCacheEntry | undefined {
+        if (results.inlayHints.length === 0) {
+            return undefined;
+        }
         const typeHints: vscode.InlayHint[] = [];
         const paramHints: vscode.InlayHint[] = [];
-        let cacheEntry: InlayHintsCacheEntry | undefined = undefined;
         results.inlayHints.forEach((h: CppInlayHint) => {
             const inlayHint: vscode.InlayHint = new vscode.InlayHint(
                 // Place hints on column of first character minus 1.
                 // TODO: this depends on what language server returns.
                 new vscode.Position(h.position.line, h.position.character - 1),
                 h.label,
-                this.getVsCodeInlayHintKind(h.kind)
+                this.CppToVsCodeInlayHintKind(h.kind)
             );
             inlayHint.paddingRight = true;
             if (inlayHint.kind === vscode.InlayHintKind.Type) {
@@ -104,15 +115,16 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
                 paramHints.push(inlayHint);
             }
         });
-        if (typeHints.length > 0 || paramHints.length > 0) {
-            cacheEntry = { FileVersion: results.fileVersion,
-                TypeHints: typeHints, ParameterHints: paramHints };
-        }
+        const cacheEntry: InlayHintsCacheEntry = {
+            FileVersion: results.fileVersion,
+            TypeHints: typeHints,
+            ParameterHints: paramHints
+        };
         return cacheEntry;
     }
 
-    private getHintsBasedOnSettings(cacheEntry: InlayHintsCacheEntry) : vscode.InlayHint[] {
+    private getHintsBasedOnSettings(cacheEntry: InlayHintsCacheEntry): vscode.InlayHint[] {
         // TODO: rename function and return hint kinds based on settings.
-        return cacheEntry?.TypeHints.concat(cacheEntry?.ParameterHints)
+        return cacheEntry?.TypeHints.concat(cacheEntry?.ParameterHints);
     }
 }

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -100,10 +100,16 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
         const showRefEnabled: boolean = true; // TODO: get from settings
         const hideParamNameEnabled: boolean = false; // TODO: get from settings
         hints.forEach((h: CppInlayHint) => {
-            const refString: string = (showRefEnabled && h.isValueRef) ? "& " : "";
+            // Build parameter label based on settings.
             // TODO: remove label if param includes parameter name or in comments.
-            const paramName: string = hideParamNameEnabled /* && h.hasParamName*/ ? "" : h.label;
-            const label: string = refString + paramName + ":";
+            const paramName: string = (hideParamNameEnabled /* && h.hasParamName*/) ? "" : h.label;
+            let refString: string = "";
+            if (showRefEnabled && h.isValueRef) {
+                refString = (paramName.length > 0) ? "& " : "&";
+            }
+            const colonString: string = (paramName.length > 0 || refString.length > 0) ? ":" : "";
+            const label: string = refString + paramName + colonString;
+
             const inlayHint: vscode.InlayHint = new vscode.InlayHint(
                 new vscode.Position(h.position.line, h.position.character),
                 label,

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -67,11 +67,11 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
                 if (cacheEntry) {
                     this.cache.set(uriString, cacheEntry);
                     return this.getHintsBasedOnSettings(cacheEntry);
-                } else {
-                    // Force another request because file versions do not match.
-                    // TODO: verify this works when data is available.
-                    this.onDidChangeInlayHintsEvent.fire();
                 }
+            } else {
+                // Force another request because file versions do not match.
+                // TODO: verify this works when data is available.
+                this.onDidChangeInlayHintsEvent.fire();
             }
         }
         return undefined;

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -1,0 +1,112 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as vscode from 'vscode';
+import { DefaultClient, openFileVersions } from '../client';
+import { Position, RequestType } from 'vscode-languageclient';
+
+interface GetInlayHintsParams {
+    uri: string;
+}
+
+enum CppInlayHintKind {
+    Type = 0,
+    Parameter = 1,
+}
+
+interface CppInlayHint {
+    position: Position;
+    label: string;
+    kind: CppInlayHintKind;
+}
+
+interface GetInlayHintsResult {
+    fileVersion: number;
+    canceled: boolean;
+    inlayHints: CppInlayHint[];
+}
+
+// TODO: either use separate lists or filter
+type InlayHintsCacheEntry = { FileVersion: number, 
+    TypeHints: vscode.InlayHint[], ParameterHints: vscode.InlayHint[] }
+
+const GetInlayHintsRequest: RequestType<GetInlayHintsParams, GetInlayHintsResult, void, void> =
+    new RequestType<GetInlayHintsParams, GetInlayHintsResult, void, void>('cpptools/getInlayHints');
+
+export class InlayHintsProvider implements vscode.InlayHintsProvider {
+    private client: DefaultClient;
+    public onDidChangeInlayHintsEvent = new vscode.EventEmitter<void>();
+    onDidChangeInlayHints?: vscode.Event<void>;
+    private cache: Map<string, InlayHintsCacheEntry> = new Map<string, InlayHintsCacheEntry>();
+
+    constructor(client: DefaultClient) {
+        this.client = client;
+        this.onDidChangeInlayHints = this.onDidChangeInlayHintsEvent.event;
+    }
+
+    public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range, token: vscode.CancellationToken)
+        : Promise<vscode.InlayHint[] | undefined> {
+        await this.client.awaitUntilLanguageClientReady();
+        const uriString: string = document.uri.toString();
+
+        // Get results from cache if available.
+        const cacheEntry: InlayHintsCacheEntry | undefined = this.cache.get(uriString);
+        if (cacheEntry && cacheEntry.FileVersion === document.version) {
+            return this.getHintsBasedOnSettings(cacheEntry);
+        }
+
+        // Get new results from the language server
+        const params: GetInlayHintsParams = { uri: uriString };
+        const inlayHintsResult: GetInlayHintsResult = await this.client.languageClient.sendRequest(GetInlayHintsRequest, params, token);
+        if (inlayHintsResult.canceled || (inlayHintsResult.fileVersion !== openFileVersions.get(uriString))) {
+            throw new vscode.CancellationError();
+        } else {
+            const typeHints: vscode.InlayHint[] | undefined = [];
+            const paramHints: vscode.InlayHint[] | undefined = [];
+            inlayHintsResult.inlayHints.forEach((h: CppInlayHint) => {
+                const inlayHint: vscode.InlayHint = new vscode.InlayHint(
+                    // Place hints on column of first character minus 1.
+                    // TODO: this depends on what language server returns.
+                    new vscode.Position(h.position.line, h.position.character - 1),
+                    h.label,
+                    this.getVsCodeInlayHintKind(h.kind)
+                );
+                inlayHint.paddingRight = true;
+                if (inlayHint.kind === vscode.InlayHintKind.Type) {
+                    typeHints.push(inlayHint);
+                } else if (inlayHint.kind === vscode.InlayHintKind.Parameter) {
+                    paramHints.push(inlayHint);
+                }
+            });
+            const cacheEntry: InlayHintsCacheEntry = {
+                FileVersion: inlayHintsResult.fileVersion,
+                TypeHints: typeHints, ParameterHints: paramHints
+            }
+            this.cache.set(uriString, cacheEntry);
+            return this.getHintsBasedOnSettings(cacheEntry);
+        }
+    }
+
+    public invalidateFile(uri: string): void {
+        this.cache.delete(uri);
+        this.onDidChangeInlayHintsEvent.fire();
+    }
+
+    private getVsCodeInlayHintKind(hintKind: CppInlayHintKind): vscode.InlayHintKind | undefined {
+        switch (hintKind) {
+            case CppInlayHintKind.Type:
+                return vscode.InlayHintKind.Type;
+            case CppInlayHintKind.Parameter:
+                return vscode.InlayHintKind.Parameter;
+            default:
+                break;
+        }
+        return undefined;
+    }
+
+    private getHintsBasedOnSettings(cacheEntry: InlayHintsCacheEntry) : vscode.InlayHint[] {
+        // TODO: rename function and return hint kinds based on settings.
+        return cacheEntry?.TypeHints.concat(cacheEntry?.ParameterHints)
+    }
+}

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -7,7 +7,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-// Importing providers here
+// Start provider imports
 import { OnTypeFormattingEditProvider } from './Providers/onTypeFormattingEditProvider';
 import { FoldingRangeProvider } from './Providers/foldingRangeProvider';
 import { SemanticTokensProvider } from './Providers/semanticTokensProvider';
@@ -18,6 +18,7 @@ import { WorkspaceSymbolProvider } from './Providers/workspaceSymbolProvider';
 import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
+import { InlayHintsProvider } from './Providers/inlayHintProvider';
 // End provider imports
 
 import { LanguageClient, LanguageClientOptions, ServerOptions, NotificationType, TextDocumentIdentifier, RequestType, ErrorAction, CloseAction, DidOpenTextDocumentParams, Range, Position, DocumentFilter } from 'vscode-languageclient';
@@ -534,6 +535,7 @@ const ShowMessageWindowNotification: NotificationType<ShowMessageWindowParams, v
 const ShowWarningNotification: NotificationType<ShowWarningParams, void> = new NotificationType<ShowWarningParams, void>('cpptools/showWarning');
 const ReportTextDocumentLanguage: NotificationType<string, void> = new NotificationType<string, void>('cpptools/reportTextDocumentLanguage');
 const SemanticTokensChanged: NotificationType<string, void> = new NotificationType<string, void>('cpptools/semanticTokensChanged');
+const InlayHintsChanged: NotificationType<string, void> = new NotificationType<string, void>('cpptools/inlayHintsChanged');
 const IntelliSenseSetupNotification: NotificationType<IntelliSenseSetup, void> = new NotificationType<IntelliSenseSetup, void>('cpptools/IntelliSenseSetup');
 const SetTemporaryTextDocumentLanguageNotification: NotificationType<SetTemporaryTextDocumentLanguageParams, void> = new NotificationType<SetTemporaryTextDocumentLanguageParams, void>('cpptools/setTemporaryTextDocumentLanguage');
 const ReportCodeAnalysisProcessedNotification: NotificationType<number, void> = new NotificationType<number, void>('cpptools/reportCodeAnalysisProcessed');
@@ -716,6 +718,8 @@ export class DefaultClient implements Client {
     private onTypeFormattingProviderDisposable: vscode.Disposable | undefined;
     private codeFoldingProvider: FoldingRangeProvider | undefined;
     private codeFoldingProviderDisposable: vscode.Disposable | undefined;
+    private inlayHintsProvider: InlayHintsProvider | undefined;
+    private inlayHintsProviderDisposable: vscode.Disposable | undefined;
     private semanticTokensProvider: SemanticTokensProvider | undefined;
     private semanticTokensProviderDisposable: vscode.Disposable | undefined;
     private innerConfiguration?: configs.CppProperties;
@@ -922,6 +926,12 @@ export class DefaultClient implements Client {
                         if (settings.enhancedColorization && this.semanticTokensLegend) {
                             this.semanticTokensProvider = new SemanticTokensProvider(this);
                             this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(this.documentSelector, this.semanticTokensProvider, this.semanticTokensLegend);
+                        }
+                        // TODO: enable based on settings.
+                        const isInlayHintsEnabled = false;
+                        if (isInlayHintsEnabled) {
+                            this.inlayHintsProvider = new InlayHintsProvider(this);
+                            this.inlayHintsProviderDisposable = vscode.languages.registerInlayHintsProvider(this.documentSelector, this.inlayHintsProvider);
                         }
                         // Listen for messages from the language server.
                         this.registerNotifications();
@@ -1626,7 +1636,9 @@ export class DefaultClient implements Client {
         if (this.semanticTokensProvider) {
             this.semanticTokensProvider.invalidateFile(uri);
         }
-
+        if (this.inlayHintsProvider) {
+            this.inlayHintsProvider.invalidateFile(uri);
+        }
         openFileVersions.delete(uri);
     }
 
@@ -2160,6 +2172,7 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(ShowWarningNotification, showWarning);
         this.languageClient.onNotification(ReportTextDocumentLanguage, (e) => this.setTextDocumentLanguage(e));
         this.languageClient.onNotification(SemanticTokensChanged, (e) => this.semanticTokensProvider?.invalidateFile(e));
+        this.languageClient.onNotification(InlayHintsChanged, (e) => this.inlayHintsProvider?.invalidateFile(e));
         this.languageClient.onNotification(IntelliSenseSetupNotification, (e) => this.logIntellisenseSetupTime(e));
         this.languageClient.onNotification(SetTemporaryTextDocumentLanguageNotification, (e) => this.setTemporaryTextDocumentLanguage(e));
         this.languageClient.onNotification(ReportCodeAnalysisProcessedNotification, (e) => this.updateCodeAnalysisProcessed(e));
@@ -3126,6 +3139,10 @@ export class DefaultClient implements Client {
         if (this.semanticTokensProviderDisposable) {
             this.semanticTokensProviderDisposable.dispose();
             this.semanticTokensProviderDisposable = undefined;
+        }
+        if (this.inlayHintsProviderDisposable) {
+            this.inlayHintsProviderDisposable.dispose();
+            this.inlayHintsProviderDisposable = undefined;
         }
         this.model.dispose();
     }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -928,7 +928,7 @@ export class DefaultClient implements Client {
                             this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(this.documentSelector, this.semanticTokensProvider, this.semanticTokensLegend);
                         }
                         // TODO: enable based on settings.
-                        const isInlayHintsEnabled: boolean = false;
+                        const isInlayHintsEnabled: boolean = true;
                         if (isInlayHintsEnabled) {
                             this.inlayHintsProvider = new InlayHintsProvider(this);
                             this.inlayHintsProviderDisposable = vscode.languages.registerInlayHintsProvider(this.documentSelector, this.inlayHintsProvider);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -928,7 +928,7 @@ export class DefaultClient implements Client {
                             this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(this.documentSelector, this.semanticTokensProvider, this.semanticTokensLegend);
                         }
                         // TODO: enable based on settings.
-                        const isInlayHintsEnabled = false;
+                        const isInlayHintsEnabled: boolean = false;
                         if (isInlayHintsEnabled) {
                             this.inlayHintsProvider = new InlayHintsProvider(this);
                             this.inlayHintsProviderDisposable = vscode.languages.registerInlayHintsProvider(this.documentSelector, this.inlayHintsProvider);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -363,7 +363,7 @@ export function processDelayedDidOpen(document: vscode.TextDocument): boolean {
     return false;
 }
 
-function onDidChangeVisibleTextEditors(editors: vscode.TextEditor[]): void {
+function onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]): void {
     // Process delayed didOpen for any visible editors we haven't seen before
     editors.forEach(editor => {
         if ((editor.document.uri.scheme === "file") && (editor.document.languageId === "c" || editor.document.languageId === "cpp" || editor.document.languageId === "cuda-cpp")) {

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -316,10 +316,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
   integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
-"@types/vscode@1.60.0":
-  version "1.60.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.60.0.tgz#9330c317691b4f53441a18b598768faeeb71618a"
-  integrity sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==
+"@types/vscode@1.65.0":
+  version "1.65.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"
+  integrity sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==
 
 "@types/which@^1.3.2":
   version "1.3.2"


### PR DESCRIPTION
For https://github.com/microsoft/vscode-cpptools/issues/5845.

### This feature will display inlay hints for:
- Auto declaration types.
- Parameter names.
- Reference operator `&` for parameters passed by non-const reference.

### Tasks:
- [x] Gets inlay hints data from language server
- [x] Displays inlay hints
- [x] [separate PR](https://github.com/microsoft/vscode-cpptools/pull/9460): add and support inlay hints settings specific to extension.

## Example
Without inlay hints
![image](https://user-images.githubusercontent.com/38734287/173155708-ebffc041-0f21-4713-a2c5-c10b17e12c6e.png)

With inlay hints for auto type and parameters.
![image](https://user-images.githubusercontent.com/38734287/173155722-e87a7244-6dca-4e03-ae0f-6f93aae6a8f9.png)
