### PR TITLE
Ensure workspaceFolderUri contains a uri and not a file path

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2429,7 +2429,7 @@ export class DefaultClient implements Client {
     private onSelectedConfigurationChanged(index: number): void {
         const params: FolderSelectedSettingParams = {
             currentConfiguration: index,
-            workspaceFolderUri: this.RootUri?.toString(),
+            workspaceFolderUri: this.RootUri?.toString()
         };
         this.notifyWhenLanguageClientReady(() => {
             this.languageClient.sendNotification(ChangeSelectedSettingNotification, params);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -660,7 +660,7 @@ export interface Client {
     requestWhenReady<T>(request: () => Thenable<T>): Thenable<T>;
     notifyWhenLanguageClientReady(notify: () => void): void;
     awaitUntilLanguageClientReady(): Thenable<void>;
-    requestSwitchHeaderSource(rootPath: string, fileName: string): Thenable<string>;
+    requestSwitchHeaderSource(rootUri: vscode.Uri, fileName: string): Thenable<string>;
     activeDocumentChanged(document: vscode.TextDocument): Promise<void>;
     restartIntelliSenseForFile(document: vscode.TextDocument): Promise<void>;
     activate(): void;
@@ -2227,10 +2227,10 @@ export class DefaultClient implements Client {
     /**
      * requests to the language server
      */
-    public requestSwitchHeaderSource(rootPath: string, fileName: string): Thenable<string> {
+    public requestSwitchHeaderSource(rootUri: vscode.Uri, fileName: string): Thenable<string> {
         const params: SwitchHeaderSourceParams = {
             switchHeaderSourceFileName: fileName,
-            workspaceFolderUri: this.RootUri?.toString()
+            workspaceFolderUri: rootUri.toString()
         };
         return this.requestWhenReady(() => this.languageClient.sendRequest(SwitchHeaderSourceRequest, params));
     }
@@ -3052,7 +3052,7 @@ class NullClient implements Client {
     requestWhenReady<T>(request: () => Thenable<T>): Thenable<T> { return request(); }
     notifyWhenLanguageClientReady(notify: () => void): void { }
     awaitUntilLanguageClientReady(): Thenable<void> { return Promise.resolve(); }
-    requestSwitchHeaderSource(rootPath: string, fileName: string): Thenable<string> { return Promise.resolve(""); }
+    requestSwitchHeaderSource(rootUri: vscode.Uri, fileName: string): Thenable<string> { return Promise.resolve(""); }
     activeDocumentChanged(document: vscode.TextDocument): Promise<void> { return Promise.resolve(); }
     restartIntelliSenseForFile(document: vscode.TextDocument): Promise<void> { return Promise.resolve(); }
     activate(): void { }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1553,7 +1553,7 @@ export class DefaultClient implements Client {
             const params: QueryTranslationUnitSourceParams = {
                 uri: docUri.toString(),
                 ignoreExisting: !!replaceExisting,
-                workspaceFolderUri: this.RootPath
+                workspaceFolderUri: this.RootUri?.toString()
             };
             const response: QueryTranslationUnitSourceResult = await this.languageClient.sendRequest(QueryTranslationUnitSourceRequest, params);
             if (!response.candidates || response.candidates.length === 0) {
@@ -2230,7 +2230,7 @@ export class DefaultClient implements Client {
     public requestSwitchHeaderSource(rootPath: string, fileName: string): Thenable<string> {
         const params: SwitchHeaderSourceParams = {
             switchHeaderSourceFileName: fileName,
-            workspaceFolderUri: rootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
         return this.requestWhenReady(() => this.languageClient.sendRequest(SwitchHeaderSourceRequest, params));
     }
@@ -2376,7 +2376,7 @@ export class DefaultClient implements Client {
         const params: CppPropertiesParams = {
             configurations: [],
             currentConfiguration: this.configuration.CurrentConfigurationIndex,
-            workspaceFolderUri: this.RootPath,
+            workspaceFolderUri: this.RootUri?.toString(),
             isReady: true
         };
         const settings: CppSettings = new CppSettings(this.RootUri);
@@ -2429,7 +2429,7 @@ export class DefaultClient implements Client {
     private onSelectedConfigurationChanged(index: number): void {
         const params: FolderSelectedSettingParams = {
             currentConfiguration: index,
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString(),
         };
         this.notifyWhenLanguageClientReady(() => {
             this.languageClient.sendNotification(ChangeSelectedSettingNotification, params);
@@ -2445,7 +2445,7 @@ export class DefaultClient implements Client {
     private onCompileCommandsChanged(path: string): void {
         const params: FileChangedParams = {
             uri: vscode.Uri.file(path).toString(),
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
         this.notifyWhenLanguageClientReady(() => this.languageClient.sendNotification(ChangeCompileCommandsNotification, params));
     }
@@ -2520,7 +2520,7 @@ export class DefaultClient implements Client {
 
         const params: CustomConfigurationParams = {
             configurationItems: sanitized,
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
 
         this.languageClient.sendNotification(CustomConfigurationNotification, params);
@@ -2611,7 +2611,7 @@ export class DefaultClient implements Client {
 
         const params: CustomBrowseConfigurationParams = {
             browseConfiguration: sanitized,
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
 
         this.languageClient.sendNotification(CustomBrowseConfigurationNotification, params);
@@ -2620,7 +2620,7 @@ export class DefaultClient implements Client {
     private clearCustomConfigurations(): void {
         this.configurationLogging.clear();
         const params: WorkspaceFolderParams = {
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
         this.notifyWhenLanguageClientReady(() => this.languageClient.sendNotification(ClearCustomConfigurationsNotification, params));
     }
@@ -2628,7 +2628,7 @@ export class DefaultClient implements Client {
     private clearCustomBrowseConfiguration(): void {
         this.browseConfigurationLogging = "";
         const params: WorkspaceFolderParams = {
-            workspaceFolderUri: this.RootPath
+            workspaceFolderUri: this.RootUri?.toString()
         };
         this.notifyWhenLanguageClientReady(() => this.languageClient.sendNotification(ClearCustomBrowseConfigurationNotification, params));
     }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -468,14 +468,14 @@ async function onSwitchHeaderSource(): Promise<void> {
         return;
     }
 
-    let rootPath: string = clients.ActiveClient.RootPath;
+    let rootUri: vscode.Uri | undefined = clients.ActiveClient.RootUri;
     const fileName: string = activeEditor.document.fileName;
 
-    if (!rootPath) {
-        rootPath = path.dirname(fileName); // When switching without a folder open.
+    if (!rootUri) {
+        rootUri = vscode.Uri.file(path.dirname(fileName)); // When switching without a folder open.
     }
 
-    let targetFileName: string = await clients.ActiveClient.requestSwitchHeaderSource(rootPath, fileName);
+    let targetFileName: string = await clients.ActiveClient.requestSwitchHeaderSource(rootUri, fileName);
     // If the targetFileName has a path that is a symlink target of a workspace folder,
     // then replace the RootRealPath with the RootPath (the symlink path).
     let targetFileNameReplaced: boolean = false;


### PR DESCRIPTION
Fixes a crash with multiroot workspaces.

Alternatively, we could pass file paths in some messages and URIs in others. This change sticks with URIs.
