### PR TITLE
Refactor experiment variable

### DIFF
--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -489,14 +489,8 @@ export async function getUI(): Promise<UI> {
 
 async function _getUI(): Promise<UI> {
     if (!ui) {
-        const experimentationService: IExperimentationService | undefined = await telemetry.getExperimentationService();
-        if (experimentationService !== undefined) {
-            const settings: CppSettings = new CppSettings();
-            const useNewUI: boolean | undefined = experimentationService.getTreatmentVariable<boolean>("vscode", "ShowLangStatBar");
-            ui = useNewUI || settings.experimentalFeatures ? new NewUI() : new OldUI();
-        } else {
-            ui = new NewUI();
-        }
+        const useNewUI: boolean = await telemetry.showLanguageStatusExperiment();
+        ui = useNewUI ? new NewUI() : new OldUI();
     }
     return ui;
 }

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -11,8 +11,6 @@ import { NewUI } from './ui_new';
 import { ReferencesCommandMode, referencesCommandModeToString } from './references';
 import { getCustomConfigProviders, CustomConfigurationProviderCollection, isSameProviderExtensionId } from './customProviders';
 import * as telemetry from '../telemetry';
-import { IExperimentationService } from 'tas-client';
-import { CppSettings } from './settings';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -78,10 +78,12 @@ export function getExperimentationService(): Promise<IExperimentationService> | 
 }
 
 export async function showLanguageStatusExperiment(): Promise<boolean> {
+    if (new CppSettings().experimentalFeatures) {
+        return true;
+    }
     const experimentationService: IExperimentationService | undefined = await getExperimentationService();
     const useNewUI: boolean | undefined = experimentationService?.getTreatmentVariable<boolean>("vscode", "ShowLangStatBar");
-    const settings: CppSettings = new CppSettings();
-    return useNewUI || settings.experimentalFeatures || false;
+    return useNewUI ?? false;
 }
 
 export async function deactivate(): Promise<void> {

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -6,6 +6,7 @@
 
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { getExperimentationServiceAsync, IExperimentationService, IExperimentationTelemetry, TargetPopulation } from 'vscode-tas-client';
+import { CppSettings } from './LanguageServer/settings';
 import * as util from './common';
 
 interface IPackageInfo {
@@ -74,6 +75,13 @@ export function activate(): void {
 
 export function getExperimentationService(): Promise<IExperimentationService> | undefined {
     return initializationPromise;
+}
+
+export async function showLanguageStatusExperiment(): Promise<boolean> {
+    const experimentationService: IExperimentationService | undefined = await getExperimentationService();
+    const useNewUI: boolean | undefined = experimentationService?.getTreatmentVariable<boolean>("vscode", "ShowLangStatBar");
+    const settings: CppSettings = new CppSettings();
+    return useNewUI || settings.experimentalFeatures || false;
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
Move logic for experiments into the telemetry module closer to the experimentation service. This is to set the pattern for future experiments so that they are all defined in the same place.