### PR TITLE
Report the origin of the CreateDeclaration/Definition commands

### DIFF
--- a/Extension/src/LanguageServer/Providers/codeActionProvider.ts
+++ b/Extension/src/LanguageServer/Providers/codeActionProvider.ts
@@ -169,6 +169,9 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                 resultCodeActions.push(...docCodeActions);
                 return;
             }
+            if (command.command === 'C_Cpp.CreateDeclarationOrDefinition' && (command.arguments ?? []).length === 0) {
+                command.arguments = ['codeAction']; // We report the sender of the command
+            }
             const vscodeCodeAction: vscode.CodeAction = {
                 title: title,
                 command: command.command === "edit" ? undefined : {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -487,11 +487,20 @@ export function registerCommands(enabled: boolean): void {
     // ----------------------------------------
 }
 
-async function logForUIExperiment(command: string): Promise<void> {
+function logForUIExperiment(command: string): void {
     const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
     const isNewUI: string = ui.isNewUI.toString();
     const isOverridden: string = (settings.experimentalFeatures ?? false).toString();
     telemetry.logLanguageServerEvent(`experiment${command}`, { newUI: isNewUI, uiOverride: isOverridden });
+}
+
+function getSenderType(sender?: any): string {
+    if (util.isString(sender)) {
+        return sender;
+    } else if (util.isUri(sender)) {
+        return 'contextMenu';
+    }
+    return 'commandPalette';
 }
 
 function onDisabledCommand(): void {
@@ -731,7 +740,11 @@ async function onDisableAllTypeCodeAnalysisProblems(code: string, identifiersAnd
     getActiveClient().handleDisableAllTypeCodeAnalysisProblems(code, identifiersAndUris);
 }
 
-async function onCreateDeclarationOrDefinition(): Promise<void> {
+async function onCreateDeclarationOrDefinition(sender?: any): Promise<void> {
+    const properties: { [key: string]: string } = {
+        sender: getSenderType(sender)
+    };
+    telemetry.logLanguageServerEvent('CreateDeclDefn', properties);
     getActiveClient().handleCreateDeclarationOrDefinition();
 }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -425,7 +425,7 @@ export function registerCommands(enabled: boolean): void {
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CreateDeclarationOrDefinition', enabled ? onCreateDeclarationOrDefinition : onDisabledCommand));
 }
 
-function logForUIExperiment(command: string, sender?: any): Promise<void> {
+function logForUIExperiment(command: string, sender?: any): void {
     const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
     const properties: {[key: string]: string} = {
         newUI: ui.isNewUI.toString(),


### PR DESCRIPTION
When #10581 goes in, I'll update this PR to use the `getSenderType` in `logForUIExperiment`