### PR TITLE
Make array settings give a warning for duplicates.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -506,6 +506,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.codeAnalysis.clangTidy.args.markdownDescription%",
           "scope": "resource"
         },
@@ -1059,6 +1060,7 @@
               "zircon-temporary-objects"
             ]
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.codeAnalysis.clangTidy.checks.enabled.markdownDescription%",
           "scope": "resource"
         },
@@ -1606,6 +1608,7 @@
               "zircon-temporary-objects"
             ]
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.codeAnalysis.clangTidy.checks.disabled.markdownDescription%",
           "scope": "resource"
         },
@@ -2387,6 +2390,7 @@
               }
             ]
           },
+          "uniqueItems": true,
           "description": "%c_cpp.configuration.commentContinuationPatterns.description%",
           "scope": "window"
         },
@@ -2433,6 +2437,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.includePath.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2441,6 +2446,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.defines.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2449,6 +2455,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.macFrameworkPath.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2468,6 +2475,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.forcedInclude.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2530,6 +2538,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.compilerArgs.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2587,6 +2596,7 @@
             "type": "string"
           },
           "default": null,
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.browse.path.markdownDescription%",
           "scope": "machine-overridable"
         },
@@ -2606,6 +2616,7 @@
           "items": {
             "type": "string"
           },
+          "uniqueItems": true,
           "markdownDescription": "%c_cpp.configuration.default.systemIncludePath.markdownDescription%",
           "scope": "machine-overridable"
         },


### PR DESCRIPTION
It also makes the dropdown enum selection UI not show duplicates.