### PR TITLE
Create declaration or definition feature

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -58,6 +58,7 @@
     "onCommand:C_Cpp.ConfigurationEditUI",
     "onCommand:C_Cpp.ConfigurationSelect",
     "onCommand:C_Cpp.ConfigurationProviderSelect",
+    "onCommand:C_Cpp.CreateDeclarationOrDefinition",
     "onCommand:C_Cpp.SwitchHeaderSource",
     "onCommand:C_Cpp.EnableErrorSquiggles",
     "onCommand:C_Cpp.DisableErrorSquiggles",
@@ -3034,6 +3035,11 @@
         "category": "C/C++"
       },
       {
+        "command": "C_Cpp.CreateDeclarationOrDefinition",
+        "title": "%c_cpp.command.CreateDeclarationOrDefinition.title%",
+        "category": "C/C++"
+      },
+      {
         "command": "C_Cpp.RunCodeAnalysisOnActiveFile",
         "title": "%c_cpp.command.RunCodeAnalysisOnActiveFile.title%",
         "category": "C/C++"
@@ -5298,7 +5304,12 @@
         {
           "command": "C_Cpp.GenerateDoxygenComment",
           "when": "editorLangId == 'c' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled' || editorLangId == 'cpp' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled' || editorLangId == 'cuda-cpp' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled'",
-          "group": "custom2@3"
+          "group": "custom2@4"
+        },
+        {
+          "command": "C_Cpp.CreateDeclarationOrDefinition",
+          "when": "editorLangId == 'c' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled' || editorLangId == 'cpp' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled' || editorLangId == 'cuda-cpp' && config.C_Cpp.intelliSenseEngine != 'disabled' && config.C_Cpp.intelliSenseEngine != 'Disabled'",
+          "group": "custom2@5"
         }
       ],
       "commandPalette": [

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -28,6 +28,7 @@
     "c_cpp.command.generateEditorConfig.title": "Generate EditorConfig contents from VC Format settings",
     "c_cpp.command.GoToNextDirectiveInGroup.title": "Go to next preprocessor directive in conditional group",
     "c_cpp.command.GoToPrevDirectiveInGroup.title": "Go to previous preprocessor directive in conditional group",
+    "c_cpp.command.CreateDeclarationOrDefinition.title": "Create Declaration / Definition",
     "c_cpp.command.RunCodeAnalysisOnActiveFile.title": "Run Code Analysis on Active File",
     "c_cpp.command.RunCodeAnalysisOnOpenFiles.title": "Run Code Analysis on Open Files",
     "c_cpp.command.RunCodeAnalysisOnAllFiles.title": "Run Code Analysis on All Files",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -168,8 +168,6 @@ function publishRefactorDiagnostics(params: PublishRefactorDiagnosticsParams): v
 
     const fileUri: vscode.Uri = vscode.Uri.parse(params.uri);
     diagnosticsCollectionRefactor.set(fileUri, newDiagnostics);
-
-    clients.timeTelemetryCollector.setUpdateRangeTime(fileUri);
 }
 
 interface WorkspaceFolderParams {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -67,6 +67,7 @@ const languageClientCrashTimes: number[] = [];
 let pendingTask: util.BlockingTask<any> | undefined;
 let compilerDefaults: configs.CompilerDefaults;
 let diagnosticsCollectionIntelliSense: vscode.DiagnosticCollection;
+let diagnosticsCollectionRefactor: vscode.DiagnosticCollection;
 
 let workspaceDisposables: vscode.Disposable[] = [];
 export let workspaceReferences: refs.ReferencesManager;
@@ -142,6 +143,33 @@ function publishIntelliSenseDiagnostics(params: PublishIntelliSenseDiagnosticsPa
     diagnosticsCollectionIntelliSense.set(realUri, diagnosticsIntelliSense);
 
     clients.timeTelemetryCollector.setUpdateRangeTime(realUri);
+}
+
+function publishRefactorDiagnostics(params: PublishRefactorDiagnosticsParams): void {
+    if (!diagnosticsCollectionRefactor) {
+        diagnosticsCollectionRefactor = vscode.languages.createDiagnosticCollection(CppSourceStr);
+    }
+
+    const newDiagnostics: vscode.Diagnostic[] = [];
+    params.diagnostics.forEach((d) => {
+        const message: string = getLocalizedString(d.localizeStringParams);
+        const diagnostic: vscode.Diagnostic = new vscode.Diagnostic(makeVscodeRange(d.range), message, d.severity);
+        diagnostic.code = d.code;
+        diagnostic.source = CppSourceStr;
+        if (d.relatedInformation) {
+            diagnostic.relatedInformation = [];
+            for (const info of d.relatedInformation) {
+                diagnostic.relatedInformation.push(new vscode.DiagnosticRelatedInformation(makeVscodeLocation(info.location), info.message));
+            }
+        }
+
+        newDiagnostics.push(diagnostic);
+    });
+
+    const fileUri: vscode.Uri = vscode.Uri.parse(params.uri);
+    diagnosticsCollectionRefactor.set(fileUri, newDiagnostics);
+
+    clients.timeTelemetryCollector.setUpdateRangeTime(fileUri);
 }
 
 interface WorkspaceFolderParams {
@@ -239,6 +267,11 @@ interface IntelliSenseDiagnosticRelatedInformation {
     message: string;
 }
 
+interface RefactorDiagnosticRelatedInformation {
+    location: Location;
+    message: string;
+}
+
 interface IntelliSenseDiagnostic {
     range: Range;
     code?: number;
@@ -247,10 +280,37 @@ interface IntelliSenseDiagnostic {
     relatedInformation?: IntelliSenseDiagnosticRelatedInformation[];
 }
 
+interface RefactorDiagnostic {
+    range: Range;
+    code?: number;
+    severity: vscode.DiagnosticSeverity;
+    localizeStringParams: LocalizeStringParams;
+    relatedInformation?: RefactorDiagnosticRelatedInformation[];
+}
+
 interface PublishIntelliSenseDiagnosticsParams {
     uri: string;
     diagnostics: IntelliSenseDiagnostic[];
 }
+
+interface PublishRefactorDiagnosticsParams {
+    uri: string;
+    diagnostics: RefactorDiagnostic[];
+}
+
+export interface CreateDeclarationOrDefinitionParams {
+    uri: string;
+    range: Range;
+}
+
+export interface CreateDeclarationOrDefinitionResult {
+    changes: { [key: string]: any[] };
+}
+
+// interface TextEdit {
+//     range: Range;
+//     newText: string;
+// }
 
 interface ShowMessageWindowParams {
     type: number;
@@ -475,6 +535,8 @@ export const GetSemanticTokensRequest: RequestType<GetSemanticTokensParams, GetS
 export const FormatDocumentRequest: RequestType<FormatParams, TextEdit[], void> = new RequestType<FormatParams, TextEdit[], void>('cpptools/formatDocument');
 export const FormatRangeRequest: RequestType<FormatParams, TextEdit[], void> = new RequestType<FormatParams, TextEdit[], void>('cpptools/formatRange');
 export const FormatOnTypeRequest: RequestType<FormatParams, TextEdit[], void> = new RequestType<FormatParams, TextEdit[], void>('cpptools/formatOnType');
+const CreateDeclarationOrDefinitionRequest: RequestType<CreateDeclarationOrDefinitionParams, CreateDeclarationOrDefinitionResult, void> = new RequestType<CreateDeclarationOrDefinitionParams, CreateDeclarationOrDefinitionResult, void>('cpptools/createDeclDef');
+//const CreateDeclarationOrDefinitionRequest: RequestType<CreateDeclarationOrDefinitionParams, WorkspaceEdit, void> = new RequestType<CreateDeclarationOrDefinitionParams, WorkspaceEdit, void>('cpptools/createDeclDef');
 const GoToDirectiveInGroupRequest: RequestType<GoToDirectiveInGroupParams, Position | undefined, void> = new RequestType<GoToDirectiveInGroupParams, Position | undefined, void>('cpptools/goToDirectiveInGroup');
 const GenerateDoxygenCommentRequest: RequestType<GenerateDoxygenCommentParams, GenerateDoxygenCommentResult | undefined, void> = new RequestType<GenerateDoxygenCommentParams, GenerateDoxygenCommentResult, void>('cpptools/generateDoxygenComment');
 
@@ -524,6 +586,7 @@ const ReferencesNotification: NotificationType<refs.ReferencesResult> = new Noti
 const ReportReferencesProgressNotification: NotificationType<refs.ReportReferencesProgressNotification> = new NotificationType<refs.ReportReferencesProgressNotification>('cpptools/reportReferencesProgress');
 const RequestCustomConfig: NotificationType<string> = new NotificationType<string>('cpptools/requestCustomConfig');
 const PublishIntelliSenseDiagnosticsNotification: NotificationType<PublishIntelliSenseDiagnosticsParams> = new NotificationType<PublishIntelliSenseDiagnosticsParams>('cpptools/publishIntelliSenseDiagnostics');
+const PublishRefactorDiagnosticsNotification: NotificationType<PublishRefactorDiagnosticsParams> = new NotificationType<PublishRefactorDiagnosticsParams>('cpptools/publishRefactorDiagnostics');
 const ShowMessageWindowNotification: NotificationType<ShowMessageWindowParams> = new NotificationType<ShowMessageWindowParams>('cpptools/showMessageWindow');
 const ShowWarningNotification: NotificationType<ShowWarningParams> = new NotificationType<ShowWarningParams>('cpptools/showWarning');
 const ReportTextDocumentLanguage: NotificationType<string> = new NotificationType<string>('cpptools/reportTextDocumentLanguage');
@@ -691,6 +754,7 @@ export interface Client {
     handleRemoveCodeAnalysisProblems(refreshSquigglesOnSave: boolean, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void>;
     handleFixCodeAnalysisProblems(workspaceEdit: vscode.WorkspaceEdit, refreshSquigglesOnSave: boolean, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void>;
     handleDisableAllTypeCodeAnalysisProblems(code: string, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void>;
+    handleCreateDeclarationOrDefinition(): Promise<void>;
     onInterval(): void;
     dispose(): void;
     addFileAssociations(fileAssociations: string, languageId: string): void;
@@ -1841,6 +1905,7 @@ export class DefaultClient implements Client {
             }
         });
         this.languageClient.onNotification(PublishIntelliSenseDiagnosticsNotification, publishIntelliSenseDiagnostics);
+        this.languageClient.onNotification(PublishRefactorDiagnosticsNotification, publishRefactorDiagnostics);
         RegisterCodeAnalysisNotifications(this.languageClient);
         this.languageClient.onNotification(ShowMessageWindowNotification, showMessageWindow);
         this.languageClient.onNotification(ShowWarningNotification, showWarning);
@@ -2907,6 +2972,54 @@ export class DefaultClient implements Client {
         this.handleRemoveCodeAnalysisProblems(false, identifiersAndUris);
     }
 
+    public async handleCreateDeclarationOrDefinition(): Promise<void> {
+        let range: vscode.Range | undefined;
+        let uri: vscode.Uri| undefined;
+            // range is based on the cursor position.
+            const editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
+            if (editor) {
+                uri = editor.document.uri;
+                if (editor.selection.isEmpty) {
+                    range = new vscode.Range(editor.selection.active, editor.selection.active);
+                } else if (editor.selection.isReversed) {
+                    range = new vscode.Range(editor.selection.active, editor.selection.anchor);
+                } else {
+                    range = new vscode.Range(editor.selection.anchor, editor.selection.active);
+                }
+            }
+        
+        if (uri && range) {
+            const params: CreateDeclarationOrDefinitionParams = {
+                uri: uri.toString(),
+                range: {
+                    start: {
+                        character: range.start.character,
+                        line: range.start.line},
+                    end: {
+                        character: range.end.character,
+                        line: range.end.line}
+                }
+            };
+            const result: CreateDeclarationOrDefinitionResult = await this.languageClient.sendRequest(CreateDeclarationOrDefinitionRequest, params);
+            // TODO: return specific errors info in result.
+            if (result.changes) {
+                const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+                for (const file in result.changes) {
+                    const uri: vscode.Uri = vscode.Uri.file(file);
+                    const edits: vscode.TextEdit[] = [];
+                    for (const edit of result.changes[file]) {
+                        const range: vscode.Range = makeVscodeRange(edit.range);
+                        edits.push(new vscode.TextEdit(range, edit.newText));
+                    }
+                    workspaceEdit.set(uri, edits);
+                };
+                // TODO: If the file requiring edits was not already open, open it?
+                // Apply edit, only if file version has not changed (if was already open).
+                await vscode.workspace.applyEdit(workspaceEdit);
+            }
+        }
+    }
+
     public onInterval(): void {
         // These events can be discarded until the language client is ready.
         // Don't queue them up with this.notifyWhenLanguageClientReady calls.
@@ -3093,6 +3206,7 @@ class NullClient implements Client {
     handleRemoveCodeAnalysisProblems(refreshSquigglesOnSave: boolean, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void> { return Promise.resolve(); }
     handleFixCodeAnalysisProblems(workspaceEdit: vscode.WorkspaceEdit, refreshSquigglesOnSave: boolean, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void> { return Promise.resolve(); }
     handleDisableAllTypeCodeAnalysisProblems(code: string, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void> { return Promise.resolve(); }
+    handleCreateDeclarationOrDefinition(): Promise<void> { return Promise.resolve(); }
     onInterval(): void { }
     dispose(): void {
         this.booleanEvent.dispose();

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -307,11 +307,6 @@ export interface CreateDeclarationOrDefinitionResult {
     changes: { [key: string]: any[] };
 }
 
-// interface TextEdit {
-//     range: Range;
-//     newText: string;
-// }
-
 interface ShowMessageWindowParams {
     type: number;
     localizeStringParams: LocalizeStringParams;
@@ -2288,7 +2283,7 @@ export class DefaultClient implements Client {
                 return false;
             });
         },
-        () => ask.Value = false);
+            () => ask.Value = false);
     }
 
     /**
@@ -2973,7 +2968,7 @@ export class DefaultClient implements Client {
 
     public async handleCreateDeclarationOrDefinition(): Promise<void> {
         let range: vscode.Range | undefined;
-        let uri: vscode.Uri| undefined;
+        let uri: vscode.Uri | undefined;
         // range is based on the cursor position.
         const editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
         if (editor) {
@@ -2993,10 +2988,12 @@ export class DefaultClient implements Client {
                 range: {
                     start: {
                         character: range.start.character,
-                        line: range.start.line},
+                        line: range.start.line
+                    },
                     end: {
                         character: range.end.character,
-                        line: range.end.line}
+                        line: range.end.line
+                    }
                 }
             };
             const result: CreateDeclarationOrDefinitionResult = await this.languageClient.sendRequest(CreateDeclarationOrDefinitionRequest, params);
@@ -3019,7 +3016,7 @@ export class DefaultClient implements Client {
                 if (modifiedDocument && lastEdit) {
                     await vscode.workspace.applyEdit(workspaceEdit);
                     const selectionRange: vscode.Range = lastEdit.range; // TODO: range should be the new range after text edit was applied.
-                    await vscode.window.showTextDocument(modifiedDocument, {selection: selectionRange});
+                    await vscode.window.showTextDocument(modifiedDocument, { selection: selectionRange });
                 }
             }
         }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2283,7 +2283,7 @@ export class DefaultClient implements Client {
                 return false;
             });
         },
-            () => ask.Value = false);
+        () => ask.Value = false);
     }
 
     /**

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -435,6 +435,7 @@ export function registerCommands(enabled: boolean): void {
     commandDisposables.push(vscode.commands.registerCommand('cpptools.setActiveConfigName', enabled ? onSetActiveConfigName : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.RestartIntelliSenseForFile', enabled ? onRestartIntelliSenseForFile : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.GenerateDoxygenComment', enabled ? onGenerateDoxygenComment : onDisabledCommand));
+    commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CreateDeclarationOrDefinition', enabled ? onCreateDeclarationOrDefinition : onDisabledCommand));
 }
 
 function onDisabledCommand(): void {
@@ -668,6 +669,10 @@ async function onFixAllCodeAnalysisProblems(version: number, workspaceEdit: vsco
 
 async function onDisableAllTypeCodeAnalysisProblems(code: string, identifiersAndUris: CodeAnalysisDiagnosticIdentifiersAndUri[]): Promise<void> {
     getActiveClient().handleDisableAllTypeCodeAnalysisProblems(code, identifiersAndUris);
+}
+
+async function onCreateDeclarationOrDefinition(): Promise<void> {
+    getActiveClient().handleCreateDeclarationOrDefinition();
 }
 
 function onAddToIncludePath(path: string): void {

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -286,111 +286,84 @@
         "hint": "'Bases' are a C++ class type."
     },
     "cm_classes": {
-        "text": "Classes",
-        "hint": "'Classes' are a C++ class type."
+        "text": "Classes"
     },
     "cm_coclasses": {
-        "text": "CoClasses",
-        "hint": "'CoClasses' are a C++ class type."
+        "text": "CoClasses"
     },
     "cm_delegates": {
-        "text": "Delegates",
-        "hint": "'Delegates' are a C++ delegate."
+        "text": "Delegates"
     },
     "cm_enums": {
-        "text": "Enums",
-        "hint": "'Enums' are a C++ enum."
+        "text": "Enums"
     },
     "cm_events": {
-        "text": "Events",
-        "hint": "'Events' are a C++ event."
+        "text": "Events"
     },
     "cm_functions": {
-        "text": "Functions",
-        "hint": "'Functions' are a C++ function."
+        "text": "Functions"
     },
     "cm_importdirectives": {
-        "text": "Import directives",
-        "hint": "'Import directives' are a C++ ."
+        "text": "Import directives"
     },
     "cm_importlibstatements": {
-        "text": "ImportLib statements",
-        "hint": "'ImportLib statements' are a C++ ."
+        "text": "ImportLib statements"
     },
     "cm_importstatements": {
-        "text": "Import statements",
-        "hint": "'Import statements' are a C++ ."
+        "text": "Import statements"
     },
     "cm_includedirectives": {
-        "text": "Include directives",
-        "hint": "'Include directives' are a C++ ."
+        "text": "Include directives"
     },
     "cm_interfaces": {
-        "text": "Interfaces",
-        "hint": "'Interfaces' are a C++ ."
+        "text": "Interfaces"
     },
     "cm_libraries": {
-        "text": "Libraries",
-        "hint": "'Libraries' are a C++ ."
+        "text": "Libraries"
     },
     "cm_macros": {
-        "text": "Macros",
-        "hint": "'Macros' are a C++ ."
+        "text": "Macros"
     },
     "cm_maps": {
-        "text": "Maps",
-        "hint": "'Maps' are a C++ ."
+        "text": "Maps"
     },
     "cm_mapentries": {
-        "text": "Map entries",
-        "hint": "'Map entries' are a C++ ."
+        "text": "Map entries"
     },
     "cm_miscellaneous": {
-        "text": "Miscellaneous",
-        "hint": "'Miscellaneous' are a C++ ."
+        "text": "Miscellaneous"
     },
     "cm_namespaces": {
-        "text": "Namespaces",
-        "hint": "'Namespaces' are a C++ ."
+        "text": "Namespaces"
     },
     "cm_parameters": {
-        "text": "Parameters",
-        "hint": "'Parameters' are a C++ ."
+        "text": "Parameters"
     },
     "cm_properties": {
-        "text": "Properties",
-        "hint": "'Properties' are a C++ ."
+        "text": "Properties"
     },
     "cm_structs": {
-        "text": "Structs",
-        "hint": "'Structs' are a C++ ."
+        "text": "Structs"
     },
     "cm_todo_insert_return": {
-        "text": "TODO: insert return statement here",
-        "hint": "'TODO: insert return statement here' are a C++ ."
+        "text": "TODO: insert return statement here"
     },
     "cm_typedefs": {
-        "text": "Typedefs",
-        "hint": "'Typedefs' are a C++ ."
+        "text": "Typedefs"
     },
     "cm_unions": {
-        "text": "Unions",
-        "hint": "'Unions' are a C++ ."
+        "text": "Unions"
     },
     "cm_usingaliases": {
-        "text": "Using aliases",
-        "hint": "'Using aliases are a C++ ."
+        "text": "Using aliases"
     },
     "cm_usingdirectives": {
-        "text": "Using directives",
-        "hint": "'Using directives' are a C++ ."
+        "text": "Using directives"
     },
     "cm_variables": {
-        "text": "Variables",
-        "hint": "C/C++ variables."
+        "text": "Variables"
     },
     "cm_addfunction": {
-        "text": "Automatic add function",
-        "hint": "Operation to automatically add a function."
+        "text": "Automatic add function"
     }
 }

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -264,5 +264,133 @@
     "file_tag": "File",
     "compiler_default_language_standard_version_old" : "Compiler returned default language standard version: {0}. Since this version is old, will try to use newer version {1} as default.",
     "unexpected_output_from_clang_tidy": "Unexpected output from clang-tidy: {0}. Expected: {1}.",
-    "generate_doxygen_comment": "Generate Doxygen Comment"
+    "generate_doxygen_comment": "Generate Doxygen Comment",
+    "offer_create_declaration": {
+        "text": "Create declaration of {0} in {1}",
+        "hint": "{0} is the name of a C/C++ function, {1} is a file name."
+    },
+    "offer_create_definition": {
+        "text": "Create definition of {0} in {1}",
+        "hint": "{0} is the name of a C/C++ function, {1} is a file name."
+    },
+    "function_definition_not_found": {
+        "text": "Function definition for '{0}' not found.",
+        "hint": "{0} is the name of a C/C++ function."
+    },
+    "cm_attributes": {
+        "text": "Attributes",
+        "hint": "'Attributes' is a C++ specifier."
+    },
+    "cm_bases": {
+        "text": "Bases",
+        "hint": "'Bases' are a C++ class type."
+    },
+    "cm_classes": {
+        "text": "Classes",
+        "hint": "'Classes' are a C++ class type."
+    },
+    "cm_coclasses": {
+        "text": "CoClasses",
+        "hint": "'CoClasses' are a C++ class type."
+    },
+    "cm_delegates": {
+        "text": "Delegates",
+        "hint": "'Delegates' are a C++ delegate."
+    },
+    "cm_enums": {
+        "text": "Enums",
+        "hint": "'Enums' are a C++ enum."
+    },
+    "cm_events": {
+        "text": "Events",
+        "hint": "'Events' are a C++ event."
+    },
+    "cm_functions": {
+        "text": "Functions",
+        "hint": "'Functions' are a C++ function."
+    },
+    "cm_importdirectives": {
+        "text": "Import directives",
+        "hint": "'Import directives' are a C++ ."
+    },
+    "cm_importlibstatements": {
+        "text": "ImportLib statements",
+        "hint": "'ImportLib statements' are a C++ ."
+    },
+    "cm_importstatements": {
+        "text": "Import statements",
+        "hint": "'Import statements' are a C++ ."
+    },
+    "cm_includedirectives": {
+        "text": "Include directives",
+        "hint": "'Include directives' are a C++ ."
+    },
+    "cm_interfaces": {
+        "text": "Interfaces",
+        "hint": "'Interfaces' are a C++ ."
+    },
+    "cm_libraries": {
+        "text": "Libraries",
+        "hint": "'Libraries' are a C++ ."
+    },
+    "cm_macros": {
+        "text": "Macros",
+        "hint": "'Macros' are a C++ ."
+    },
+    "cm_maps": {
+        "text": "Maps",
+        "hint": "'Maps' are a C++ ."
+    },
+    "cm_mapentries": {
+        "text": "Map entries",
+        "hint": "'Map entries' are a C++ ."
+    },
+    "cm_miscellaneous": {
+        "text": "Miscellaneous",
+        "hint": "'Miscellaneous' are a C++ ."
+    },
+    "cm_namespaces": {
+        "text": "Namespaces",
+        "hint": "'Namespaces' are a C++ ."
+    },
+    "cm_parameters": {
+        "text": "Parameters",
+        "hint": "'Parameters' are a C++ ."
+    },
+    "cm_properties": {
+        "text": "Properties",
+        "hint": "'Properties' are a C++ ."
+    },
+    "cm_structs": {
+        "text": "Structs",
+        "hint": "'Structs' are a C++ ."
+    },
+    "cm_todo_insert_return": {
+        "text": "TODO: insert return statement here",
+        "hint": "'TODO: insert return statement here' are a C++ ."
+    },
+    "cm_typedefs": {
+        "text": "Typedefs",
+        "hint": "'Typedefs' are a C++ ."
+    },
+    "cm_unions": {
+        "text": "Unions",
+        "hint": "'Unions' are a C++ ."
+    },
+    "cm_usingaliases": {
+        "text": "Using aliases",
+        "hint": "'Using aliases are a C++ ."
+    },
+    "cm_usingdirectives": {
+        "text": "Using directives",
+        "hint": "'Using directives' are a C++ ."
+    },
+    "cm_variables": {
+        "text": "Variables",
+        "hint": "C/C++ variables."
+    },
+    "cm_addfunction": {
+        "text": "Automatic add function",
+        "hint": "Operation to automatically add a function."
+    }
 }


### PR DESCRIPTION
Add the feature to create a declaration or definition for a function.
Issue ref: #664 

**Current known bugs/limitations:**
- file creation (for example creating a corresponding source file for a header file) is not fully working.
- Created declaration or definition is not formatted.

**Create Definition**
Example: functions that are declared but have no definitions will show a hint on hover that no definition is found. Clicking on the declared function will offer a code action to create a definition for it.

Hint on hover
![image](https://user-images.githubusercontent.com/38734287/201448023-72c1efe9-a18c-4404-9bba-349426f29625.png)

Code action
![image](https://user-images.githubusercontent.com/38734287/201448063-feb70376-4307-46ff-96b1-38437c7200a5.png)

Definition created when code action is executed
![image](https://user-images.githubusercontent.com/38734287/201448077-5f6954ba-3ea9-444d-8dd5-209d839cf543.png)


**Create Declaration**
Example: class member function is defined in a source file but is not declared in the class's header file will offer a code action to create a declaration for it when clicked on.

Code action
![image](https://user-images.githubusercontent.com/38734287/201448458-fd309be8-0fa5-4580-80c7-2e3f5b4efad9.png)

Declaration created when code action is executed
![image](https://user-images.githubusercontent.com/38734287/201448507-71433601-b20c-4db8-a593-47a07c22cb62.png)

