### PR TITLE
Fix theme image paths

### DIFF
--- a/Themes/README.md
+++ b/Themes/README.md
@@ -10,19 +10,19 @@ VS Code has since provided an API for semantic colorization. The C/C++ Extension
 
 Light Theme
 
-![Light Theme 2019 example](./assets/light.png)
+![Light Theme 2019 example](https://github.com/Microsoft/vscode-cpptools/raw/HEAD/Themes/assets/light.png)
 
 Dark Theme
 
-![Dark Theme 2019 example](./assets/dark.png)
+![Dark Theme 2019 example](https://github.com/Microsoft/vscode-cpptools/raw/HEAD/Themes/assets/dark.png)
 
 2017 Light Theme
 
-![2017 Light Theme example](./assets/light2017.png)
+![2017 Light Theme example](https://github.com/Microsoft/vscode-cpptools/raw/HEAD/Themes/assets/light2017.png)
 
 2017 Dark Theme
 
-![2017 Dark Theme example](./assets/dark2017.png)
+![2017 Dark Theme example](https://github.com/Microsoft/vscode-cpptools/raw/HEAD/Themes/assets/dark2017.png)
 
 ## Contributing
 


### PR DESCRIPTION
These had been updated to use relative paths.  It looks like VSCE automatically resolves them to repo URLs.  Unfortunately, that logic assumes the VSIX is being built from the root of the repo, which Themes is not.  So, it got the paths wrong.

I've only added `Themes/` to the paths VSCE generated.  So, the approach (i.e. using the github path, but not a raw content path) is consistent with what seems to be the default behavior for in-repo references.

We should probably move the Themes into their own repo.
