### PR TITLE
Add Ada to the list of supported languages (#10475)

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3146,6 +3146,7 @@
         "type": "cppdbg",
         "label": "C++ (GDB/LLDB)",
         "languages": [
+          "ada",
           "c",
           "cpp",
           "cuda-cpp",
@@ -4893,6 +4894,7 @@
         "label": "C++ (Windows)",
         "when": "workspacePlatform == windows",
         "languages": [
+          "ada",
           "c",
           "cpp",
           "cuda-cpp",
@@ -5289,6 +5291,9 @@
       }
     ],
     "breakpoints": [
+      {
+        "language": "ada"
+      },
       {
         "language": "c"
       },


### PR DESCRIPTION
To allow debugging Ada projects with GDB. Fixes https://github.com/microsoft/vscode-cpptools/issues/10475