### PR TITLE
Revert "Reduce default C++ inlay hint font size 12 to match VS and potentially reduce confusion (#9480)

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4057,20 +4057,17 @@
       "[cpp]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 12
+        "editor.semanticHighlighting.enabled": true
       },
       "[cuda-cpp]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 12
+        "editor.semanticHighlighting.enabled": true
       },
       "[c]": {
         "editor.wordBasedSuggestions": false,
         "editor.suggest.insertMode": "replace",
-        "editor.semanticHighlighting.enabled": true,
-        "editor.inlayHints.fontSize": 12
+        "editor.semanticHighlighting.enabled": true
       }
     },
     "semanticTokenTypes": [


### PR DESCRIPTION
This reverts commit a2683630e0daa2410291f92fd6f8a7ba8bb957f6.