### PR TITLE
Fix document corruption due to delayed evaluation in protocolFilter

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Fix clang-tidy and clang-format not working on CentOS7 and other Linux OS's without glibc 2.27 or greater. [#10019](https://github.com/microsoft/vscode-cpptools/issues/10019)
 * Fix various bugs with the `C_Cpp.codeAnalysis.clangTidy.headerFilter` setting. [#10023](https://github.com/microsoft/vscode-cpptools/issues/10023)
 * Fix Doxygen comment generation when there's a selection. [#10028](https://github.com/microsoft/vscode-cpptools/issues/10028)
+* Fix issue that could cause document corruption. [#10035](https://github.com/microsoft/vscode-cpptools/issues/10035)
 * Fixed crash on Linux/Mac when a full command line is specified in `compilerPath` containing invalid arguments. [PR #10070](https://github.com/microsoft/vscode-cpptools/pull/10070)
 * Fix random "Failed to spawn IntelliSense process: 65520" on Mac. [#10091](https://github.com/microsoft/vscode-cpptools/issues/10091)
 * Fix "Don't hardcode path to kill in UnixUtilities". [#10124](https://github.com/microsoft/vscode-cpptools/issues/10124)


### PR DESCRIPTION
This should address https://github.com/microsoft/vscode-cpptools/issues/10035 as well as some document corruption issues related to CDD.

The issue arose in protocolFilter.ts due to use of deferred lambdas.  That caused some TypeScript objects to be re-evaluated later, when the message was actually sent, instead of within the protocolFilter handler at the time the message was intended to be processed.  For example, when processing a `didChange` message, the `TextDocument` has a particular document version number, but we would get a more recent version number when `sendMessage` was actually called after deferred through `notifyWhenLanguageClientReady`.  The mismatching version numbers resulted in incorrect management of the contents of the buffer cache in the native process.

It doesn't seem necessary to defer using `notifyWhenLanguageClientReady`, as the protocolFilter would not be processing messages if it were not ready to.

I also removed the call to `processDelayedDidOpen` from `didChange`, as it could attempt to defer as well.  This was a failsafe anyway.  We should not be getting calls to `didChange` without having previously processed a `didOpen` (delayed or otherwise).  If we did, that would seem to indicate a more serious issue elsewhere.

Alternatively, this perhaps could have been addressed using `await` with the protocol handler, as those can now be async.  However, I expect that could be vulnerable to deadlock.  For example: If it were to try to wait for message B before allowing delivery of message A to complete, that would deadlock the queue.  Instead, the logic within protocolFilter should be careful to ensure that `sendMessage` occurs in a synchronous manner before returning.
