### PR TITLE
Fix a crash in extractArgs

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -991,7 +991,7 @@ function extractArgs(argsString: string): string[] {
                 }
                 const still_escaping: boolean = (backslashCount % 2) !== 0;
                 if (!reachedEnd && c === '\"') {
-                    backslashCount /= 2;
+                    backslashCount = Math.floor(backslashCount / 2);
                 }
                 while (backslashCount--) {
                     currentArg += '\\';


### PR DESCRIPTION
This code was originally copied from the native side and was based on: https://daviddeley.com/autohotkey/parameters/parameters.htm

In TypeScript, the division by 2 did not result in a whole number, as it does on the native side, leading to a potential infinite loop shortly after when trying to decrement the value down to 0.
