### PR TITLE
Ensure configs are reprocessed after every call to `parsePropertiesFile`

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -615,8 +615,10 @@ export class CppProperties {
                 }
                 config.includePath.splice(config.includePath.length, 0, path);
                 this.writeToJson();
-                this.handleConfigurationChange();
             }
+            // Any time parsePropertiesFile is called, configurationJson gets
+            // reverted to an unprocessed state and needs to be reprocessed.
+            this.handleConfigurationChange();
         }, () => {});
     }
 
@@ -633,8 +635,10 @@ export class CppProperties {
                             delete config.configurationProvider;
                         }
                         this.writeToJson();
-                        this.handleConfigurationChange();
                     }
+                    // Any time parsePropertiesFile is called, configurationJson gets
+                    // reverted to an unprocessed state and needs to be reprocessed.
+                    this.handleConfigurationChange();
                     resolve();
                 }, () => {});
             } else {
@@ -660,8 +664,10 @@ export class CppProperties {
             if (config) {
                 config.compileCommands = path;
                 this.writeToJson();
-                this.handleConfigurationChange();
             }
+            // Any time parsePropertiesFile is called, configurationJson gets
+            // reverted to an unprocessed state and needs to be reprocessed.
+            this.handleConfigurationChange();
         }, () => {});
     }
 
@@ -969,10 +975,6 @@ export class CppProperties {
                         if (this.client.lastCustomBrowseConfigurationProviderId !== undefined) {
                             keepCachedBrowseConfig = configuration.configurationProvider === this.client.lastCustomBrowseConfigurationProviderId.Value;
                         }
-                    } else if (this.client.lastCustomBrowseConfigurationProviderId !== undefined
-                        && !!this.client.lastCustomBrowseConfigurationProviderId.Value) {
-                        // Use the last configuration provider we received a browse config from as the provider ID.
-                        configuration.configurationProvider = this.client.lastCustomBrowseConfigurationProviderId.Value;
                     }
                 } else if (this.client.lastCustomBrowseConfigurationProviderId !== undefined) {
                     keepCachedBrowseConfig = configuration.configurationProvider === this.client.lastCustomBrowseConfigurationProviderId.Value;
@@ -1127,6 +1129,9 @@ export class CppProperties {
                     showDocument(document, viewColumn);
                 }
             }
+            // Any time parsePropertiesFile is called, configurationJson gets
+            // reverted to an unprocessed state and needs to be reprocessed.
+            this.handleConfigurationChange();
         }
     }
 
@@ -1150,6 +1155,9 @@ export class CppProperties {
                         vscode.workspace.openTextDocument(this.propertiesFile);
                     }
                 }
+                // Any time parsePropertiesFile is called, configurationJson gets
+                // reverted to an unprocessed state and needs to be reprocessed.
+                this.handleConfigurationChange();
             }
         }
     }
@@ -1162,6 +1170,9 @@ export class CppProperties {
             this.settingsPanel.updateErrors(this.getErrorsForConfigUI(this.settingsPanel.selectedConfigIndex));
             this.writeToJson();
         }
+        // Any time parsePropertiesFile is called, configurationJson gets
+        // reverted to an unprocessed state and needs to be reprocessed.
+        this.handleConfigurationChange();
     }
 
     private onConfigSelectionChanged(): void {
@@ -1192,6 +1203,9 @@ export class CppProperties {
             // Save new config to file
             this.writeToJson();
         }
+        // Any time parsePropertiesFile is called, configurationJson gets
+        // reverted to an unprocessed state and needs to be reprocessed.
+        this.handleConfigurationChange();
     }
 
     public handleConfigurationChange(): void {
@@ -1199,21 +1213,16 @@ export class CppProperties {
             return; // Occurs when propertiesFile hasn't been checked yet.
         }
         this.configFileWatcherFallbackTime = new Date();
-        if (this.propertiesFile) {
-            this.parsePropertiesFile();
-            // parsePropertiesFile can fail, but it won't overwrite an existing configurationJson in the event of failure.
-            // this.configurationJson should only be undefined here if we have never successfully parsed the propertiesFile.
-            if (this.configurationJson) {
-                if (this.CurrentConfigurationIndex < 0 ||
-                    this.CurrentConfigurationIndex >= this.configurationJson.configurations.length) {
-                    // If the index is out of bounds (during initialization or due to removal of configs), fix it.
-                    const index: number | undefined = this.getConfigIndexForPlatform(this.configurationJson);
-                    if (this.currentConfigurationIndex !== undefined) {
-                        if (!index) {
-                            this.currentConfigurationIndex.setDefault();
-                        } else {
-                            this.currentConfigurationIndex.Value = index;
-                        }
+        if (this.parsePropertiesFile() && this.configurationJson) {
+            if (this.CurrentConfigurationIndex < 0 ||
+                this.CurrentConfigurationIndex >= this.configurationJson.configurations.length) {
+                // If the index is out of bounds (during initialization or due to removal of configs), fix it.
+                const index: number | undefined = this.getConfigIndexForPlatform(this.configurationJson);
+                if (this.currentConfigurationIndex !== undefined) {
+                    if (!index) {
+                        this.currentConfigurationIndex.setDefault();
+                    } else {
+                        this.currentConfigurationIndex.Value = index;
                     }
                 }
             }


### PR DESCRIPTION
`parsePropertiesFile` will revert the contents of `configurationJson` to the contents of `c_cpp_properties.json`, removing any updates that may have been made to the effective configuration(s).  Some updates occur later (in `handleConfigurationChange`, in calls to `resetToDefaultSettings`, `applyDefaultIncludePathsAndFrameworks` and `updateServerOnFolderSettingsChange`).

We sometimes call `parsePropertiesFile` when we need the original contents of `c_cpp_properties.json`.  When this happens, due to this updating the same `configurationJson` value we are using for the effective configuration, it's necessary to reprocess the configuration(s) (by calling `handleConfigurationChange`).

This change adds some missing calls to `handleConfigurationChange` after calls to `parsePropertiesFile`.

Ultimately, a better solution would be to rework how we're processing configurations and avoid relying on the same underlying `configurationJson` buffer in multiple places (i.e. json config squiggles), and/or add a helper function to load the original `c_cpp_properties.json` for modification without having to overwrite the effective configuration, etc..