### PR TITLE
Fix debug with IntelliSense engine disabled when there's no existing launch.json

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -383,106 +383,107 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             (!configuredBuildTasks.some(taskJson => (taskJson.definition.label === taskDetected.definition.label))));
         buildTasks = buildTasks.concat(configuredBuildTasks, dedupDetectedBuildTasks);
 
-        if (buildTasks.length === 0) {
-            return [];
-        }
-
         // Filter out build tasks that don't match the currently selected debug configuration type.
-        buildTasks = buildTasks.filter((task: CppBuildTask) => {
-            const command: string = task.definition.command as string;
-            if (!command) {
+        if (buildTasks.length !== 0) {
+            buildTasks = buildTasks.filter((task: CppBuildTask) => {
+                const command: string = task.definition.command as string;
+                if (!command) {
+                    return false;
+                }
+                if (defaultTemplateConfig.name.startsWith("(Windows) ")) {
+                    if (command.startsWith("cl.exe")) {
+                        return true;
+                    }
+                } else {
+                    if (!command.startsWith("cl.exe")) {
+                        return true;
+                    }
+                }
                 return false;
-            }
-            if (defaultTemplateConfig.name.startsWith("(Windows) ")) {
-                if (command.startsWith("cl.exe")) {
-                    return true;
-                }
-            } else {
-                if (!command.startsWith("cl.exe")) {
-                    return true;
-                }
-            }
-            return false;
-        });
+            });
+        }
 
         // Generate new configurations for each build task.
         // Generating a task is async, therefore we must *await* *all* map(task => config) Promises to resolve.
