### PR TITLE
Change engine logging and add natvis diagnostics

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -286,7 +286,7 @@
         "name": "iar",
         "source": "iar",
         "owner": "cpptools",
-        "fileLocation" : "absolute",
+        "fileLocation": "absolute",
         "pattern": {
           "regexp": "^\"(.*?)\",(\\d+)\\s+(?:[Ff]atal\\s+)?([Ww]arning|[Ee]rror)\\[(\\w+\\d+)\\]:\\s+(.*)$",
           "file": 1,
@@ -3453,9 +3453,30 @@
                     "default": true
                   },
                   "engineLogging": {
-                    "type": "boolean",
-                    "description": "%c_cpp.debuggers.logging.engineLogging.description%",
-                    "default": false
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "verbose",
+                          "warning",
+                          "error",
+                          "none"
+                        ],
+                        "enumDescriptions": [
+                          "%c_cpp.debuggers.logging.category.verbose.description%",
+                          "%c_cpp.debuggers.logging.category.warning.description%",
+                          "%c_cpp.debuggers.logging.category.error.description%",
+                          "%c_cpp.debuggers.logging.category.none.description%"
+                        ],
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": "none"
+                      },
+                      {
+                        "type": "boolean",
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": false
+                      }
+                    ]
                   },
                   "trace": {
                     "type": "boolean",
@@ -3466,6 +3487,32 @@
                     "type": "boolean",
                     "description": "%c_cpp.debuggers.logging.traceResponse.description%",
                     "default": false
+                  },
+                  "natvisDiagnostics": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "verbose",
+                          "warning",
+                          "error",
+                          "none"
+                        ],
+                        "enumDescriptions": [
+                          "%c_cpp.debuggers.logging.category.verbose.description%",
+                          "%c_cpp.debuggers.logging.category.warning.description%",
+                          "%c_cpp.debuggers.logging.category.error.description%",
+                          "%c_cpp.debuggers.logging.category.none.description%"
+                        ],
+                        "description": "%c_cpp.debuggers.logging.natvisDiagnostics.description%",
+                        "default": "none"
+                      },
+                      {
+                        "type": "boolean",
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": false
+                      }
+                    ]
                   }
                 }
               },
@@ -4194,9 +4241,30 @@
                     "default": true
                   },
                   "engineLogging": {
-                    "type": "boolean",
-                    "description": "%c_cpp.debuggers.logging.engineLogging.description%",
-                    "default": false
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "verbose",
+                          "warning",
+                          "error",
+                          "none"
+                        ],
+                        "enumDescriptions": [
+                          "%c_cpp.debuggers.logging.category.verbose.description%",
+                          "%c_cpp.debuggers.logging.category.warning.description%",
+                          "%c_cpp.debuggers.logging.category.error.description%",
+                          "%c_cpp.debuggers.logging.category.none.description%"
+                        ],
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": "none"
+                      },
+                      {
+                        "type": "boolean",
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": false
+                      }
+                    ]
                   },
                   "trace": {
                     "type": "boolean",
@@ -4207,6 +4275,32 @@
                     "type": "boolean",
                     "description": "%c_cpp.debuggers.logging.traceResponse.description%",
                     "default": false
+                  },
+                  "natvisDiagnostics": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "verbose",
+                          "warning",
+                          "error",
+                          "none"
+                        ],
+                        "enumDescriptions": [
+                          "%c_cpp.debuggers.logging.category.verbose.description%",
+                          "%c_cpp.debuggers.logging.category.warning.description%",
+                          "%c_cpp.debuggers.logging.category.error.description%",
+                          "%c_cpp.debuggers.logging.category.none.description%"
+                        ],
+                        "description": "%c_cpp.debuggers.logging.natvisDiagnostics.description%",
+                        "default": "none"
+                      },
+                      {
+                        "type": "boolean",
+                        "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+                        "default": false
+                      }
+                    ]
                   }
                 }
               },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -396,8 +396,8 @@
     "c_cpp.semanticTokenModifiers.global.description": "Style to use for symbols that are global.",
     "c_cpp.semanticTokenModifiers.local.description": "Style to use for symbols that are local.",
     "c_cpp.debuggers.logging.natvisDiagnostics.description": "Optional flag to determine whether diagnostic natvis messages should be logged to the Debug Console. Defaults to None.",
