### PR TITLE
Prefix all cpptools-specific context vars

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -5362,19 +5362,19 @@
       "editor/title/run": [
         {
           "command": "C_Cpp.BuildAndDebugFile",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile",
           "group": "navigation@0"
         },
         {
           "command": "C_Cpp.BuildAndRunFile",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile",
           "group": "navigation@1"
         }
       ],
       "editor/title": [
         {
           "command": "C_Cpp.AddDebugConfiguration",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen",
           "group": "navigation"
         }
       ],
@@ -5406,7 +5406,7 @@
         },
         {
           "command": "C_Cpp.AddDebugConfiguration",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.buildAndDebug.isSourceFile && cpptools.buildAndDebug.isFolderOpen",
           "group": "custom2@3"
         },
         {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -219,14 +219,14 @@
         {
           "id": "CppReferencesView",
           "name": "%c_cpp.contributes.views.cppReferencesView.title%",
-          "when": "cppReferenceTypes:hasResults"
+          "when": "cpptools.hasReferencesResults"
         }
       ],
       "debug": [
         {
           "id": "CppSshTargetsView",
           "name": "%c_cpp.contributes.views.sshTargetsView.title%",
-          "when": "enableCppSshTargetsView"
+          "when": "cpptools.enableSshTargetsView"
         }
       ]
     },
@@ -5362,19 +5362,19 @@
       "editor/title/run": [
         {
           "command": "C_Cpp.BuildAndDebugFile",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile",
           "group": "navigation@0"
         },
         {
           "command": "C_Cpp.BuildAndRunFile",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile",
           "group": "navigation@1"
         }
       ],
       "editor/title": [
         {
           "command": "C_Cpp.AddDebugConfiguration",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen",
           "group": "navigation"
         }
       ],
@@ -5406,7 +5406,7 @@
         },
         {
           "command": "C_Cpp.AddDebugConfiguration",
-          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && BuildAndDebug.isSourceFile && BuildAndDebug.isFolderOpen",
+          "when": "editorLangId == 'c' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen || editorLangId == 'cuda-cpp' && config.C_Cpp.debugShortcut && cpptools.BuildAndDebug.isSourceFile && cpptools.BuildAndDebug.isFolderOpen",
           "group": "custom2@3"
         },
         {
@@ -5423,11 +5423,11 @@
       "commandPalette": [
         {
           "command": "C_Cpp.referencesViewGroupByType",
-          "when": "cppReferenceTypes:hasResults"
+          "when": "cpptools.hasReferencesResults"
         },
         {
           "command": "C_Cpp.referencesViewUngroupByType",
-          "when": "cppReferenceTypes:hasResults"
+          "when": "cpptools.hasReferencesResults"
         },
         {
           "command": "C_Cpp.addSshTarget",

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -146,7 +146,7 @@ async function enableSshTargetsView(): Promise<void> {
     if (sshTargetsViewEnabled || sshTargetsViewSetting === 'disabled') {
         return;
     }
-    await vscode.commands.executeCommand('setContext', 'enableCppSshTargetsView', true);
+    await vscode.commands.executeCommand('setContext', 'cpptools.enableSshTargetsView', true);
     sshConfigWatcher = chokidar.watch(getSshConfigurationFiles(), { ignoreInitial: true })
         .on('add', () => vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
         .on('change', () => vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
@@ -155,7 +155,7 @@ async function enableSshTargetsView(): Promise<void> {
 }
 
 async function disableSshTargetsView(): Promise<void> {
-    await vscode.commands.executeCommand('setContext', 'enableCppSshTargetsView', false);
+    await vscode.commands.executeCommand('setContext', 'cpptools.enableSshTargetsView', false);
     if (sshConfigWatcher) {
         sshConfigWatcher.close();
         sshConfigWatcher = undefined;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1595,10 +1595,10 @@ export class DefaultClient implements Client {
         if (document.uri.scheme === "file") {
             const uri: string = document.uri.toString();
             openFileVersions.set(uri, document.version);
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isSourceFile', util.isCppOrCFile(document.uri));
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isFolderOpen', util.isFolderOpen(document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', util.isCppOrCFile(document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isFolderOpen', util.isFolderOpen(document.uri));
         } else {
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isSourceFile', false);
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', false);
         }
     }
 
@@ -2581,8 +2581,8 @@ export class DefaultClient implements Client {
             && (editor.document.languageId === "c"
                 || editor.document.languageId === "cpp"
                 || editor.document.languageId === "cuda-cpp")) {
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isSourceFile', util.isCppOrCFile(editor.document.uri));
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isFolderOpen', util.isFolderOpen(editor.document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', util.isCppOrCFile(editor.document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isFolderOpen', util.isFolderOpen(editor.document.uri));
             // If using vcFormat, check for a ".editorconfig" file, and apply those text options to the active document.
             const settings: CppSettings = new CppSettings(this.RootUri);
             if (settings.useVcFormat(editor.document)) {
@@ -2604,7 +2604,7 @@ export class DefaultClient implements Client {
                 }
             }
         } else {
-            vscode.commands.executeCommand('setContext', 'BuildAndDebug.isSourceFile', false);
+            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', false);
         }
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1595,10 +1595,10 @@ export class DefaultClient implements Client {
         if (document.uri.scheme === "file") {
             const uri: string = document.uri.toString();
             openFileVersions.set(uri, document.version);
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', util.isCppOrCFile(document.uri));
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isFolderOpen', util.isFolderOpen(document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isSourceFile', util.isCppOrCFile(document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isFolderOpen', util.isFolderOpen(document.uri));
         } else {
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', false);
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isSourceFile', false);
         }
     }
 
@@ -2581,8 +2581,8 @@ export class DefaultClient implements Client {
             && (editor.document.languageId === "c"
                 || editor.document.languageId === "cpp"
                 || editor.document.languageId === "cuda-cpp")) {
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', util.isCppOrCFile(editor.document.uri));
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isFolderOpen', util.isFolderOpen(editor.document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isSourceFile', util.isCppOrCFile(editor.document.uri));
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isFolderOpen', util.isFolderOpen(editor.document.uri));
             // If using vcFormat, check for a ".editorconfig" file, and apply those text options to the active document.
             const settings: CppSettings = new CppSettings(this.RootUri);
             if (settings.useVcFormat(editor.document)) {
@@ -2604,7 +2604,7 @@ export class DefaultClient implements Client {
                 }
             }
         } else {
-            vscode.commands.executeCommand('setContext', 'cpptools.BuildAndDebug.isSourceFile', false);
+            vscode.commands.executeCommand('setContext', 'cpptools.buildAndDebug.isSourceFile', false);
         }
     }
 

--- a/Extension/src/LanguageServer/referencesView.ts
+++ b/Extension/src/LanguageServer/referencesView.ts
@@ -27,7 +27,7 @@ export class FindAllRefsView {
         if (this.referencesModel) {
             hasResults = this.referencesModel.hasResults();
         }
-        vscode.commands.executeCommand('setContext', 'cppReferenceTypes:hasResults', hasResults);
+        vscode.commands.executeCommand('setContext', 'cpptools.hasReferencesResults', hasResults);
     }
 
     setData(results: ReferencesResult, isCanceled: boolean, groupByFile: boolean): void {


### PR DESCRIPTION
Context variable names from all extension share the same scope.  This change uses a prefix to reduce the risk of name collisions.