### PR TITLE
Add left padding to "auto" inlay hints with no spaces on the left

### DIFF
--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -22,6 +22,7 @@ interface CppInlayHint {
     inlayHintKind: InlayHintKind;
     isValueRef: boolean;
     hasParamName: boolean;
+    leftPadding: boolean;
 }
 
 interface GetInlayHintsResult {
@@ -130,6 +131,9 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
                     h.label,
                     vscode.InlayHintKind.Type);
                 inlayHint.paddingRight = true;
+                if (h.leftPadding) {
+                    inlayHint.paddingLeft = true;
+                }
                 typeHints.push(inlayHint);
             }
         }

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -131,9 +131,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
                     h.label,
                     vscode.InlayHintKind.Type);
                 inlayHint.paddingRight = true;
-                if (h.leftPadding) {
-                    inlayHint.paddingLeft = true;
-                }
+                inlayHint.paddingLeft = h.leftPadding;
                 typeHints.push(inlayHint);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/9479