### PR TITLE
Added IAR problem matcher (#10054)

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -280,6 +280,20 @@
           "severity": 4,
           "message": 5
         }
+      },
+      {
+        "name": "iar",
+        "source": "iar",
+        "owner": "cpptools",
+        "fileLocation" : "absolute",
+        "pattern": {
+          "regexp": "^\"(.*?)\",(\\d+)\\s+(?:[Ff]atal\\s+)?([Ww]arning|[Ee]rror)\\[(\\w+\\d+)\\]:\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "severity": 3,
+          "code": 4,
+          "message": 5
+        }
       }
     ],
     "configuration": [


### PR DESCRIPTION
This pull requests adds IAR problem matcher.

Warning example that is generated by IAR compiler:

`"D:\iar_test\main.c",6  Warning[Pe177]: variable "c" was declared but never referenced`

There is one thing that needs to be said (not sure if it is issue or not). By default for some reasons IAR splits the error/warning message over multiple lines, if the message is too long. In such case problem matcher will catch only the first part of the message, for example:
![Code_2022-10-30_23-45-24](https://user-images.githubusercontent.com/11231925/198907918-7ca99344-3aca-4461-a776-8f16c3e74869.png)

However, there is an option that can be passed to IAR - `--no_wrap_diagnostics` in such situation the problem matcher works without any problem.
![Code_2022-10-31_00-49-50](https://user-images.githubusercontent.com/11231925/198907985-3e2638bb-cd04-439c-a4f2-26950b71e25a.png)

I tried to use the multiline problem matcher, however this doesn't look good in my opinion, plus from what I see the IAR message may be split over multiple lines (more than two), so it would be hard or even impossible to implement such problem matcher.

![Code_2022-10-30_23-46-12](https://user-images.githubusercontent.com/11231925/198908016-bee9d063-373a-4855-a809-ef63bece649a.png)

In my opinion best idea is to leave it as in my pull request. If someone want to get the whole message, they should use the `--no_wrap_diagnostics` IAR option.

