### PR TITLE
Prevent looping between C and C++.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -27,7 +27,7 @@ import { SourceFileConfigurationItem, WorkspaceBrowseConfiguration, SourceFileCo
 import { Status, IntelliSenseStatus } from 'vscode-cpptools/out/testApi';
 import { getLocaleId, getLocalizedString, LocalizeStringParams } from './localization';
 import { Location, TextEdit } from './commonTypes';
-import { makeVscodeRange, makeVscodeLocation } from './utils';
+import { makeVscodeRange, makeVscodeLocation, handleChangedFromCppToC } from './utils';
 import * as util from '../common';
 import * as configs from './configurations';
 import { CppSettings, getEditorConfigSettings, OtherSettings, SettingsParams, WorkspaceFolderSettingsParams } from './settings';
@@ -1934,27 +1934,11 @@ export class DefaultClient implements Client {
         const document: vscode.TextDocument = await vscode.workspace.openTextDocument(params.path);
         if (!!document && document.languageId !== languageId) {
             if (document.languageId === "cpp" && languageId === "c") {
-                if (DefaultClient.shouldChangeFromCToCpp(document)) {
-                    DefaultClient.docsChangedFromCppToC.add(document.fileName);
-                }
+                handleChangedFromCppToC(document);
             }
             vscode.languages.setTextDocumentLanguage(document, languageId);
         }
     }
-
-    // Check this before attempting to switch a document from C to C++.
-    public static shouldChangeFromCToCpp(document: vscode.TextDocument): boolean {
-        if ((document.fileName.endsWith(".C") || document.fileName.endsWith(".H"))) {
-            const cppSettings: CppSettings = new CppSettings();
-            if (cppSettings.autoAddFileAssociations) {
-                return !DefaultClient.docsChangedFromCppToC.has(document.fileName);
-            }
-            // We could potentially add a new setting to enable switching to cpp even when files.associations isn't changed.
-        }
-        return false;
-    }
-
-    private static docsChangedFromCppToC: Set<string> = new Set<string>();
 
     private associations_for_did_change?: Set<string>;
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -342,18 +342,15 @@ export function processDelayedDidOpen(document: vscode.TextDocument): boolean {
                 };
                 let languageChanged: boolean = false;
                 // Work around vscode treating ".C" or ".H" as c, by adding this file name to file associations as cpp
-                if ((document.uri.path.endsWith(".C") || document.uri.path.endsWith(".H")) && document.languageId === "c") {
-                    const cppSettings: CppSettings = new CppSettings();
-                    if (cppSettings.autoAddFileAssociations) {
-                        const fileName: string = path.basename(document.uri.fsPath);
-                        const mappingString: string = fileName + "@" + document.uri.fsPath;
-                        client.addFileAssociations(mappingString, "cpp");
-                        client.sendDidChangeSettings();
-                        vscode.languages.setTextDocumentLanguage(document, "cpp").then((newDoc: vscode.TextDocument) => {
-                            finishDidOpen(newDoc);
-                        });
-                        languageChanged = true;
-                    }
+                if (document.languageId === "c" && DefaultClient.shouldChangeFromCToCpp(document)) {
+                    const baseFileName: string = path.basename(document.fileName);
+                    const mappingString: string = baseFileName + "@" + document.fileName;
+                    client.addFileAssociations(mappingString, "cpp");
+                    client.sendDidChangeSettings();
+                    vscode.languages.setTextDocumentLanguage(document, "cpp").then((newDoc: vscode.TextDocument) => {
+                        finishDidOpen(newDoc);
+                    });
+                    languageChanged = true;
                 }
                 if (!languageChanged) {
                     finishDidOpen(document);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -15,7 +15,7 @@ import { UI, getUI } from './ui';
 import { Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
 import { CodeAnalysisDiagnosticIdentifiersAndUri, CodeActionDiagnosticInfo, codeAnalysisCodeToFixes,
     codeAnalysisFileToCodeActions, codeAnalysisAllFixes } from './codeAnalysis';
-import { makeCpptoolsRange, rangeEquals } from './utils';
+import { makeCpptoolsRange, rangeEquals, shouldChangeFromCToCpp } from './utils';
 import { ClientCollection } from './clientCollection';
 import { CppSettings } from './settings';
 import { PersistentState } from './persistentState';
@@ -342,7 +342,7 @@ export function processDelayedDidOpen(document: vscode.TextDocument): boolean {
                 };
                 let languageChanged: boolean = false;
                 // Work around vscode treating ".C" or ".H" as c, by adding this file name to file associations as cpp
-                if (document.languageId === "c" && DefaultClient.shouldChangeFromCToCpp(document)) {
+                if (document.languageId === "c" && shouldChangeFromCToCpp(document)) {
                     const baseFileName: string = path.basename(document.fileName);
                     const mappingString: string = baseFileName + "@" + document.fileName;
                     client.addFileAssociations(mappingString, "cpp");

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -6,9 +6,10 @@
 
 import * as path from 'path';
 import { Middleware } from 'vscode-languageclient';
-import { Client, DefaultClient } from './client';
+import { Client } from './client';
 import * as vscode from 'vscode';
 import { clients, onDidChangeActiveTextEditor } from './extension';
+import { shouldChangeFromCToCpp } from './utils';
 
 export function createProtocolFilter(): Middleware {
     // Disabling lint for invoke handlers
@@ -42,7 +43,7 @@ export function createProtocolFilter(): Middleware {
                             }
                         };
                         let languageChanged: boolean = false;
-                        if (document.languageId === "c" && DefaultClient.shouldChangeFromCToCpp(document)) {
+                        if (document.languageId === "c" && shouldChangeFromCToCpp(document)) {
                             const baesFileName: string = path.basename(document.fileName);
                             const mappingString: string = baesFileName + "@" + document.fileName;
                             me.addFileAssociations(mappingString, "cpp");

--- a/Extension/src/LanguageServer/utils.ts
+++ b/Extension/src/LanguageServer/utils.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { Range } from 'vscode-languageclient';
 import { Location, TextEdit } from './commonTypes';
+import { CppSettings } from './settings';
 
 export function makeCpptoolsRange(vscRange: vscode.Range): Range {
     return { start: { line: vscRange.start.line, character: vscRange.start.character },
@@ -28,3 +29,24 @@ export function rangeEquals(range1: vscode.Range | Range, range2: vscode.Range |
     return range1.start.line === range2.start.line && range1.start.character === range2.start.character &&
     range1.end.line === range2.end.line && range1.end.character === range2.end.character;
 }
+
+// Check this before attempting to switch a document from C to C++.
+export function shouldChangeFromCToCpp(document: vscode.TextDocument): boolean {
+    if ((document.fileName.endsWith(".C") || document.fileName.endsWith(".H"))) {
+        const cppSettings: CppSettings = new CppSettings();
+        if (cppSettings.autoAddFileAssociations) {
+            return !docsChangedFromCppToC.has(document.fileName);
+        }
+        // We could potentially add a new setting to enable switching to cpp even when files.associations isn't changed.
+    }
+    return false;
+}
+
+// Call this before changing from C++ to C.
+export function handleChangedFromCppToC(document: vscode.TextDocument): void {
+    if (shouldChangeFromCToCpp(document)) {
+        docsChangedFromCppToC.add(document.fileName);
+    }
+}
+
+const docsChangedFromCppToC: Set<string> = new Set<string>();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/9689 (A regression starting with https://github.com/microsoft/vscode-cpptools/releases/tag/1.8.0-insiders triggered by: "Fix an issue in which the language id for header files were not updated to match the source file of its TU. https://github.com/microsoft/vscode-cpptools/issues/8381").

This is the fix method that @Colengms suggested to me.