### PR TITLE
Fix possible undefined ui, wrong experimentalFeatures scope access, and duplicate DiagnosticCollection name

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -37,7 +37,7 @@ import { UI, getUI } from './ui';
 import { createProtocolFilter } from './protocolFilter';
 import { DataBinding } from './dataBinding';
 import minimatch = require("minimatch");
-import { updateLanguageConfigurations, CppSourceStr, clients } from './extension';
+import { updateLanguageConfigurations, CppSourceStr, configPrefix, clients } from './extension';
 import { SettingsTracker } from './settingsTracker';
 import { getTestHook, TestHook } from '../testHook';
 import { getCustomConfigProviders, CustomConfigurationProvider1, isSameProviderExtensionId } from '../LanguageServer/customProviders';
@@ -122,7 +122,7 @@ function showMessageWindow(params: ShowMessageWindowParams): void {
 
 function publishIntelliSenseDiagnostics(params: PublishIntelliSenseDiagnosticsParams): void {
     if (!diagnosticsCollectionIntelliSense) {
-        diagnosticsCollectionIntelliSense = vscode.languages.createDiagnosticCollection(CppSourceStr);
+        diagnosticsCollectionIntelliSense = vscode.languages.createDiagnosticCollection(configPrefix + "IntelliSense");
     }
 
     // Convert from our Diagnostic objects to vscode Diagnostic objects
@@ -150,7 +150,7 @@ function publishIntelliSenseDiagnostics(params: PublishIntelliSenseDiagnosticsPa
 
 function publishRefactorDiagnostics(params: PublishRefactorDiagnosticsParams): void {
     if (!diagnosticsCollectionRefactor) {
-        diagnosticsCollectionRefactor = vscode.languages.createDiagnosticCollection(CppSourceStr);
+        diagnosticsCollectionRefactor = vscode.languages.createDiagnosticCollection(configPrefix + "Refactor");
     }
 
     const newDiagnostics: vscode.Diagnostic[] = [];

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -426,7 +426,7 @@ export function registerCommands(enabled: boolean): void {
 }
 
 function logForUIExperiment(command: string, sender?: any): void {
-    const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
+    const settings: CppSettings = new CppSettings();
     const properties: {[key: string]: string} = {
         newUI: ui.isNewUI.toString(),
         uiOverride: (settings.experimentalFeatures ?? false).toString(),

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -491,9 +491,11 @@ async function _getUI(): Promise<UI> {
     if (!ui) {
         const experimentationService: IExperimentationService | undefined = await telemetry.getExperimentationService();
         if (experimentationService !== undefined) {
-            const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
+            const settings: CppSettings = new CppSettings();
             const useNewUI: boolean | undefined = experimentationService.getTreatmentVariable<boolean>("vscode", "ShowLangStatBar");
             ui = useNewUI || settings.experimentalFeatures ? new NewUI() : new OldUI();
+        } else {
+            ui = new NewUI();
         }
     }
     return ui;


### PR DESCRIPTION
Fix Extension Host warning: Accessing a window scoped configuration for a resource is not expected. To associate 'C_Cpp.experimentalFeatures' to a resource, define its scope to 'resource' in configuration contributions in 'package.json'.

And "DiagnosticCollection with name 'C/C++' does already exist."