### PR TITLE
Fix cl.exe being excluded for .c files and c/cpp caching.

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -482,13 +482,13 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         if (fileIsCpp) {
             if (!DebugConfigurationProvider.detectedCppBuildTasks || DebugConfigurationProvider.detectedCppBuildTasks.length === 0) {
                 DebugConfigurationProvider.detectedCppBuildTasks = await cppBuildTaskProvider.getTasks(true);
-                DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCppBuildTasks;
             }
+            DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCppBuildTasks;
         } else {
             if (!DebugConfigurationProvider.detectedCBuildTasks || DebugConfigurationProvider.detectedCBuildTasks.length === 0) {
                 DebugConfigurationProvider.detectedCBuildTasks = await cppBuildTaskProvider.getTasks(true);
-                DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCBuildTasks;
             }
+            DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCBuildTasks;
         }
     }
 

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -38,6 +38,8 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     private assetProvider: IConfigurationAssetProvider;
     // Keep a list of tasks detected by cppBuildTaskProvider.
     private static detectedBuildTasks: CppBuildTask[] = [];
+    private static detectedCppBuildTasks: CppBuildTask[] = [];
+    private static detectedCBuildTasks: CppBuildTask[] = [];
     protected static recentBuildTaskLabel: string;
 
     public constructor(assetProvider: IConfigurationAssetProvider, type: DebuggerType) {
@@ -449,8 +451,44 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     }
 
     private async loadDetectedTasks(): Promise<void> {
-        if (!DebugConfigurationProvider.detectedBuildTasks || DebugConfigurationProvider.detectedBuildTasks.length === 0) {
-            DebugConfigurationProvider.detectedBuildTasks = await cppBuildTaskProvider.getTasks(true);
+        const editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
+        const emptyTasks: CppBuildTask[] = [];
+        if (!editor) {
+            DebugConfigurationProvider.detectedBuildTasks = emptyTasks;
+            return;
+        }
+
+        const fileExt: string = path.extname(editor.document.fileName);
+        if (!fileExt) {
+            DebugConfigurationProvider.detectedBuildTasks = emptyTasks;
+            return;
+        }
+
+        // Don't offer tasks for header files.
+        const isHeader: boolean = util.isHeaderFile (editor.document.uri);
+        if (isHeader) {
+            DebugConfigurationProvider.detectedBuildTasks = emptyTasks;
+            return;
+        }
+
+        // Don't offer tasks if the active file's extension is not a recognized C/C++ extension.
+        const fileIsCpp: boolean = util.isCppFile(editor.document.uri);
+        const fileIsC: boolean = util.isCFile(editor.document.uri);
+        if (!(fileIsCpp || fileIsC)) {
+            DebugConfigurationProvider.detectedBuildTasks = emptyTasks;
+            return;
+        }
+
+        if (fileIsCpp) {
+            if (!DebugConfigurationProvider.detectedCppBuildTasks || DebugConfigurationProvider.detectedCppBuildTasks.length === 0) {
+                DebugConfigurationProvider.detectedCppBuildTasks = await cppBuildTaskProvider.getTasks(true);
+                DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCppBuildTasks;
+            }
+        } else {
+            if (!DebugConfigurationProvider.detectedCBuildTasks || DebugConfigurationProvider.detectedCBuildTasks.length === 0) {
+                DebugConfigurationProvider.detectedCBuildTasks = await cppBuildTaskProvider.getTasks(true);
+                DebugConfigurationProvider.detectedBuildTasks = DebugConfigurationProvider.detectedCBuildTasks;
+            }
         }
     }
 

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -122,10 +122,19 @@ export class CppBuildTaskProvider implements TaskProvider {
         const knownCompilerPathsSet: Set<string> = new Set();
         let knownCompilers: configs.KnownCompiler[] | undefined = await activeClient.getKnownCompilers();
         if (knownCompilers) {
-            const compiler_condition: (info: configs.KnownCompiler) => boolean = info => ((fileIsCpp && !info.isC) || (fileIsC && info.isC)) &&
-                (!isCompilerValid || (!!userCompilerPathAndArgs &&
-                (path.basename(info.path) !== userCompilerPathAndArgs.compilerName))) &&
-                (!isWindows || !info.path.startsWith("/")); // TODO: Add WSL compiler support.
+            const compiler_condition: (info: configs.KnownCompiler) => boolean = info =>
+                (
+                    // Filter out c compilers for cpp files and vice versa, except for cl.exe, which handles both.
+                    path.basename(info.path) === "cl.exe" ||
+                    (fileIsCpp && !info.isC) || (fileIsC && info.isC)
+                ) &&
+                (
+                    !isCompilerValid || (!!userCompilerPathAndArgs &&
+                    (path.basename(info.path) !== userCompilerPathAndArgs.compilerName))
+                ) &&
+                (
+                    !isWindows || !info.path.startsWith("/")
+                ); // TODO: Add WSL compiler support.
             const cl_to_add: configs.KnownCompiler | undefined = userCompilerIsCl ? undefined : knownCompilers.find(info =>
                 ((path.basename(info.path) === "cl.exe") && compiler_condition(info)));
             knownCompilers = knownCompilers.filter(info =>


### PR DESCRIPTION
1. Fix cl.exe build tasks not showing for .c files.
2. Fix .c build tasks being cached for .cpp files (and vice versa).

I hit these bugs while investigating https://github.com/microsoft/vscode-cpptools/discussions/9535 .