### PR TITLE
Fix duplicate compiler args from custom configurations using cpptools-api <6

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2793,6 +2793,7 @@ export class DefaultClient implements Client {
                     itemConfig.compilerPath = compilerPathAndArgs.compilerPath;
                     if (providerVersion < Version.v6) {
                         itemConfig.compilerArgsLegacy = compilerPathAndArgs.allCompilerArgs;
+                        itemConfig.compilerArgs = undefined;
                     } else {
                         itemConfig.compilerArgs = compilerPathAndArgs.allCompilerArgs;
                     }
@@ -2884,6 +2885,7 @@ export class DefaultClient implements Client {
                 sanitized.compilerPath = compilerPathAndArgs.compilerPath;
                 if (providerVersion < Version.v6) {
                     sanitized.compilerArgsLegacy = compilerPathAndArgs.allCompilerArgs;
+                    sanitized.compilerArgs = undefined;
                 } else {
                     sanitized.compilerArgs = compilerPathAndArgs.allCompilerArgs;
                 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/9531