### PR TITLE
Contribute breakpoints for the "rust" language

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3953,6 +3953,9 @@
       },
       {
         "language": "cuda"
+      },
+      {
+        "language": "rust"
       }
     ],
     "jsonValidation": [

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2871,7 +2871,8 @@
         "languages": [
           "c",
           "cpp",
-          "cuda-cpp"
+          "cuda-cpp",
+          "rust"
         ],
         "_aiKeyComment": "Ignore 'Property aiKey is not allowed'. See https://github.com/microsoft/vscode/issues/76493",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
@@ -3549,7 +3550,8 @@
         "languages": [
           "c",
           "cpp",
-          "cuda-cpp"
+          "cuda-cpp",
+          "rust"
         ],
         "_aiKeyComment": "Ignore 'Property aiKey is not allowed'. See https://github.com/microsoft/vscode/issues/76493",
         "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",


### PR DESCRIPTION
Since rust code can be debugged with this extension, contribute breakpoints for the "rust" language such that the workaround of "allow breakpoints in all files" is no longer required.