### PR TITLE
Add #include <c++> highlighting

### DIFF
--- a/Extension/src/includeCpp.ts
+++ b/Extension/src/includeCpp.ts
@@ -1,0 +1,88 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
+
+const regex: RegExp = /(#)(i)(n)(c)(l)(u)(d)(e)(\s+)(<)([Cc])(\+)(\+)(>)/;
+
+const decorationTypes: (vscode.TextEditorDecorationType | undefined)[] = [
+    // These colors come from the HSV color space. S and V are both 100% and H
+    // H is incremented by 360 / 14 degrees for each color, providing a unique
+    // color for each of the 14 capture groups. The one missing color represents
+    // the space between the include and the header name.
+    "#FF0000",
+    "#FF6D00",
+    "#FFDB00",
+    "#B6FF00",
+    "#49FF00",
+    "#00FF24",
+    "#00FF92",
+    "#00FFFF",
+    undefined,
+    "#4C6AFF", // S changed to 70 to improve contrast
+    "#7F4CFF", // S changed to 70 to improve contrast
+    "#B600FF",
+    "#FF00DB",
+    "#FF006D"
+].map((color: string | undefined) =>
+    color === undefined ? undefined
+        : vscode.window.createTextEditorDecorationType({
+            color,
+            rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed
+        }));
+
+const hoverMessage: vscode.MarkdownString = new vscode.MarkdownString(
+    localize(
+        "includecpp.hover",
+        "[#include <C++>](https://www.includecpp.org/) is a global, inclusive, and diverse community for developers interested in C++."
+    )
+);
+
+function updateDecorationsForEditor(editor: vscode.TextEditor): void {
+    const document: vscode.TextDocument = editor.document;
+    const content: string = document.getText(
+        new vscode.Range(new vscode.Position(0, 0), document.positionAt(4096)));
+    const match: RegExpMatchArray | null = content.match(regex);
+    if (!match || match.index === undefined) {
+        return;
+    }
+
+    let offset: number = match.index;
+    for (let i: number = 1; i < match.length; ++i) {
+        const start: vscode.Position = document.positionAt(offset);
+        offset += match[i].length;
+        const end: vscode.Position = document.positionAt(offset);
+
+        // Subtract one because the regex match array includes the entire match
+        // at index zero.
+        const decoration: vscode.TextEditorDecorationType | undefined =
+            decorationTypes[i - 1];
+        if (decoration) {
+            editor.setDecorations(decoration, [{
+                range: new vscode.Range(start, end),
+                hoverMessage
+            }]);
+        }
+    }
+
+    return;
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+    vscode.workspace.onDidChangeTextDocument((event) => {
+        vscode.window.visibleTextEditors
+            .filter((editor) => editor.document === event.document)
+            .forEach(updateDecorationsForEditor);
+    }, undefined, context.subscriptions);
+    vscode.window.onDidChangeActiveTextEditor(
+        (editor) => { if (editor) { updateDecorationsForEditor(editor); } },
+        undefined, context.subscriptions);
+    vscode.window.visibleTextEditors.forEach(updateDecorationsForEditor);
+}

--- a/Extension/src/includeCpp.ts
+++ b/Extension/src/includeCpp.ts
@@ -41,7 +41,7 @@ const decorationTypes: (vscode.TextEditorDecorationType | undefined)[] = [
 const hoverMessage: vscode.MarkdownString = new vscode.MarkdownString(
     localize(
         "includecpp.hover",
-        "[#include <C++>](https://www.includecpp.org/) is a global, inclusive, and diverse community for developers interested in C++."
+        "[#include <C++>](https://go.microsoft.com/fwlink/?linkid=2209335) is a global, inclusive, and diverse community for developers interested in C++."
     )
 );
 

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -23,6 +23,7 @@ import * as nls from 'vscode-nls';
 import { cppBuildTaskProvider, CppBuildTaskProvider } from './LanguageServer/cppBuildTaskProvider';
 import { getLocaleId, getLocalizedHtmlPath } from './LanguageServer/localization';
 import { disposeOutputChannels, log } from './logger';
+import { activate as activateIncludeCpp } from './includeCpp';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -143,6 +144,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));
     }
+
+    activateIncludeCpp(context);
 
     return cppTools;
 }


### PR DESCRIPTION
Based on this tweet https://twitter.com/timur_audio/status/1172558628987031553

![includecpp](https://user-images.githubusercontent.com/6981284/195667390-55ec39ca-f174-4dcd-93c0-85d4f2d7d9b0.gif)

Changes that should probably be made before this ships:

- Limit highlighting to C++ file types
- Rate limit how often we scan for `#include <c++>` in the file. Although it currently only ever scans the first 4k of the file, it does the scan on every keystroke.