### PR TITLE
Fix issue with cached browse config not being removed

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -825,6 +825,11 @@ export class DefaultClient implements Client {
     private loggingLevel: string | undefined;
     private configurationProvider?: string;
 
+    public lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> | undefined;
+    public lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> | undefined;
+    public lastCustomBrowseConfigurationProviderVersion: PersistentFolderState<Version> | undefined;
+    private registeredProviders: PersistentFolderState<string[]> | undefined;
+
     public static referencesParams: RenameParams | FindAllReferencesParams | undefined;
     public static referencesRequestPending: boolean = false;
     public static referencesPendingCancellations: ReferencesCancellationState[] = [];
@@ -1075,6 +1080,20 @@ export class DefaultClient implements Client {
      */
 
     constructor(workspaceFolder?: vscode.WorkspaceFolder, initializeNow?: boolean) {
+        if (workspaceFolder !== undefined) {
+            this.lastCustomBrowseConfiguration = new PersistentFolderState<WorkspaceBrowseConfiguration | undefined>("CPP.lastCustomBrowseConfiguration", undefined, workspaceFolder);
+            this.lastCustomBrowseConfigurationProviderId = new PersistentFolderState<string | undefined>("CPP.lastCustomBrowseConfigurationProviderId", undefined, workspaceFolder);
+            this.lastCustomBrowseConfigurationProviderVersion = new PersistentFolderState<Version>("CPP.lastCustomBrowseConfigurationProviderVersion", Version.v5, workspaceFolder);
+            this.registeredProviders = new PersistentFolderState<string[]>("CPP.registeredProviders", [], workspaceFolder);
+            // If this provider did the register in the last session, clear out the cached browse config.
+            if (!this.isProviderRegistered(this.lastCustomBrowseConfigurationProviderId.Value)) {
+                this.lastCustomBrowseConfigurationProviderId.Value = undefined;
+                if (this.lastCustomBrowseConfiguration !== undefined) {
+                    this.lastCustomBrowseConfiguration.Value = undefined;
+                }
+            }
+            this.registeredProviders.Value = [];
+        }
         if (!semanticTokensLegend) {
             // Semantic token types are identified by indexes in this list of types, in the legend.
             const tokenTypesLegend: string[] = [];
@@ -1134,7 +1153,7 @@ export class DefaultClient implements Client {
                 await firstClientStarted;
                 try {
                     const workspaceFolder: vscode.WorkspaceFolder | undefined = this.rootFolder;
-                    this.innerConfiguration = new configs.CppProperties(rootUri, workspaceFolder);
+                    this.innerConfiguration = new configs.CppProperties(this, rootUri, workspaceFolder);
                     this.innerConfiguration.ConfigurationsChanged((e) => this.onConfigurationsChanged(e));
                     this.innerConfiguration.SelectionChanged((e) => this.onSelectedConfigurationChanged(e));
                     this.innerConfiguration.CompileCommandsChanged((e) => this.onCompileCommandsChanged(e));
@@ -1586,7 +1605,13 @@ export class DefaultClient implements Client {
         openFileVersions.delete(uri);
     }
 
-    private registeredProviders: CustomConfigurationProvider1[] = [];
+    public isProviderRegistered(extensionId: string | undefined): boolean {
+        if (extensionId === undefined || this.registeredProviders === undefined) {
+            return false;
+        }
+        return this.registeredProviders.Value.indexOf(extensionId) > -1;
+    }
+
     public onRegisterCustomConfigurationProvider(provider: CustomConfigurationProvider1): Thenable<void> {
         const onRegistered: () => void = () => {
             // version 2 providers control the browse.path. Avoid thrashing the tag parser database by pausing parsing until
@@ -1596,10 +1621,12 @@ export class DefaultClient implements Client {
             }
         };
         return this.notifyWhenLanguageClientReady(() => {
-            if (this.registeredProviders.includes(provider)) {
-                return; // Prevent duplicate processing.
+            if (this.registeredProviders === undefined // Shouldn't happen.
+                // Prevent duplicate processing.
+                || this.registeredProviders.Value.includes(provider.extensionId)) {
+                return;
             }
-            this.registeredProviders.push(provider);
+            this.registeredProviders.Value.push(provider.extensionId);
             const rootFolder: vscode.WorkspaceFolder | undefined = this.RootFolder;
             if (!rootFolder) {
                 return; // There is no c_cpp_properties.json to edit because there is no folder open.
@@ -2704,16 +2731,13 @@ export class DefaultClient implements Client {
         });
 
         await this.languageClient.sendRequest(ChangeCppPropertiesRequest, params);
-        const lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> | undefined = cppProperties.LastCustomBrowseConfigurationProviderId;
-        const lastCustomBrowseConfigurationProviderVersion: PersistentFolderState<Version> | undefined = cppProperties.LastCustomBrowseConfigurationProviderVersion;
-        const lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> | undefined = cppProperties.LastCustomBrowseConfiguration;
-        if (!!lastCustomBrowseConfigurationProviderId && !!lastCustomBrowseConfiguration && !!lastCustomBrowseConfigurationProviderVersion) {
+        if (!!this.lastCustomBrowseConfigurationProviderId && !!this.lastCustomBrowseConfiguration && !!this.lastCustomBrowseConfigurationProviderVersion) {
             if (!this.doneInitialCustomBrowseConfigurationCheck) {
                 // Send the last custom browse configuration we received from this provider.
                 // This ensures we don't start tag parsing without it, and undo'ing work we have to re-do when the (likely same) browse config arrives
                 // Should only execute on launch, for the initial delivery of configurations
-                if (lastCustomBrowseConfiguration.Value) {
-                    this.sendCustomBrowseConfiguration(lastCustomBrowseConfiguration.Value, lastCustomBrowseConfigurationProviderId.Value, lastCustomBrowseConfigurationProviderVersion.Value);
+                if (this.lastCustomBrowseConfiguration.Value) {
+                    this.sendCustomBrowseConfiguration(this.lastCustomBrowseConfiguration.Value, this.lastCustomBrowseConfigurationProviderId.Value, this.lastCustomBrowseConfigurationProviderVersion.Value);
                     params.isReady = false;
                 }
                 this.doneInitialCustomBrowseConfigurationCheck = true;
@@ -2855,11 +2879,12 @@ export class DefaultClient implements Client {
 
     private sendCustomBrowseConfiguration(config: any, providerId: string | undefined, providerVersion: Version, timeoutOccured?: boolean): void {
         const rootFolder: vscode.WorkspaceFolder | undefined = this.RootFolder;
-        if (!rootFolder) {
+        if (!rootFolder
+            || !this.lastCustomBrowseConfiguration
+            || !this.lastCustomBrowseConfigurationProviderId) {
             return;
         }
-        const lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> = new PersistentFolderState<WorkspaceBrowseConfiguration | undefined>("CPP.lastCustomBrowseConfiguration", undefined, rootFolder);
-        const lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> = new PersistentFolderState<string | undefined>("CPP.lastCustomBrowseConfigurationProviderId", undefined, rootFolder);
+
         let sanitized: util.Mutable<InternalWorkspaceBrowseConfiguration>;
 
         this.browseConfigurationLogging = "";
@@ -2871,7 +2896,7 @@ export class DefaultClient implements Client {
                 if (!timeoutOccured) {
                     console.log("Received an invalid browse configuration from configuration provider.");
                 }
-                const configValue: WorkspaceBrowseConfiguration | undefined = lastCustomBrowseConfiguration.Value;
+                const configValue: WorkspaceBrowseConfiguration | undefined = this.lastCustomBrowseConfiguration.Value;
                 if (configValue) {
                     sanitized = configValue;
                     console.log("Falling back to last received browse configuration: ", JSON.stringify(sanitized, null, 2));
@@ -2884,7 +2909,7 @@ export class DefaultClient implements Client {
             sanitized = { ...<InternalWorkspaceBrowseConfiguration>config };
             if (!this.isWorkspaceBrowseConfiguration(sanitized)) {
                 console.log("Received an invalid browse configuration from configuration provider: " + JSON.stringify(sanitized));
-                const configValue: WorkspaceBrowseConfiguration | undefined = lastCustomBrowseConfiguration.Value;
+                const configValue: WorkspaceBrowseConfiguration | undefined = this.lastCustomBrowseConfiguration.Value;
                 if (configValue) {
                     sanitized = configValue;
                     console.log("Falling back to last received browse configuration: ", JSON.stringify(sanitized, null, 2));
@@ -2917,11 +2942,11 @@ export class DefaultClient implements Client {
                 }
             }
 
-            lastCustomBrowseConfiguration.Value = sanitized;
+            this.lastCustomBrowseConfiguration.Value = sanitized;
             if (!providerId) {
-                lastCustomBrowseConfigurationProviderId.setDefault();
+                this.lastCustomBrowseConfigurationProviderId.setDefault();
             } else {
-                lastCustomBrowseConfigurationProviderId.Value = providerId;
+                this.lastCustomBrowseConfigurationProviderId.Value = providerId;
             }
             break;
         }


### PR DESCRIPTION
We cache the last used browse config, to avoid resetting the contents of the database on the next session while waiting for the same config provider to register again.

For security purposes, we want to clear that cached browse config if the same provider does not register in a subsequent session.  Clearing the browse configuration at the end of the session is not reliable, as the call to `update` on the `Momento` is async, and may not complete.

With this change, we now persist the providers that have registered in a workspace folder, and, on a subsequent session, if we see that the provider of the cached browse configuration did not register in the previous session, the cached browse config removed.

Moved the persistent variables involved into the client object.