### PR TITLE
Fix random failures when adding or removing workspace folders

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix uncaught exception with some configuration providers. [PR #10629](https://github.com/microsoft/vscode-cpptools/pull/10629)
 * Fix bugs with the "You do not have IntelliSense configured" prompt. [#10658](https://github.com/microsoft/vscode-cpptools/issues/10658), [#10659](https://github.com/microsoft/vscode-cpptools/issues/10659)
 * Fix `__GXX_RTTI` incorrectly being defined by IntelliSense with clang and `-fms-compatibility`.
+* Fix random failures when adding or removing workspace folders.
 * Reduce the likelihood of an `onWillSaveWaitUntil` timeout.
 * Fix an IntelliSense crash with C++20 concepts.
 * Stop querying clang-cl.exe as C.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -849,7 +849,7 @@ export class DefaultClient implements Client {
     public get ReferencesCommandModeChanged(): vscode.Event<refs.ReferencesCommandMode> { return this.model.referencesCommandMode.ValueChanged; }
     public get TagParserStatusChanged(): vscode.Event<string> { return this.model.parsingWorkspaceStatus.ValueChanged; }
     public get ActiveConfigChanged(): vscode.Event<string> { return this.model.activeConfigName.ValueChanged; }
-    public isInitialized() : boolean { return this.innerLanguageClient !== undefined; }
+    public isInitialized(): boolean { return this.innerLanguageClient !== undefined; }
 
     /**
      * don't use this.rootFolder directly since it can be undefined

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -791,6 +791,7 @@ export interface Client {
     dispose(): void;
     addFileAssociations(fileAssociations: string, languageId: string): void;
     sendDidChangeSettings(): void;
+    isInitialized(): boolean;
 }
 
 export function createClient(workspaceFolder?: vscode.WorkspaceFolder): Client {
@@ -848,6 +849,7 @@ export class DefaultClient implements Client {
     public get ReferencesCommandModeChanged(): vscode.Event<refs.ReferencesCommandMode> { return this.model.referencesCommandMode.ValueChanged; }
     public get TagParserStatusChanged(): vscode.Event<string> { return this.model.parsingWorkspaceStatus.ValueChanged; }
     public get ActiveConfigChanged(): vscode.Event<string> { return this.model.activeConfigName.ValueChanged; }
+    public isInitialized() : boolean { return this.innerLanguageClient !== undefined; }
 
     /**
      * don't use this.rootFolder directly since it can be undefined
@@ -908,6 +910,10 @@ export class DefaultClient implements Client {
         clients.forEach(client => {
             if (client instanceof DefaultClient) {
                 const defaultClient: DefaultClient = <DefaultClient>client;
+                if (!client.isInitialized()) {
+                    // This can randomly get hit when adding/removing workspace folders.
+                    return;
+                }
                 defaultClient.configuration.CompilerDefaults = compilerDefaults;
                 defaultClient.configuration.handleConfigurationChange();
             }
@@ -3551,4 +3557,5 @@ class NullClient implements Client {
     }
     addFileAssociations(fileAssociations: string, languageId: string): void { }
     sendDidChangeSettings(): void { }
+    isInitialized(): boolean { return true; }
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -332,6 +332,10 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
             if (!client.TrackedDocuments.has(document)) {
                 // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
                 clients.timeTelemetryCollector.setDidOpenTime(document.uri);
+                if (!client.isInitialized()) {
+                    // This can randomly get hit when adding/removing workspace folders.
+                    await client.awaitUntilLanguageClientReady();
+                }
                 client.TrackedDocuments.add(document);
                 // Work around vscode treating ".C" or ".H" as c, by adding this file name to file associations as cpp
                 if (document.languageId === "c" && shouldChangeFromCToCpp(document)) {


### PR DESCRIPTION
i.e. when the client is not initialized yet.

The updateClientConfigurations case is the easiest to repro (it's hit from the 'select default compiler' initialization code in the client constructor):
![image](https://user-images.githubusercontent.com/19859882/224845323-600a912c-67e1-430c-9f85-e54da8fd7aaa.png)

The 2nd one is harder to repro, related to didOpen (not sure the exact repro requirements):
"Attempting to use languageClient before initialized"