### PR TITLE
Fix empty inlay hint error.

### DIFF
--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -121,14 +121,14 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
             if (settings.inlayHintsReferenceOperator && hint.isValueRef) {
                 refOperatorString = (paramHintLabel.length > 0 && settings.inlayHintsReferenceOperatorShowSpace) ? "& " : "&";
             }
-            let label: string = "";
-            if (paramHintLabel.length > 0 || refOperatorString.length > 0) {
-                label = refOperatorString +  paramHintLabel + ":";
+
+            if (paramHintLabel.length <= 0 && refOperatorString.length <= 0) {
+                continue;
             }
 
             const inlayHint: vscode.InlayHint = new vscode.InlayHint(
                 new vscode.Position(hint.position.line, hint.position.character),
-                label,
+                refOperatorString +  paramHintLabel + ":",
                 vscode.InlayHintKind.Parameter);
             inlayHint.paddingRight = true;
             resolvedHints.push(inlayHint);

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -119,10 +119,10 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
             }
             let refOperatorString: string = "";
             if (settings.inlayHintsReferenceOperator && hint.isValueRef) {
-                refOperatorString = (paramHintLabel.length > 0 && settings.inlayHintsReferenceOperatorShowSpace) ? "& " : "&";
+                refOperatorString = (paramHintLabel !== "" && settings.inlayHintsReferenceOperatorShowSpace) ? "& " : "&";
             }
 
-            if (paramHintLabel.length <= 0 && refOperatorString.length <= 0) {
+            if (paramHintLabel === "" && refOperatorString === "") {
                 continue;
             }
 


### PR DESCRIPTION
Fix VS Code warning/errors: "INVALID inlay hint, empty label W {position: W, label: '', kind: 2, paddingRight: true}"

Not sure if it causes a bug but it spams the Debug Console with 200+ cases when debugging.