### PR TITLE
Remove deferring from protocolFilter

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -92,7 +92,13 @@ export function createProtocolFilter(): Middleware {
         },
         provideCompletionItem: invoke4,
         resolveCompletionItem: invoke2,
-        provideHover: invoke3,
+        provideHover: (document, position, token, next: (document: any, position: any, token: any) => any) => {
+            const me: Client = clients.getClientFor(document.uri);
+            if (me.TrackedDocuments.has(document)) {
+                return next(document, position, token);
+            }
+            return null;
+        },
         provideSignatureHelp: invoke4,
         provideDefinition: invoke3,
         provideReferences: invoke4,

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -13,12 +13,10 @@ import { clients, onDidChangeActiveTextEditor } from './extension';
 
 export function createProtocolFilter(): Middleware {
     // Disabling lint for invoke handlers
-    const defaultHandler: (data: any, callback: (data: any) => Promise<void>) => Promise<void> = async (data, callback: (data: any) => void) => { clients.ActiveClient.notifyWhenLanguageClientReady(() => callback(data)); };
-    // const invoke1 = async (a: any, next: (a: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a); };
-    const invoke2 = async (a: any, b: any, next: (a: any, b: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b); };
-    const invoke3 = async (a: any, b: any, c: any, next: (a: any, b: any, c: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b, c); };
-    const invoke4 = async (a: any, b: any, c: any, d: any, next: (a: any, b: any, c: any, d: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b, c, d); };
-    // const invoke5 = async (a: any, b: any, c: any, d: any, e: any, next: (a: any, b: any, c: any, d: any, e: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b, c, d, e); };
+    const invoke1 = async (a: any, next: (a: any) => any) => next(a);
+    const invoke2 = async (a: any, b: any, next: (a: any, b: any) => any) => next(a, b);
+    const invoke3 = async (a: any, b: any, c: any, next: (a: any, b: any, c: any) => any) => next(a, b, c);
+    const invoke4 = async (a: any, b: any, c: any, d: any, next: (a: any, b: any, c: any, d: any) => any) => next(a, b, c, d);
     /* tslint:enable */
 
     return {
@@ -34,9 +32,9 @@ export function createProtocolFilter(): Middleware {
                     clients.timeTelemetryCollector.setDidOpenTime(document.uri);
                     if (clients.checkOwnership(me, document)) {
                         me.TrackedDocuments.add(document);
-                        const finishDidOpen = (doc: vscode.TextDocument) => {
-                            me.provideCustomConfiguration(doc.uri, undefined);
-                            sendMessage(doc);
+                        const finishDidOpen = async (doc: vscode.TextDocument) => {
+                            await me.provideCustomConfiguration(doc.uri, undefined);
+                            await sendMessage(doc);
                             me.onDidOpenTextDocument(doc);
                             if (editor && editor === vscode.window.activeTextEditor) {
                                 onDidChangeActiveTextEditor(editor);
@@ -50,14 +48,13 @@ export function createProtocolFilter(): Middleware {
                                 const mappingString: string = fileName + "@" + document.uri.fsPath;
                                 me.addFileAssociations(mappingString, "cpp");
                                 me.sendDidChangeSettings();
-                                vscode.languages.setTextDocumentLanguage(document, "cpp").then((newDoc: vscode.TextDocument) => {
-                                    finishDidOpen(newDoc);
-                                });
+                                const newDoc: vscode.TextDocument = await vscode.languages.setTextDocumentLanguage(document, "cpp");
+                                await finishDidOpen(newDoc);
                                 languageChanged = true;
                             }
                         }
                         if (!languageChanged) {
-                            finishDidOpen(document);
+                            await finishDidOpen(document);
                         }
                     }
                 }
@@ -74,45 +71,35 @@ export function createProtocolFilter(): Middleware {
         didChange: async (textDocumentChangeEvent, sendMessage) => {
             const me: Client = clients.getClientFor(textDocumentChangeEvent.document.uri);
             me.onDidChangeTextDocument(textDocumentChangeEvent);
-            sendMessage(textDocumentChangeEvent);
+            await sendMessage(textDocumentChangeEvent);
         },
-        willSave: defaultHandler,
+        willSave: invoke1,
         willSaveWaitUntil: async (event, sendMessage) => {
             const me: Client = clients.getClientFor(event.document.uri);
             if (me.TrackedDocuments.has(event.document)) {
-                // Don't use me.requestWhenReady or notifyWhenLanguageClientReady;
-                // otherwise, the message can be delayed too long.
                 return sendMessage(event);
             }
-            return Promise.resolve([]);
+            return [];
         },
-        didSave: defaultHandler,
+        didSave: invoke1,
         didClose: async (document, sendMessage) => {
             const me: Client = clients.getClientFor(document.uri);
             if (me.TrackedDocuments.has(document)) {
                 me.onDidCloseTextDocument(document);
                 me.TrackedDocuments.delete(document);
-                sendMessage(document);
+                await sendMessage(document);
             }
         },
-
         provideCompletionItem: invoke4,
         resolveCompletionItem: invoke2,
-        provideHover: (document, position, token, next: (document: any, position: any, token: any) => any) => {
-            const me: Client = clients.getClientFor(document.uri);
-            if (clients.checkOwnership(me, document)) {
-                return clients.ActiveClient.requestWhenReady(() => next(document, position, token));
-            }
-            return null;
-        },
+        provideHover: invoke3,
         provideSignatureHelp: invoke4,
         provideDefinition: invoke3,
         provideReferences: invoke4,
         provideDocumentHighlights: invoke3,
-        provideDeclaration: invoke3
-        // I believe the default handler will do the same thing.
-        // workspace: {
-        //     didChangeConfiguration: (sections, sendMessage) => sendMessage(sections)
-        // }
+        provideDeclaration: invoke3,
+        workspace: {
+            didChangeConfiguration: invoke1
+        }
     };
 }


### PR DESCRIPTION
A more complete fix for: https://github.com/microsoft/vscode-cpptools/pull/10227

An issue had occurred with `didChange`, as the `contentChanges` field of the `TextDocumentChangeEvent` can become inconsistent with the `document` field when re-evaluated late.

This change removes most deferring from protocolFilter.  There are still `await`'s that occur prior to processing `didOpen`, but that seems to be OK - it should be valid to process the document passed to `didOpen` at any point.  (The native code will discard any edits that are received for versions prior to the one received from `didOpen`, or when the file is not yet known to be open).  

This fix is based on the assumption that there are no otherwise unhandled order dependencies that must be enforced for these messages.  The original implementation was designed to fundamental ensure all messages are processed serially, and this is removing code that ensured that.  But, so far, I've been unable to identify any issues with these messages potentially occurring out of order relative to internal messages.  These messages all represent actions the user has already performed, operations they want to initiate, etc., that could occur at any time, and therefore their ordering relative to internal messages is already indeterminate.  When edits are involved or could invalidate an operation, we should also already be using the document version to verify the operation and discarding the results of the operation if versions do not match.
