### PR TITLE
Call hierarchy feature

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
                 "format": ["PascalCase"]
             }
         ],
-        "@typescript-eslint/indent": "error",
         "@typescript-eslint/member-delimiter-style": [
             "error",
             {

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -1,0 +1,69 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as vscode from 'vscode';
+import { DefaultClient } from '../client';
+import { processDelayedDidOpen } from '../extension';
+
+export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
+    private client: DefaultClient;
+
+    constructor(client: DefaultClient) {
+        this.client = client;
+    }
+
+    public async prepareCallHierarchy(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken):
+    Promise<vscode.CallHierarchyItem | vscode.CallHierarchyItem[] | undefined> {
+        const range: vscode.Range | undefined = document.getWordRangeAtPosition(position);
+        if (range === undefined) {
+            return undefined;
+        }
+
+        const symbol: string = document.getText(range);
+        await this.client.requestWhenReady(() => processDelayedDidOpen(document));
+
+        // Get call items denoted by given document and position
+        // items = await this.client.languageClient.sendRequest(PrepareCallHierarchyRequest, params, token);
+
+        // create a vscode.CallHierarchyItem for each returned call item.
+        const callItemsResult: vscode.CallHierarchyItem[] = [];
+        callItemsResult.push(new vscode.CallHierarchyItem(vscode.SymbolKind.Function, symbol, 'scope name of item', document.uri, range, range));
+
+        return callItemsResult;
+    }
+
+    public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
+    Promise<vscode.CallHierarchyIncomingCall[]> {
+        //await this.client.awaitUntilLanguageClientReady();
+        const incomingCallItemsResult: vscode.CallHierarchyIncomingCall[] = [];
+
+        // Get "call to" items from language server
+        // items = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, token);
+
+        // create a vscode.CallHierarchyIncomingCall for each returned call item.
+        const callItem: vscode.CallHierarchyItem = new vscode.CallHierarchyItem(
+            vscode.SymbolKind.Function, item.name, 'scope name of item', item.uri, item.range, item.selectionRange);
+        const incomingCall: vscode.CallHierarchyIncomingCall = new vscode.CallHierarchyIncomingCall(callItem, []);
+        incomingCallItemsResult.push(incomingCall);
+
+        return incomingCallItemsResult;
+    }
+
+    public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
+    Promise<vscode.CallHierarchyOutgoingCall[]> {
+        //await this.client.awaitUntilLanguageClientReady();
+        const outgoingCallItemsResult: vscode.CallHierarchyOutgoingCall[] = [];
+
+        // Get "call from" items from language server
+        // items = await this.client.languageClient.sendRequest(CallHierarchyCallsFromRequest, params, token);
+
+        // create a vscode.CallHierarchyOutgoingCall for each returned call item.
+        const callItem: vscode.CallHierarchyItem = new vscode.CallHierarchyItem(
+            vscode.SymbolKind.Function, item.name, 'scope name of item', item.uri, item.range, item.selectionRange);
+        const outgoingCall: vscode.CallHierarchyOutgoingCall = new vscode.CallHierarchyOutgoingCall(callItem, []);
+        outgoingCallItemsResult.push(outgoingCall);
+
+        return outgoingCallItemsResult;
+    }
+}

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -50,7 +50,8 @@ interface CallHierarchyItemResult {
     item?: CallHierarchyItem;
 
     /**
-     * If a request is cancelled, `succeeded` will be undefined.
+     * If a request is cancelled, `succeeded` will be undefined to indicate no result was returned.
+     * Therfore, object is not defined as optional on the language server.
      */
     succeeded: boolean;
 }

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -105,6 +105,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         if (token.isCancellationRequested || response.succeeded === undefined) {
             throw new vscode.CancellationError();
         } else if (response.item === undefined) {
+            // TODO: add a message if item is not a function
             return undefined;
         }
 
@@ -146,7 +147,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
             position: Position.create(item.range.start.line, item.range.start.character)
         };
         const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsFromRequest, params, token);