-    "c_cpp.debuggers.logging.natvisDiagnostics.verbose.description": "Logs that are used for interactive investigation during development. These logs should primarily contain information useful for debugging and have no long-term value.",
-    "c_cpp.debuggers.logging.natvisDiagnostics.warning.description": "Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the application execution to stop.",
-    "c_cpp.debuggers.logging.natvisDiagnostics.error.description": "Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a failure in the current activity, not an application-wide failure.",
-    "c_cpp.debuggers.logging.natvisDiagnostics.none.description": "Not used for writing log messages. Specifies that a logging category should not write any messages."
+    "c_cpp.debuggers.logging.category.verbose.description": "Logs that are used for interactive investigation during development. These logs should primarily contain information useful for debugging and have no long-term value.",
+    "c_cpp.debuggers.logging.category.warning.description": "Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the application execution to stop.",
+    "c_cpp.debuggers.logging.category.error.description": "Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a failure in the current activity, not an application-wide failure.",
+    "c_cpp.debuggers.logging.category.none.description": "Not used for writing log messages. Specifies that a logging category should not write any messages."
 }

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -394,5 +394,10 @@
     "c_cpp.semanticTokenTypes.numberLiteral.description": "Style for C++ user-defined literal numbers.",
     "c_cpp.semanticTokenTypes.stringLiteral.description": "Style for C++ user-defined literal strings.",
     "c_cpp.semanticTokenModifiers.global.description": "Style to use for symbols that are global.",
-    "c_cpp.semanticTokenModifiers.local.description": "Style to use for symbols that are local."
+    "c_cpp.semanticTokenModifiers.local.description": "Style to use for symbols that are local.",
+    "c_cpp.debuggers.logging.natvisDiagnostics.description": "Optional flag to determine whether diagnostic natvis messages should be logged to the Debug Console. Defaults to None.",
+    "c_cpp.debuggers.logging.natvisDiagnostics.verbose.description": "Logs that are used for interactive investigation during development. These logs should primarily contain information useful for debugging and have no long-term value.",
+    "c_cpp.debuggers.logging.natvisDiagnostics.warning.description": "Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the application execution to stop.",
+    "c_cpp.debuggers.logging.natvisDiagnostics.error.description": "Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a failure in the current activity, not an application-wide failure.",
+    "c_cpp.debuggers.logging.natvisDiagnostics.none.description": "Not used for writing log messages. Specifies that a logging category should not write any messages."
 }

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -76,9 +76,30 @@
           "default": true
         },
         "engineLogging": {
-          "type": "boolean",
-          "description": "%c_cpp.debuggers.logging.engineLogging.description%",
-          "default": false
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "verbose",
+                "warning",
+                "error",
+                "none"
+              ],
+              "enumDescriptions": [
+                "%c_cpp.debuggers.logging.category.verbose.description%",
+                "%c_cpp.debuggers.logging.category.warning.description%",
+                "%c_cpp.debuggers.logging.category.error.description%",
+                "%c_cpp.debuggers.logging.category.none.description%"
+              ],
+              "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+              "default": "none"
+            },
+            {
+              "type": "boolean",
+              "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+              "default": false
+            }
+          ]
         },
         "trace": {
           "type": "boolean",
@@ -89,6 +110,32 @@
           "type": "boolean",
           "description": "%c_cpp.debuggers.logging.traceResponse.description%",
           "default": false
+        },
+        "natvisDiagnostics": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "verbose",
+                "warning",
+                "error",
+                "none"
+              ],
+              "enumDescriptions": [
+                "%c_cpp.debuggers.logging.category.verbose.description%",
+                "%c_cpp.debuggers.logging.category.warning.description%",
+                "%c_cpp.debuggers.logging.category.error.description%",
+                "%c_cpp.debuggers.logging.category.none.description%"
+              ],
+              "description": "%c_cpp.debuggers.logging.natvisDiagnostics.description%",
+              "default": "none"
+            },
+            {
+              "type": "boolean",
+              "description": "%c_cpp.debuggers.logging.engineLogging.description%",
+              "default": false
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
This PR adds logging categories to engineLogging and adds in the option for natvisDiagnostics with different categories.

See https://github.com/microsoft/MIEngine/pull/1322