### PR TITLE
Fix selection and formatting for CDD (and extra newlines with clang-format)

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3015,7 +3015,7 @@ export class DefaultClient implements Client {
                     const uri: vscode.Uri = vscode.Uri.file(file);
                     const edits: vscode.TextEdit[] = [];
                     for (const edit of result.changes[file]) {
-                        let range: vscode.Range = makeVscodeRange(edit.range);
+                        const range: vscode.Range = makeVscodeRange(edit.range);
                         if (lastEdit && lastEdit.range.isEqual(range)) {
                             numNewlinesFromPreviousEdits += DefaultClient.countNewlines(lastEdit.newText);
                         }
@@ -3047,7 +3047,7 @@ export class DefaultClient implements Client {
                     const formatOptions: vscode.FormattingOptions = {
                         insertSpaces: settings.editorInsertSpaces ?? true,
                         tabSize: settings.editorTabSize ?? 4
-                    }
+                    };
                     const formatTextEdits: vscode.TextEdit[] | undefined = await vscode.commands.executeCommand<vscode.TextEdit[] | undefined>("vscode.executeFormatRangeProvider", modifiedDocument, formatRange, formatOptions);
                     if (formatTextEdits && formatTextEdits.length > 0) {
                         formatEdits.set(modifiedDocument, formatTextEdits);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3023,15 +3023,13 @@ export class DefaultClient implements Client {
                     }
 
                     // Move the cursor to the new code, accounting for \n or \n\n at the start.
-                    let selectionRange: vscode.Range = lastEdit.range;
+                    let selectionRange: vscode.Range = new vscode.Range(new vscode.Position(lastEdit.range.start.line, 0), new vscode.Position(lastEdit.range.start.line, 0));
                     if (lastEdit.newText.startsWith("\r\n\r\n") || lastEdit.newText.startsWith("\n\n")) {
                         selectionRange = new vscode.Range(new vscode.Position(selectionRange.start.line + 2, 0), new vscode.Position(selectionRange.start.line + 2, 0));
                         numNewlines -= 2;
                     } else if (lastEdit.newText.startsWith("\r\n") || lastEdit.newText.startsWith("\n")) {
                         selectionRange = new vscode.Range(new vscode.Position(selectionRange.start.line + 1, 0), new vscode.Position(selectionRange.start.line + 1, 0));
                         numNewlines -= 1;
-                    } else {
-                        selectionRange = new vscode.Range(new vscode.Position(selectionRange.start.line, 0), new vscode.Position(selectionRange.start.line, 0));
                     }
                     await vscode.window.showTextDocument(modifiedDocument, { selection: selectionRange });
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3028,6 +3028,10 @@ export class DefaultClient implements Client {
                         startLine += 1;
                         numNewlines -= 1;
                     }
+                    if (!lastEdit.newText.endsWith("\n")) {
+                        numNewlines++; // Increase the format range.
+                    }
+
                     const selectionPosition: vscode.Position = new vscode.Position(startLine + numNewlinesFromPreviousEdits, 0);
                     const selectionRange: vscode.Range = new vscode.Range(selectionPosition, selectionPosition);
                     await vscode.window.showTextDocument(modifiedDocument, { selection: selectionRange });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/10161, https://github.com/microsoft/vscode-cpptools/issues/10160.

Also https://github.com/microsoft/vscode-cpptools/issues/10164 for clang-format due to a by-product of its extra newline removal).