### PR TITLE
Check for the file version before formatting after CDD.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3028,7 +3028,7 @@ export class DefaultClient implements Client {
         if (modifiedDocument === undefined || lastEdit === undefined) {
             return;
         }
-        
+
         await vscode.workspace.applyEdit(workspaceEdit);
         let numNewlines: number = (lastEdit.newText.match(/\n/g) || []).length;
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cpptools/issues/10203

Check if the document version is modified before applying the formatting edit.

Also, replaced all the nested "ifs" with early returns since the nesting was getting large.