### PR TITLE
Added ARMCC/Keil problem matcher (#10054)

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -280,6 +280,23 @@
           "severity": 4,
           "message": 5
         }
+      },
+      {
+        "name": "armcc5",
+        "source": "armcc5",
+        "owner": "cpptools",
+        "fileLocation": [
+          "autoDetect",
+          "${cwd}"
+        ],
+        "pattern": {
+          "regexp": "^\"(.*)?\",\\s+line\\s+(\\d+):\\s+([Ee]rror|[Ww]arning):\\s+#(.*?):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "severity": 3,
+          "code": 4,
+          "message": 5
+        }
       }
     ],
     "configuration": [


### PR DESCRIPTION
This pull requests adds ARMCC (the compiler used by Keil) problem matcher.

Warning example that is generated by ARM compiler:

`"main.c", line 8: Warning:  #177-D: variable "c"  was declared but never referenced`

Worth to note:

There are two version of ARM Compiler. Arm Compiler 5 (also known as ARMCC) and Arm Compiler 6 (also known as ARMClang). The latter is often confused with the first one, this is why I propose to name this matcher "armcc5".

PS. From what i Know the Arm Compiler 6 uses the same warning/error output format as GCC, so I don't think there is a need for additional matcher.