-        let configs: CppDebugConfiguration[] = await Promise.all(buildTasks.map<Promise<CppDebugConfiguration>>(async task => {
-            const definition: CppBuildTaskDefinition = task.definition as CppBuildTaskDefinition;
-            const compilerPath: string = definition.command;
-            const compilerName: string = path.basename(compilerPath);
-            const newConfig: CppDebugConfiguration = { ...defaultTemplateConfig }; // Copy enumerables and properties
-            newConfig.existing = false;
+        let configs: CppDebugConfiguration[] = [];
+        if (buildTasks.length !== 0) {
+            configs = await Promise.all(buildTasks.map<Promise<CppDebugConfiguration>>(async task => {
+                const definition: CppBuildTaskDefinition = task.definition as CppBuildTaskDefinition;
+                const compilerPath: string = definition.command;
+                const compilerName: string = path.basename(compilerPath);
+                const newConfig: CppDebugConfiguration = { ...defaultTemplateConfig }; // Copy enumerables and properties
+                newConfig.existing = false;
 
-            newConfig.name = configPrefix + compilerName + " " + this.buildAndDebugActiveFileStr();
-            newConfig.preLaunchTask = task.name;
-            if (newConfig.type === DebuggerType.cppdbg) {
-                newConfig.externalConsole = false;
-            } else {
-                newConfig.console = "externalTerminal";
-            }
-            const isWindows: boolean = platformInfo.platform === 'win32';
-            // Extract the .exe path from the defined task.
-            const definedExePath: string | undefined = util.findExePathInArgs(task.definition.args);
-            newConfig.program = definedExePath ? definedExePath : util.defaultExePath();
-            // Add the "detail" property to show the compiler path in QuickPickItem.
-            // This property will be removed before writing the DebugConfiguration in launch.json.
-            newConfig.detail = localize("pre.Launch.Task", "preLaunchTask: {0}", task.name);
-            newConfig.taskDetail = task.detail;
-            newConfig.taskStatus = task.existing ?
-                ((task.name === DebugConfigurationProvider.recentBuildTaskLabelStr) ? TaskStatus.recentlyUsed : TaskStatus.configured) :
-                TaskStatus.detected;
-            if (task.isDefault) {
-                newConfig.isDefault = true;
-            }
-            const isCl: boolean = compilerName === "cl.exe";
-            newConfig.cwd = isWindows && !isCl && !process.env.PATH?.includes(path.dirname(compilerPath)) ? path.dirname(compilerPath) : "${fileDirname}";
-
-            return new Promise<CppDebugConfiguration>(resolve => {
-                if (platformInfo.platform === "darwin") {
-                    return resolve(newConfig);
+                newConfig.name = configPrefix + compilerName + " " + this.buildAndDebugActiveFileStr();
+                newConfig.preLaunchTask = task.name;
+                if (newConfig.type === DebuggerType.cppdbg) {
+                    newConfig.externalConsole = false;
                 } else {
-                    let debuggerName: string;
-                    if (compilerName.startsWith("clang")) {
-                        newConfig.MIMode = "lldb";
-                        debuggerName = "lldb-mi";
-                        // Search for clang-8, clang-10, etc.
-                        if ((compilerName !== "clang-cl.exe") && (compilerName !== "clang-cpp.exe")) {
-                            const suffixIndex: number = compilerName.indexOf("-");
-                            if (suffixIndex !== -1) {
-                                const suffix: string = compilerName.substring(suffixIndex);
-                                debuggerName += suffix;
-                            }
-                        }
-                        newConfig.type = DebuggerType.cppdbg;
-                    } else if (compilerName === "cl.exe") {
-                        newConfig.miDebuggerPath = undefined;
-                        newConfig.type = DebuggerType.cppvsdbg;
-                        return resolve(newConfig);
-                    } else {
-                        debuggerName = "gdb";
-                    }
-                    if (isWindows) {
-                        debuggerName = debuggerName.endsWith(".exe") ? debuggerName : (debuggerName + ".exe");
-                    }
-                    const compilerDirname: string = path.dirname(compilerPath);
-                    const debuggerPath: string = path.join(compilerDirname, debuggerName);
-                    if (isWindows) {
-                        newConfig.miDebuggerPath = debuggerPath;
-                        return resolve(newConfig);
-                    } else {
-                        fs.stat(debuggerPath, (err, stats: fs.Stats) => {
-                            if (!err && stats && stats.isFile()) {
-                                newConfig.miDebuggerPath = debuggerPath;
-                            } else {
-                                newConfig.miDebuggerPath = path.join("/usr", "bin", debuggerName);
-                            }
-                            return resolve(newConfig);
-                        });
-                    }
+                    newConfig.console = "externalTerminal";
                 }
-            });
-        }));
+                const isWindows: boolean = platformInfo.platform === 'win32';
+                // Extract the .exe path from the defined task.
+                const definedExePath: string | undefined = util.findExePathInArgs(task.definition.args);
+                newConfig.program = definedExePath ? definedExePath : util.defaultExePath();
+                // Add the "detail" property to show the compiler path in QuickPickItem.
+                // This property will be removed before writing the DebugConfiguration in launch.json.
+                newConfig.detail = localize("pre.Launch.Task", "preLaunchTask: {0}", task.name);
+                newConfig.taskDetail = task.detail;
+                newConfig.taskStatus = task.existing ?
+                    ((task.name === DebugConfigurationProvider.recentBuildTaskLabelStr) ? TaskStatus.recentlyUsed : TaskStatus.configured) :
+                    TaskStatus.detected;
+                if (task.isDefault) {
+                    newConfig.isDefault = true;
+                }
+                const isCl: boolean = compilerName === "cl.exe";
+                newConfig.cwd = isWindows && !isCl && !process.env.PATH?.includes(path.dirname(compilerPath)) ? path.dirname(compilerPath) : "${fileDirname}";
+
+                return new Promise<CppDebugConfiguration>(resolve => {
+                    if (platformInfo.platform === "darwin") {
+                        return resolve(newConfig);
+                    } else {
+                        let debuggerName: string;
+                        if (compilerName.startsWith("clang")) {
+                            newConfig.MIMode = "lldb";
+                            debuggerName = "lldb-mi";
+                            // Search for clang-8, clang-10, etc.
+                            if ((compilerName !== "clang-cl.exe") && (compilerName !== "clang-cpp.exe")) {
+                                const suffixIndex: number = compilerName.indexOf("-");
+                                if (suffixIndex !== -1) {
+                                    const suffix: string = compilerName.substring(suffixIndex);
+                                    debuggerName += suffix;
+                                }
+                            }
+                            newConfig.type = DebuggerType.cppdbg;
+                        } else if (compilerName === "cl.exe") {
+                            newConfig.miDebuggerPath = undefined;
+                            newConfig.type = DebuggerType.cppvsdbg;
+                            return resolve(newConfig);
+                        } else {
+                            debuggerName = "gdb";
+                        }
+                        if (isWindows) {
+                            debuggerName = debuggerName.endsWith(".exe") ? debuggerName : (debuggerName + ".exe");
+                        }
+                        const compilerDirname: string = path.dirname(compilerPath);
+                        const debuggerPath: string = path.join(compilerDirname, debuggerName);
+                        if (isWindows) {
+                            newConfig.miDebuggerPath = debuggerPath;
+                            return resolve(newConfig);
+                        } else {
+                            fs.stat(debuggerPath, (err, stats: fs.Stats) => {
+                                if (!err && stats && stats.isFile()) {
+                                    newConfig.miDebuggerPath = debuggerPath;
+                                } else {
+                                    newConfig.miDebuggerPath = path.join("/usr", "bin", debuggerName);
+                                }
+                                return resolve(newConfig);
+                            });
+                        }
+                    }
+                });
+            }));
+        }
         configs.push(defaultTemplateConfig);
         const existingConfigs: CppDebugConfiguration[] | undefined = this.getLaunchConfigs(folder, type)?.map(config => {
             if (!config.detail && config.preLaunchTask) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/9762

I just moved the code into the "if" blocks...GitHub's diffing isn't handling it well.

Regression compared to 1.8.4. Follow up to https://github.com/microsoft/vscode-cpptools/pull/8876  .

The experience after this fix isn't the same as 1.8.4 because we don't create the launch.json automatically, but the user can use the UI options to generate the launch.json, i.e. click the Open 'launch.json' button option in the dialog box that appears, and then using the Add Configuration button in the bottom right.