-        if (token.isCancellationRequested || response.calls === undefined ) {
+        if (token.isCancellationRequested || response.calls === undefined) {
             throw new vscode.CancellationError();
         } else if (response.calls.length === 0) {
             return undefined;

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -90,7 +90,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
     }
 
     public async prepareCallHierarchy(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken):
-    Promise<vscode.CallHierarchyItem | undefined> {
+        Promise<vscode.CallHierarchyItem | undefined> {
         const range: vscode.Range | undefined = document.getWordRangeAtPosition(position);
         if (range === undefined) {
             return undefined;
@@ -113,7 +113,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
     }
 
     public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
-    Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
+        Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
         if (item === undefined) {
             return undefined;
         }
@@ -134,7 +134,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
     }
 
     public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
-    Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
+        Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
         if (item === undefined) {
             return undefined;
         }

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -47,7 +47,7 @@ interface CallHierarchyItemParams {
 }
 
 interface CallHierarchyItemResult {
-    item: CallHierarchyItem;
+    item?: CallHierarchyItem;
 }
 
 interface CallHierarchyCallsItem {
@@ -121,7 +121,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         // const response: CallHierarchyCallsResult = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, token);
         // if (token.isCancellationRequested) {
         //     throw new vscode.CancellationError();
-        // } else if (response.calls === undefined || response.calls.size === 0) {
+        // } else if (response.calls === undefined || response.calls.length === 0) {
         //      return undefined;
         // }
 
@@ -168,8 +168,8 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         for (const call of calls) {
             const callHierarchyItem: vscode.CallHierarchyItem = this.makeVscodeCallHierarchyItem(call.item);
             const fromRanges: vscode.Range[] = [];
-            for (const r of call.fromRanges) {
-                fromRanges.push(makeVscodeRange(r));
+            for (const range of call.fromRanges) {
+                fromRanges.push(makeVscodeRange(range));
             }
 
             const outgoingCall: vscode.CallHierarchyOutgoingCall =

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -78,7 +78,7 @@ const CallHierarchyItemRequest: RequestType<CallHierarchyParams, CallHierarchyIt
     new RequestType<CallHierarchyParams, CallHierarchyItemResult, void>('cpptools/prepareCallHierarchy');
 
 const CallHierarchyCallsToRequest: RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void> =
-new RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void>('cpptools/callHierarchyCallsTo');
+    new RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void>('cpptools/callHierarchyCallsTo');
 
 const CallHierarchyCallsFromRequest: RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void> =
     new RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void>('cpptools/callHierarchyCallsFrom');

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -48,6 +48,11 @@ interface CallHierarchyParams {
 
 interface CallHierarchyItemResult {
     item?: CallHierarchyItem;
+
+    /**
+     * If a request is cancelled, `succeeded` will be undefined.
+     */
+    succeeded: boolean;
 }
 
 interface CallHierarchyCallsItem {
@@ -97,7 +102,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
             position: Position.create(position.line, position.character)
         };
         const response: CallHierarchyItemResult = await this.client.languageClient.sendRequest(CallHierarchyItemRequest, params, token);
-        if (token.isCancellationRequested) {
+        if (token.isCancellationRequested || response.succeeded === undefined) {
             throw new vscode.CancellationError();
         } else if (response.item === undefined) {
             return undefined;
@@ -119,9 +124,9 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         //     position: Position.create(item.range.start.line, item.range.start.character)
         // };
         // const response: CallHierarchyCallsResult = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, token);
-        // if (token.isCancellationRequested) {
+        // if (token.isCancellationRequested || response.calls === undefined) {
         //     throw new vscode.CancellationError();
-        // } else if (response.calls === undefined || response.calls.length === 0) {
+        // } else if (response.calls.length === 0) {
         //      return undefined;
         // }
 
@@ -141,9 +146,9 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
             position: Position.create(item.range.start.line, item.range.start.character)
         };
         const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsFromRequest, params, token);
-        if (token.isCancellationRequested) {
+        if (token.isCancellationRequested || response.calls === undefined ) {
             throw new vscode.CancellationError();
-        } else if (response.calls === undefined || response.calls.length === 0) {
+        } else if (response.calls.length === 0) {
             return undefined;
         }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -19,6 +19,7 @@ import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
 import { InlayHintsProvider } from './Providers/inlayHintProvider';
+import { CallHierarchyProvider } from './Providers/CallHierarchyProvider';
 // End provider imports
 
 import { LanguageClientOptions, NotificationType, TextDocumentIdentifier, RequestType, ErrorAction, CloseAction, DidOpenTextDocumentParams, Range, Position } from 'vscode-languageclient';
@@ -1343,6 +1344,7 @@ export class DefaultClient implements Client {
                         this.disposables.push(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(this)));
                         this.disposables.push(vscode.languages.registerDocumentSymbolProvider(util.documentSelector, new DocumentSymbolProvider(), undefined));
                         this.disposables.push(vscode.languages.registerCodeActionsProvider(util.documentSelector, new CodeActionProvider(this), undefined));
+                        this.disposables.push(vscode.languages.registerCallHierarchyProvider(util.documentSelector, new CallHierarchyProvider(this)));
                         // Because formatting and codeFolding can vary per folder, we need to register these providers once
                         // and leave them registered. The decision of whether to provide results needs to be made on a per folder basis,
                         // within the providers themselves.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -19,7 +19,7 @@ import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
 import { InlayHintsProvider } from './Providers/inlayHintProvider';
-import { CallHierarchyProvider } from './Providers/CallHierarchyProvider';
+import { CallHierarchyProvider } from './Providers/callHierarchyProvider';
 // End provider imports
 
 import { LanguageClientOptions, NotificationType, TextDocumentIdentifier, RequestType, ErrorAction, CloseAction, DidOpenTextDocumentParams, Range, Position } from 'vscode-languageclient';


### PR DESCRIPTION
Issue: https://github.com/microsoft/vscode-cpptools/issues/16

Add `CallHierarchyProvider` class to implement VS Code's `vscode.CallHierarchyProvider` API.

Note: this changeset also disables indentation check because it is not reliable (https://github.com/typescript-eslint/typescript-eslint/issues/1824)
