### PR TITLE
Add telemetry for playButton

### DIFF
--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -27,16 +27,18 @@ export enum DebuggerType {
 
 export enum DebuggerEvent {
     debugPanel = "debugPanel",  // F5 or "Run and Debug" Panel
-    playButton = "playButton"   // "Run and Debug" play button
+    playButton = "playButton",   // "Run and Debug" play button
+    addConfigGear = "AddConfigGear"
 }
 
-export enum TaskConfigStatus {
-    recentlyUsed = "Recently Used Task",
+export enum TaskStatus {
+    recentlyUsed = "Recently Used Task", // A configured task that has been used recently.
+
     configured = "Configured Task", // The tasks that are configured in tasks.json file.
     detected = "Detected Task"      // The tasks that are available based on detected compilers.
 }
 
-export enum DebugConfigSource {
+export enum ConfigSource {
     singleFile = "singleFile",              // a debug config defined for a single mode file
     workspaceFolder = "workspaceFolder",    // a debug config defined in launch.json
     workspace = "workspace",                // a debug config defined in workspace level
@@ -44,12 +46,25 @@ export enum DebugConfigSource {
     unknown = "unknown"
 }
 
+export enum ConfigMode {
+    launchConfig = "launchConfig",
+    noLaunchConfig = "noLaunchConfig",
+    unknown = "unknown"
+}
+
+export enum DebugType {
+    debug = "debug",
+    run = "run"
+}
+
 export interface CppDebugConfiguration extends vscode.DebugConfiguration {
     detail?: string;
-    taskStatus?: TaskConfigStatus;
+    taskStatus?: TaskStatus;
     isDefault?: boolean; // The debug configuration is considered as default, if the prelaunch task is set as default.
-    source?: DebugConfigSource;
+    configSource?: ConfigSource;
     debuggerEvent?: DebuggerEvent;
+    debugType?: DebugType;
+    existing?: boolean;
 }
 
 export interface IConfigurationSnippet {

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -226,8 +226,8 @@ export class CppBuildTaskProvider implements TaskProvider {
         return buildTasksJson.filter((task: CppBuildTask) => task !== null);
     }
 
-    public async writeDefaultBuildTask(taskLabel: string): Promise<void> {
-        return this.writeBuildTask(taskLabel, true);
+    public async writeDefaultBuildTask(taskLabel: string, workspaceFolder?: WorkspaceFolder): Promise<void> {
+        return this.writeBuildTask(taskLabel, workspaceFolder, true);
     }
 
     public async isExistingTask(taskLabel: string, workspaceFolder?: WorkspaceFolder): Promise<boolean> {
@@ -239,8 +239,8 @@ export class CppBuildTaskProvider implements TaskProvider {
         return rawTasksJson.tasks.find((task: any) => task.label && task.label === taskLabel);
     }
 
-    public async writeBuildTask(taskLabel: string, setAsDefault: boolean = false): Promise<void> {
-        const rawTasksJson: any = await this.getRawTasksJson();
+    public async writeBuildTask(taskLabel: string, workspaceFolder?: WorkspaceFolder, setAsDefault: boolean = false): Promise<void> {
+        const rawTasksJson: any = await this.getRawTasksJson(workspaceFolder);
         if (!rawTasksJson.tasks) {
             rawTasksJson.tasks = new Array();
         }


### PR DESCRIPTION
Add telemetry
Add telemetry for "Add Configuration"
fix single-mode file bug

New Telemetry style:

**three telemetry event names:** 
- `debugPanel`   // F5 or "Run and Debug" debug panel
- `playButton`    // "Run and Debug" play button
- `addConfigGear`     // the gear icon

**debugType:**  `debug`, `run`

**configSource:** `singleFile`, `workspaceFolder`, `workspace`, `global`, `unknown`

**configMode:** `launchConfig`, `noLaunchConfig`

**cancelled**: `true`/`false`
**success**: `true`/`false` 