### PR TITLE
Fix an uncaught exception

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1892,8 +1892,8 @@ export class DefaultClient implements Client {
                     return null;
                 }
             };
-            const configs: SourceFileConfigurationItem[] | null | undefined = await this.callTaskWithTimeout(provideConfigurationAsync, configProviderTimeout, tokenSource);
             try {
+                const configs: SourceFileConfigurationItem[] | null | undefined = await this.callTaskWithTimeout(provideConfigurationAsync, configProviderTimeout, tokenSource);
                 if (configs && configs.length > 0) {
                     this.sendCustomConfigurations(configs, provider.version);
                 }


### PR DESCRIPTION
Addresses an issue reported internally by the WAVE team, in which the call to `callTaskWithTimeout` is resulting in an uncaught exception when it times out.
