### PR TITLE
Update cmake language package in README

### DIFF
--- a/ExtensionPack/README.md
+++ b/ExtensionPack/README.md
@@ -3,7 +3,7 @@
 This extension pack includes a set of popular extensions for C++ development in Visual Studio Code:
 * [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 * [C/C++ Themes](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-themes)
-* [CMake](https://marketplace.visualstudio.com/items?itemName=twxs.cmake)
+* [CMake](https://marketplace.visualstudio.com/items?itemName=josetr.cmake-language-support-vscode)
 * [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
 * [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen)
 * [Better C++ Syntax](https://marketplace.visualstudio.com/items?itemName=jeff-hykin.better-cpp-syntax)

--- a/ExtensionPack/README.md
+++ b/ExtensionPack/README.md
@@ -3,7 +3,7 @@
 This extension pack includes a set of popular extensions for C++ development in Visual Studio Code:
 * [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 * [C/C++ Themes](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-themes)
-* [CMake](https://marketplace.visualstudio.com/items?itemName=josetr.cmake-language-support-vscode)
+* [CMake Language Support](https://marketplace.visualstudio.com/items?itemName=josetr.cmake-language-support-vscode)
 * [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
 * [Doxygen Documentation Generator](https://marketplace.visualstudio.com/items?itemName=cschlosser.doxdocgen)
 * [Better C++ Syntax](https://marketplace.visualstudio.com/items?itemName=jeff-hykin.better-cpp-syntax)


### PR DESCRIPTION
VS Code is recommending that the language support extension bundled with the cmake-tools package has been updated (see https://github.com/microsoft/vscode-cmake-tools/pull/2597). This PR updates the reference in the README from the old to the recommended cmake language extentions.