### PR TITLE
Fix issue with loc pipelines (revert to node 16)

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -24,6 +24,11 @@ pool:
   - ImageOverride -equals AzurePipelinesWindows2022compliant
 
 steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '16.x'
+  displayName: 'Install Node.js'
+
 - task: CmdLine@2
   inputs:
     script: 'cd Extension && yarn install'


### PR DESCRIPTION
Due to https://github.com/microsoft/vscode-nls-dev/issues/47 and our use of webpack, the workaround I had tried in https://github.com/microsoft/vscode-cpptools/pull/10571 isn't going to work for us.

For now, it looks like we can revert the loc pipeline to using Node 16.  When the `vscode-nls-dev` issue is addressed, we can probably apply the other fix.