### PR TITLE
Fix auto provider detection

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -828,11 +828,12 @@ export class CppProperties {
         if (!this.configurationJson) {
             return;
         }
+        this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
         const settings: CppSettings = new CppSettings(this.rootUri);
         const userSettings: CppSettings = new CppSettings();
         const env: Environment = this.ExtendedEnvironment;
         for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
-            const configuration: Configuration = { ...this.configurationJson.configurations[i] };
+            const configuration: Configuration = this.configurationJson.configurations[i];
             configuration.rawCompilerPath = configuration.compilerPath;
 
             configuration.includePath = this.updateConfigurationPathsArray(configuration.includePath, settings.defaultIncludePath, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1266,6 +1266,7 @@ export class CppProperties {
 
     private parsePropertiesFile(): boolean {
         if (!this.propertiesFile) {
+            this.configurationJson = getDefaultCppProperties();
             return false;
         }
         let success: boolean = true;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -21,12 +21,11 @@ import { setTimeout } from 'timers';
 import * as which from 'which';
 import { getOutputChannelLogger } from '../logger';
 import { compilerPaths, DefaultClient } from './client';
-import { UI } from './ui';
+import { UI, getUI } from './ui';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const configVersion: number = 4;
-let ui: UI;
 
 type Environment = { [key: string]: string | string[] };
 
@@ -351,7 +350,7 @@ export class CppProperties {
             const configuration: Configuration | undefined = this.CurrentConfiguration;
             if (configuration) {
                 if (configuration.compilerPath !== undefined || configuration.compileCommands !== undefined || configuration.configurationProvider !== undefined) {
-                    ui.showCompilerStatusIcon(false);
+                    getUI().then((ui: UI) => ui.showCompilerStatusIcon(false));
                 }
                 this.applyDefaultConfigurationValues(configuration);
                 this.configurationIncomplete = false;
@@ -833,7 +832,7 @@ export class CppProperties {
         const userSettings: CppSettings = new CppSettings();
         const env: Environment = this.ExtendedEnvironment;
         for (let i: number = 0; i < this.configurationJson.configurations.length; i++) {
-            const configuration: Configuration = this.configurationJson.configurations[i];
+            const configuration: Configuration = { ...this.configurationJson.configurations[i] };
             configuration.rawCompilerPath = configuration.compilerPath;
 
             configuration.includePath = this.updateConfigurationPathsArray(configuration.includePath, settings.defaultIncludePath, env);
@@ -970,10 +969,6 @@ export class CppProperties {
                         if (this.client.lastCustomBrowseConfigurationProviderId !== undefined) {
                             keepCachedBrowseConfig = configuration.configurationProvider === this.client.lastCustomBrowseConfigurationProviderId.Value;
                         }
-                    } else if (this.client.lastCustomBrowseConfigurationProviderId !== undefined
-                        && !!this.client.lastCustomBrowseConfigurationProviderId.Value) {
-                        // Use the last configuration provider we received a browse config from as the provider ID.
-                        configuration.configurationProvider = this.client.lastCustomBrowseConfigurationProviderId.Value;
                     }
                 } else if (this.client.lastCustomBrowseConfigurationProviderId !== undefined) {
                     keepCachedBrowseConfig = configuration.configurationProvider === this.client.lastCustomBrowseConfigurationProviderId.Value;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -828,7 +828,6 @@ export class CppProperties {
         if (!this.configurationJson) {
             return;
         }
-        this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
         const settings: CppSettings = new CppSettings(this.rootUri);
         const userSettings: CppSettings = new CppSettings();
         const env: Environment = this.ExtendedEnvironment;
@@ -1196,10 +1195,7 @@ export class CppProperties {
             return; // Occurs when propertiesFile hasn't been checked yet.
         }
         this.configFileWatcherFallbackTime = new Date();
-        if (this.propertiesFile) {
-            this.parsePropertiesFile();
-            // parsePropertiesFile can fail, but it won't overwrite an existing configurationJson in the event of failure.
-            // this.configurationJson should only be undefined here if we have never successfully parsed the propertiesFile.
+        if (this.parsePropertiesFile()) {
             if (this.configurationJson) {
                 if (this.CurrentConfigurationIndex < 0 ||
                     this.CurrentConfigurationIndex >= this.configurationJson.configurations.length) {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1262,7 +1262,7 @@ export class CppProperties {
 
     private parsePropertiesFile(): boolean {
         if (!this.propertiesFile) {
-            this.configurationJson = getDefaultCppProperties();
+            this.configurationJson = undefined;
             return false;
         }
         let success: boolean = true;


### PR DESCRIPTION
We're seeing a scenario in which one provider will register, get automatically selected because it's the only one (and then provide a browse configuration), but not get properly un-selected when a subsequent provider registers.

Removed a check that was opportunistically using a configuration provider if registered and if we received a browse configuration for it, as this scenario would lead to the 'too early' automatically selected config provider being kept.

We have a pattern in place to clear out any modifications we had made to the configuration (by calling `parsePropertiesFile` again) when we need to reprocess it.  But, that was a NO-OP if there was no `c_cpp_properties.json` file, so our modifications would not get removed in that scenario (making the prior registered configuration provider look like the user had explicitly specified it).  I updated that to instead use the default configuration, and I needed to fix one place where we didn't do that reset if the contents were empty.