### PR TITLE
Minor fixes to changelog

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -37,8 +37,8 @@
 ## Version 1.11.5: August 9, 2022
 ## Bug Fixes
 * Fix crash when tag parsing files containing certain string literals. [#9538](https://github.com/microsoft/vscode-cpptools/issues/9538)
-* Fix `llvm-project` parser crash on file: `clang\test\parser\parser_overflow.c`. [#9653](https://github.com/microsoft/vscode-cpptools/issues/9653)
-* Fix `llvm-project` parser crash on file: `libcxx\test\support\test.support\make_string_header.pass.cpp` [#9679](https://github.com/microsoft/vscode-cpptools/issues/9679)
+* Fix `llvm-project` parser crash on file: `clang/test/parser/parser_overflow.c`. [#9653](https://github.com/microsoft/vscode-cpptools/issues/9653)
+* Fix `llvm-project` parser crash on file: `libcxx/test/support/test.support/make_string_header.pass.cpp`. [#9679](https://github.com/microsoft/vscode-cpptools/issues/9679)
 
 ## Version 1.11.4: July 21, 2022
 ## New Features


### PR DESCRIPTION
Adding missing `.`, and updated paths to use forward slashes.