### PR TITLE
Updates for the multirootDeadlock test.

### DIFF
--- a/Extension/.vscode/launch.json
+++ b/Extension/.vscode/launch.json
@@ -108,7 +108,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"C:/git/Vcls-vscode-test/test.code-workspace",
+				"C:/git/Vcls-vscode-test/MultirootDeadlockTest/test.code-workspace",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/integrationTests/IntelliSenseFeatures/index"
 			],

--- a/Extension/.vscode/launch.json
+++ b/Extension/.vscode/launch.json
@@ -108,7 +108,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"C:/git/Vcls-vscode-test/SingleRootProject",
+				"C:/git/Vcls-vscode-test/test.code-workspace",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/integrationTests/IntelliSenseFeatures/index"
 			],

--- a/Extension/test/integrationTests/IntelliSenseFeatures/inlayhints.test.ts
+++ b/Extension/test/integrationTests/IntelliSenseFeatures/inlayhints.test.ts
@@ -28,7 +28,7 @@ suite("[Inlay hints test]", function(): void {
     let referenceOperatorEnabledValue: any;
     let referenceOperatorShowSpaceValue: any;
     // Test setup
-    const rootUri: vscode.Uri = vscode.workspace.workspaceFolders[0].uri;
+    const rootUri: vscode.Uri = vscode.workspace.workspaceFolders[1].uri;
     const filePath: string | undefined = rootUri.fsPath + "/inlay_hints.cpp";
     const fileUri: vscode.Uri = vscode.Uri.file(filePath);
     const disposables: vscode.Disposable[] = [];

--- a/Extension/test/integrationTests/IntelliSenseFeatures/quickInfo.test.ts
+++ b/Extension/test/integrationTests/IntelliSenseFeatures/quickInfo.test.ts
@@ -12,7 +12,7 @@ import * as testHelpers from '../testHelpers';
 suite("[Quick info test]", function(): void {
     let cpptools: apit.CppToolsTestApi;
     const disposables: vscode.Disposable[] = [];
-    const filePath: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/quickInfo.cpp";
+    const filePath: string = vscode.workspace.workspaceFolders[1].uri.fsPath + "/quickInfo.cpp";
     const fileUri: vscode.Uri = vscode.Uri.file(filePath);
     let platform: string = "";
 

--- a/Extension/test/integrationTests/IntelliSenseFeatures/reference.test.ts
+++ b/Extension/test/integrationTests/IntelliSenseFeatures/reference.test.ts
@@ -11,7 +11,7 @@ import * as apit from 'vscode-cpptools/out/testApi';
 suite(`[Reference test]`, function(): void {
     let cpptools: apit.CppToolsTestApi;
     const disposables: vscode.Disposable[] = [];
-    const path: string = vscode.workspace.workspaceFolders[0].uri.fsPath + "/references.cpp";
+    const path: string = vscode.workspace.workspaceFolders[1].uri.fsPath + "/references.cpp";
     const fileUri: vscode.Uri = vscode.Uri.file(path);
     let testHook: apit.CppToolsTestHook;
     let getIntelliSenseStatus: any;

--- a/Extension/test/integrationTests/IntelliSenseFeatures/runTest.ts
+++ b/Extension/test/integrationTests/IntelliSenseFeatures/runTest.ts
@@ -12,7 +12,7 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './index');
 
-        // Note, when running tests locally, replace testWorkspace with local path to "~/Vcls-vscode-test/test.code-workspace"
+        // Note, when running tests locally, replace TESTS_WORKSPACE with local path to "~/Vcls-vscode-test/MultirootDeadlockTest/test.code-workspace"
         // in the Launch.json file.
         let testWorkspace: string | undefined = process.env.TESTS_WORKSPACE;
         if (!testWorkspace) {

--- a/Extension/test/integrationTests/IntelliSenseFeatures/runTest.ts
+++ b/Extension/test/integrationTests/IntelliSenseFeatures/runTest.ts
@@ -12,7 +12,7 @@ async function main() {
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './index');
 
-        // Note, when running tests locally, replace testWorkspace with local path to "~/Vcls-vscode-test/SingleRootProject"
+        // Note, when running tests locally, replace testWorkspace with local path to "~/Vcls-vscode-test/test.code-workspace"
         // in the Launch.json file.
         let testWorkspace: string | undefined = process.env.TESTS_WORKSPACE;
         if (!testWorkspace) {


### PR DESCRIPTION
This changes the integrationTests to reference the 2nd project in the multiroot workspace (the SingleRootProject) instead of the SingleRootProject directly.