### PR TITLE
Fix issues with didOpen synchronization

### DIFF
--- a/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
@@ -57,8 +57,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         const client: Client = clients.getClientFor(document.uri);
         if (client instanceof DefaultClient) {
             const defaultClient: DefaultClient = <DefaultClient>client;
-            await processDelayedDidOpen(document);
-            await defaultClient.awaitUntilLanguageClientReady();
+            await client.requestWhenReady(() => processDelayedDidOpen(document));
             const params: GetDocumentSymbolRequestParams = {
                 uri: document.uri.toString()
             };

--- a/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
@@ -57,9 +57,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         const client: Client = clients.getClientFor(document.uri);
         if (client instanceof DefaultClient) {
             const defaultClient: DefaultClient = <DefaultClient>client;
-            if (!defaultClient.TrackedDocuments.has(document)) {
-                processDelayedDidOpen(document);
-            }
+            await processDelayedDidOpen(document);
             await defaultClient.awaitUntilLanguageClientReady();
             const params: GetDocumentSymbolRequestParams = {
                 uri: document.uri.toString()

--- a/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
+++ b/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
 import { DefaultClient, GetFoldingRangesParams, GetFoldingRangesRequest, FoldingRangeKind, GetFoldingRangesResult, CppFoldingRange } from '../client';
+import { processDelayedDidOpen } from '../extension';
 import { CppSettings } from '../settings';
 
 export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
@@ -22,6 +23,7 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
         const params: GetFoldingRangesParams = {
             uri: document.uri.toString()
         };
+        await processDelayedDidOpen(document);
         await this.client.awaitUntilLanguageClientReady();
         const response: GetFoldingRangesResult = await this.client.languageClient.sendRequest(GetFoldingRangesRequest, params, token);
         if (token.isCancellationRequested || response.ranges === undefined) {

--- a/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
+++ b/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
@@ -23,8 +23,7 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
         const params: GetFoldingRangesParams = {
             uri: document.uri.toString()
         };
-        await processDelayedDidOpen(document);
-        await this.client.awaitUntilLanguageClientReady();
+        await this.client.requestWhenReady(() => processDelayedDidOpen(document));
         const response: GetFoldingRangesResult = await this.client.languageClient.sendRequest(GetFoldingRangesRequest, params, token);
         if (token.isCancellationRequested || response.ranges === undefined) {
             throw new vscode.CancellationError();

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { DefaultClient, openFileVersions } from '../client';
 import { Position, RequestType } from 'vscode-languageclient';
 import { CppSettings } from '../settings';
+import { processDelayedDidOpen } from '../extension';
 
 interface GetInlayHintsParams {
     uri: string;
@@ -54,6 +55,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
 
     public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range,
         token: vscode.CancellationToken): Promise<vscode.InlayHint[] | undefined> {
+        await processDelayedDidOpen(document);
         await this.client.awaitUntilLanguageClientReady();
         const uriString: string = document.uri.toString();
 

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -55,8 +55,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
 
     public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range,
         token: vscode.CancellationToken): Promise<vscode.InlayHint[] | undefined> {
-        await processDelayedDidOpen(document);
-        await this.client.awaitUntilLanguageClientReady();
+        await this.client.requestWhenReady(() => processDelayedDidOpen(document));
         const uriString: string = document.uri.toString();
 
         // Get results from cache if available.

--- a/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
+++ b/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
@@ -18,8 +18,7 @@ export class SemanticTokensProvider implements vscode.DocumentSemanticTokensProv
     }
 
     public async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
-        await processDelayedDidOpen(document);
-        await this.client.awaitUntilLanguageClientReady();
+        await this.client.requestWhenReady(() => processDelayedDidOpen(document));
         const uriString: string = document.uri.toString();
         // First check the semantic token cache to see if we already have results for that file and version
         const cache: [number, vscode.SemanticTokens] | undefined = this.tokenCaches.get(uriString);

--- a/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
+++ b/Extension/src/LanguageServer/Providers/semanticTokensProvider.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
 import { DefaultClient, GetSemanticTokensParams, GetSemanticTokensRequest, openFileVersions, GetSemanticTokensResult, semanticTokensLegend } from '../client';
+import { processDelayedDidOpen } from '../extension';
 
 export class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
     private client: DefaultClient;
@@ -17,6 +18,7 @@ export class SemanticTokensProvider implements vscode.DocumentSemanticTokensProv
     }
 
     public async provideDocumentSemanticTokens(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SemanticTokens> {
+        await processDelayedDidOpen(document);
         await this.client.awaitUntilLanguageClientReady();
         const uriString: string = document.uri.toString();
         // First check the semantic token cache to see if we already have results for that file and version

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -253,7 +253,6 @@ export class CppProperties {
                     this.isCppPropertiesJsonVisible = true;
                     if (!wasVisible) {
                         this.handleSquiggles();
-
                     }
                 }
             });

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -344,7 +344,7 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
                 }
                 await client.provideCustomConfiguration(document.uri, undefined);
                 client.onDidOpenTextDocument(document);
-                await client.takeOwnership(document);
+                await client.sendDidOpen(document);
                 return true;
             }
         }
@@ -356,8 +356,8 @@ function onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]): v
     // Process delayed didOpen for any visible editors we haven't seen before
     editors.forEach(async (editor) => {
         if ((editor.document.uri.scheme === "file") && (editor.document.languageId === "c" || editor.document.languageId === "cpp" || editor.document.languageId === "cuda-cpp")) {
-            await processDelayedDidOpen(editor.document);
             const client: Client = clients.getClientFor(editor.document.uri);
+            await client.requestWhenReady(() => processDelayedDidOpen(editor.document));
             client.onDidChangeVisibleTextEditor(editor);
         }
     });

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -328,7 +328,6 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
     const client: Client = clients.getClientFor(document.uri);
     if (client) {
         // Log warm start.
-        clients.timeTelemetryCollector.setDidOpenTime(document.uri);
         if (clients.checkOwnership(client, document)) {
             if (!client.TrackedDocuments.has(document)) {
                 // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -11,10 +11,10 @@ import { clients, onDidChangeActiveTextEditor, processDelayedDidOpen } from './e
 
 export function createProtocolFilter(): Middleware {
     // Disabling lint for invoke handlers
-    const invoke1 = async (a: any, next: (a: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a); };
-    const invoke2 = async (a: any, b: any, next: (a: any, b: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b); };
-    const invoke3 = async (a: any, b: any, c: any, next: (a: any, b: any, c: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b, c); };
-    const invoke4 = async (a: any, b: any, c: any, d: any, next: (a: any, b: any, c: any, d: any) => any) => { await clients.ActiveClient.awaitUntilLanguageClientReady(); return next(a, b, c, d); };    /* tslint:enable */
+    const invoke1 = (a: any, next: (a: any) => any): any => clients.ActiveClient.requestWhenReady(() => next(a));
+    const invoke2 = (a: any, b: any, next: (a: any, b: any) => any): any => clients.ActiveClient.requestWhenReady(() => next(a, b));
+    const invoke3 = (a: any, b: any, c: any, next: (a: any, b: any, c: any) => any): any => clients.ActiveClient.requestWhenReady(() => next(a, b, c));
+    const invoke4 = (a: any, b: any, c: any, d: any, next: (a: any, b: any, c: any, d: any) => any): any => clients.ActiveClient.requestWhenReady(() => next(a, b, c, d));
 
     return {
         didOpen: async (document, sendMessage) => {
@@ -38,10 +38,11 @@ export function createProtocolFilter(): Middleware {
             }
         },
         didChange: async (textDocumentChangeEvent, sendMessage) => {
-            await clients.ActiveClient.awaitUntilLanguageClientReady();
-            const me: Client = clients.getClientFor(textDocumentChangeEvent.document.uri);
-            me.onDidChangeTextDocument(textDocumentChangeEvent);
-            await sendMessage(textDocumentChangeEvent);
+            await clients.ActiveClient.requestWhenReady(async () => {
+                const me: Client = clients.getClientFor(textDocumentChangeEvent.document.uri);
+                me.onDidChangeTextDocument(textDocumentChangeEvent);
+                await sendMessage(textDocumentChangeEvent);
+            });
         },
         willSave: invoke1,
         willSaveWaitUntil: async (event, sendMessage) => {
@@ -56,24 +57,25 @@ export function createProtocolFilter(): Middleware {
         },
         didSave: invoke1,
         didClose: async (document, sendMessage) => {
-            await clients.ActiveClient.awaitUntilLanguageClientReady();
-            const me: Client = clients.getClientFor(document.uri);
-            if (me.TrackedDocuments.has(document)) {
-                me.onDidCloseTextDocument(document);
-                me.TrackedDocuments.delete(document);
-                await sendMessage(document);
-            }
+            await clients.ActiveClient.requestWhenReady(async () => {
+                const me: Client = clients.getClientFor(document.uri);
+                if (me.TrackedDocuments.has(document)) {
+                    me.onDidCloseTextDocument(document);
+                    me.TrackedDocuments.delete(document);
+                    await sendMessage(document);
+                }
+            });
         },
         provideCompletionItem: invoke4,
         resolveCompletionItem: invoke2,
-        provideHover: async (document, position, token, next: (document: any, position: any, token: any) => any) => {
-            await clients.ActiveClient.awaitUntilLanguageClientReady();
-            const me: Client = clients.getClientFor(document.uri);
-            if (me.TrackedDocuments.has(document)) {
-                return next(document, position, token);
-            }
-            return null;
-        },
+        provideHover: async (document, position, token, next: (document: any, position: any, token: any) => any) =>
+            clients.ActiveClient.requestWhenReady(async () => {
+                const me: Client = clients.getClientFor(document.uri);
+                if (me.TrackedDocuments.has(document)) {
+                    return next(document, position, token);
+                }
+                return null;
+            }),
         provideSignatureHelp: invoke4,
         provideDefinition: invoke3,
         provideReferences: invoke4,

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -23,7 +23,7 @@ export function createProtocolFilter(): Middleware {
                 // If the file was visible editor when we were activated, we will not get a call to
                 // onDidChangeVisibleTextEditors, so immediately open any file that is visible when we receive didOpen.
                 // Otherwise, we defer opening the file until it's actually visible.
-                await processDelayedDidOpen(document);
+                await clients.ActiveClient.requestWhenReady(() => processDelayedDidOpen(document));
                 if (editor && editor === vscode.window.activeTextEditor) {
                     onDidChangeActiveTextEditor(editor);
                 }


### PR DESCRIPTION
Addresses issues with certain messages (semantic token, inlay hints, and code folding) being delivered before we've processed `didOpen`.

Adds an implicit didOpen for messages that require didOpen to have already occurred.

Updates delayed didOpen processing to use async/await consistently, so processing of didOpen could be more reliably synchronized with.

Always passes `processDelayedDidOpen` through `requestWhenReady` to avoid the potential race conditions that could occur if multiple callers (i.e. providers) tried to call into it at essentially the same time.

Uses `requestWhenReady` in protocolFilter to ensure all async handling in each message handler is included in what is being sequenced.