### PR TITLE
Auto-configure a default custom configuration provider even if `default.compilerPath` is set

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -951,8 +951,6 @@ export class CppProperties {
                 // and there is only 1 registered custom config provider, default to using that provider.
                 const providers: CustomConfigurationProviderCollection = getCustomConfigProviders();
                 const hasEmptyConfiguration: boolean = !this.propertiesFile
-                    && !settings.defaultCompilerPath
-                    && settings.defaultCompilerPath !== ""
                     && !settings.defaultIncludePath
                     && !settings.defaultDefines
                     && !settings.defaultMacFrameworkPath


### PR DESCRIPTION
This logic is intended to auto-configure a detected custom configuration provider if no other configuration information is found.  Since we may now write a compiler to the `default.compilerPath` setting, if needed to identify a trustable compiler, it seems like we should disregard when only that is set when determining whether to automatically use a custom configuration provider.

Whether this is the correct behavior may be open for debate.  For instance, if someone were intentionally using just `default.compilerPath` to configure their environment, this may wind up using a custom configuration provider where they don't want it to.