### PR TITLE
Fix issue with call to cpptools-wordexp with invalid arguments

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1012,12 +1012,12 @@ function extractArgs(argsString: string): string[] {
         }
         return result;
     } else {
-        const wordexpResult: any = child_process.execFileSync(getExtensionFilePath("bin/cpptools-wordexp"), [argsString]);
-        if (wordexpResult === undefined) {
-            return [];
-        }
-        const jsonText: string = wordexpResult.toString();
         try {
+            const wordexpResult: any = child_process.execFileSync(getExtensionFilePath("bin/cpptools-wordexp"), [argsString], { shell: false });
+            if (wordexpResult === undefined) {
+                return [];
+            }
+            const jsonText: string = wordexpResult.toString();
             return jsonc.parse(jsonText, undefined, true);
         } catch {
             return [];


### PR DESCRIPTION
There are 2 issues here.
 1. When command line arguments contain invalid shell escaping/content, `cpptools-wordexp` will (intentionally) exit with an error code.  This is translated into an exception by `execFileSync`, which wasn't being caught.
 2. On Alpine linux, despite explicit use of `shell: false` (which is also the default), `execFileSync` will perform shell parsing on arguments (making the invocation of `cpptools-wordexp` redundant).  This appears to be a bug in node or Alpine itself.  This does not occur on non-Alpine linux distros.  This also causes an exception to be thrown from `execFileSync` when the command line args contain invalid shell escaping/content.

Issue 1 is fixed by catching the exception, which also works around the symptoms of 2.  In both cases, the compilerPath will not be usable.

This does not address incorrect command line parsing results on Alpine, as shell parsing is occurring twice.  (This only impacts when a user pastes a full command line into `compilerPath` instead of just the compiler path).  This would be addressed by #9681 , as that would allow us to call `wordexp` directly.