### PR TITLE
Fix localized strings

### DIFF
--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -404,7 +404,7 @@
     "refactor_create_declaration_definition_failed":
     {
         "text": "Create Declaration / Definition failed: %s",
-        "hint": "The operation 'Create Declaration / Definition' on a function was not successful. %s is the info why it failed."
+        "hint": "The operation 'Create Declaration / Definition' on a function was not successful. %s is the error info that has a period at the end of the string."
     },
     "refactor_create_default_delete":
     {

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -267,7 +267,7 @@
     "file_tag": "File",
     "compiler_default_language_standard_version_old" : "Compiler returned default language standard version: {0}. Since this version is old, will try to use newer version {1} as default.",
     "unexpected_output_from_clang_tidy": "Unexpected output from clang-tidy: {0}. Expected: {1}.",
-    "generate_doxygen_comment": "Generate Doxygen Comment",
+    "generate_doxygen_comment": "Generate Doxygen comment",
     "offer_create_declaration": {
         "text": "Create declaration of '{0}' in {1}",
         "hint": "{0} is the name of a C/C++ function, {1} is a file name."
@@ -371,11 +371,11 @@
     },
     "e_com_virtual_redundant": {
         "text": "vsCMFunctionVirtual is redundant and must not be specified when with vsCMFunctionComMethod.",
-        "hint": "Do not localized 'vsCMFunctionVirtual' and 'vsCMFunctionComMethod', they are code implementation."
+        "hint": "Do not localize 'vsCMFunctionVirtual' and 'vsCMFunctionComMethod', they are code implementation."
     },
     "e_static_com_method": {
         "text": "vsCMFunctionComMethod cannot be static.",
-        "hint": "Do not localized 'vsCMFunctionComMethod', it is code implementation."
+        "hint": "Do not localize 'vsCMFunctionComMethod', it is code implementation."
     },
     "e_invalid_ftype": {
         "text": "Invalid C/C++ file: '%s'.",
@@ -403,8 +403,8 @@
     },
     "refactor_create_declaration_definition_failed":
     {
-        "text": "Create Declaration / Definition failed:",
-        "hint": "The operation 'Create Declaration / Definition' on a function was not successfully."
+        "text": "Create Declaration / Definition failed: %s",
+        "hint": "The operation 'Create Declaration / Definition' on a function was not successful. %s is the info why it failed."
     },
     "refactor_create_default_delete":
     {


### PR DESCRIPTION
- Fix hint text.
- Fix create declaration/definition failed string format.
- Lower case "comment" in code action command "Generate Doxygen comment" as the other commands are sentence case.

Example of updated string.
![image](https://user-images.githubusercontent.com/38734287/216741492-fe237752-7800-4fa4-a09e-73fdeda3c109.png)
