### PR TITLE
Remove legacyCompilerArgsBehavior deprecation.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2670,8 +2670,7 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%c_cpp.configuration.legacyCompilerArgsBehavior.markdownDescription%",
-          "scope": "resource",
-          "deprecationMessage": "%c_cpp.configuration.legacyCompilerArgsBehavior.deprecationMessage%"
+          "scope": "resource"
         }
       }
     },


### PR DESCRIPTION
The setting is hard to discover, i.e. hidden, if it's deprecated (no autocomplete or visibility in the settings UI).