### PR TITLE
Dispose of cached browse config on dispose if no longer registered.

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -2134,6 +2134,16 @@ export class CppProperties {
     }
 
     dispose(): void {
+        if (this.lastCustomBrowseConfigurationProviderId !== undefined) {
+            const config: Configuration | undefined = this.CurrentConfiguration;
+            if (config !== undefined && config.configurationProvider !== this.lastCustomBrowseConfigurationProviderId.Value) {
+                this.lastCustomBrowseConfigurationProviderId.Value = undefined;
+                if (this.lastCustomBrowseConfiguration !== undefined) {
+                    this.lastCustomBrowseConfiguration.Value = undefined;
+                }
+            }
+        }
+
         this.disposables.forEach((d) => d.dispose());
         this.disposables = [];
 


### PR DESCRIPTION
This was originally intended as an optimization for a race condition at start-up.  If a custom configuration provider had previously been used, but had not yet registered, we were clearing out its headers from the database before shortly thereafter needing to add them back in again once it's registered.  We addressed this by caching the browse configuration for the provider and using it immediately on the next launch.

This change removes the cache at the end of the session, if the configuration provider did not actually register at all.  This avoids a potential security issue, due to execution of a no-longer-desired compilerPath to query for system include paths.