### PR TITLE
Switch to new key format since AIF is retired

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2920,7 +2920,7 @@
           "rust"
         ],
         "_aiKeyComment": "Ignore 'Property aiKey is not allowed'. See https://github.com/microsoft/vscode/issues/76493",
-        "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+        "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
         "variables": {
           "pickProcess": "extension.pickNativeProcess",
           "pickRemoteProcess": "extension.pickRemoteNativeProcess"
@@ -4450,7 +4450,7 @@
           "rust"
         ],
         "_aiKeyComment": "Ignore 'Property aiKey is not allowed'. See https://github.com/microsoft/vscode/issues/76493",
-        "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+        "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
         "variables": {
           "pickProcess": "extension.pickNativeProcess"
         },

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -55,7 +55,7 @@ export class ExperimentationTelemetry implements IExperimentationTelemetry {
 
 let initializationPromise: Promise<IExperimentationService> | undefined;
 let experimentationTelemetry: ExperimentationTelemetry | undefined;
-const appInsightsKey: string = "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217";
+const appInsightsKey: string = "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255";
 
 export function activate(): void {
     try {


### PR DESCRIPTION
AIF keys are being retired. When the new module version `0.6.3` is released they will throw errors. All VS Code core extensions and VS Code core have moved over and we have high confidence in this change