### PR TITLE
Fix blank status after a cpptools pause.

### DIFF
--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -207,6 +207,10 @@ export class NewUI implements UI {
     }
 
     private setIsParsingWorkspacePaused(val: boolean): void {
+        if (!this.isParsingFiles && !this.isParsingWorkspace) {
+            // Ignore a pause change if no parsing is actually happening.
+            return;
+        }
         this.isParsingWorkspacePaused = val;
         this.browseEngineStatusBarItem.busy = !val || this.isParsingFiles;
         this.browseEngineStatusBarItem.text = "$(database)";


### PR DESCRIPTION
Fix this blank status:
![image](https://user-images.githubusercontent.com/19859882/217692026-4efacf78-38a8-43b8-a3f4-c3d4748bf42f.png)

Follow up to https://github.com/microsoft/vscode-cpptools/pull/10437
