### PR TITLE
Fix buffer size exceeded with NativeAttach

### DIFF
--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -18,15 +18,15 @@ nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFo
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export interface AttachItemsProvider {
-    getAttachItems(): Promise<AttachItem[]>;
+    getAttachItems(token?: vscode.CancellationToken): Promise<AttachItem[]>;
 }
 
 export class AttachPicker {
     constructor(private attachItemsProvider: AttachItemsProvider) { }
 
     // We should not await on this function.
-    public async ShowAttachEntries(): Promise<string | undefined> {
-        return showQuickPick(() => this.attachItemsProvider.getAttachItems());
+    public async ShowAttachEntries(token?: vscode.CancellationToken): Promise<string | undefined> {
+        return showQuickPick(() => this.attachItemsProvider.getAttachItems(token));
     }
 }
 

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -353,7 +353,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             } else {
                 const attachItemsProvider: AttachItemsProvider = NativeAttachItemsProviderFactory.Get();
                 const attacher: AttachPicker = new AttachPicker(attachItemsProvider);
-                processId = await attacher.ShowAttachEntries();
+                processId = await attacher.ShowAttachEntries(token);
             }
 
             if (processId) {

--- a/Extension/src/Debugger/nativeAttach.ts
+++ b/Extension/src/Debugger/nativeAttach.ts
@@ -229,7 +229,12 @@ function spawnChildProcess(command: string, token?: vscode.CancellationToken): P
             process.on('close', (code: number) => {
                 cleanUpCallbacks();
                 if (code !== 0) {
-                    reject(new Error(localize("error.processList.spawn", '"{0}" exited with code: "{1}".', command, code)));
+                    let errorMessage: string = localize("error.processList.spawn", '"{0}" exited with code: "{1}".', command, code);
+                    if (stderr && stderr.length > 0) {
+                        errorMessage += os.EOL;
+                        errorMessage += stderr;
+                    }
+                    reject(new Error(errorMessage));
                     return;
                 }
 


### PR DESCRIPTION
This PR migrates the nativeAttach child_process calls to use 'spawn' instead of 'exec'. This allows the extension to deal with large process listing output via input/output streams instead of using a single hardcoded buffer.

Added support for canceling and timeout if the spawned process does not exit within 30 seconds.

@gregg-miskelly

Fixes: #10107