### PR TITLE
Reduce default C++ inlay hint font size to match VS and potentially reduce confusion

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4034,17 +4034,20 @@
       "[cpp]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true
+        "editor.semanticHighlighting.enabled": true,
+        "editor.inlayHints.fontSize": 11
       },
       "[cuda-cpp]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true
+        "editor.semanticHighlighting.enabled": true,
+        "editor.inlayHints.fontSize": 11
       },
       "[c]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true
+        "editor.semanticHighlighting.enabled": true,
+        "editor.inlayHints.fontSize": 11
       }
     },
     "semanticTokenTypes": [

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4035,19 +4035,19 @@
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
         "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 11
+        "editor.inlayHints.fontSize": 12
       },
       "[cuda-cpp]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
         "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 11
+        "editor.inlayHints.fontSize": 12
       },
       "[c]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
         "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 11
+        "editor.inlayHints.fontSize": 12
       }
     },
     "semanticTokenTypes": [


### PR DESCRIPTION
The smaller font size makes it more obvious that the inlay hint is not actual editor text, and hopefully users will realize that the type data shown is the complete type data (existing type data should be ignored) and not intended to be mentally combined with the existing type data on the left, e.g. in the example below, it's not a pointer to a const, but a const pointer to a non-const int:

![image](https://user-images.githubusercontent.com/19859882/174861727-41ef949f-106a-4a56-95f0-ca707e40afc1.png)
This doesn't affect inlay hints for other languages.

UPDATE: Size 11 seemed slightly too small and the VS UI is in flux, so it seems better to go with 12, which matches the 90% used by editor.codeLensFontSize in VS Code.