### PR TITLE
Fix regression that resulted in `compilerPath` shown in settings UI

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -614,7 +614,10 @@
             "scope": "machine-overridable"
           },
           "C_Cpp.default.compilerPath": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "default": null,
             "markdownDescription": "%c_cpp.configuration.default.compilerPath.markdownDescription%",
             "scope": "machine-overridable"


### PR DESCRIPTION
Fixed a regression introduced in https://github.com/microsoft/vscode-cpptools/pull/8129 , which caused the `default.compilerPath` field to become editable in VS Code settings UI.

This is related to: https://github.com/microsoft/vscode-cpptools/issues/10795

In `C_Cpp.default.compilerPath`, we consider the value of a blank string `""` as being distinct from null/undefined.  However, string settings displayed in VS Code settings UI do not make that distinction.  In lieu of removing this distinction from our code (so as not to break existing users), we prevented this field from being editable in the settings UI by using a 'type' that is not strictly just 'string'.

```
"C_Cpp.default.compilerPath": {
  "type": [
    "string",
    "null"
  ],
  "default": null,
  "markdownDescription": "%c_cpp.configuration.default.compilerPath.markdownDescription%",
  "scope": "machine-overridable"
},
```

This results in a link in VS Code's settings UI, referring the user to the JSON file to properly edit that field.

![image](https://user-images.githubusercontent.com/49173979/230994629-c5d5a49a-6bee-48da-930f-281a81f07049.png)

Alternatively, we could either:
a) Stop using `""` to indicate not to fall back to a default detected compiler, perhaps in favor of a separate setting. (i.e. `"fallbackToDetectedCompiler": false`.
b) Leave the existing imperfect behavior in place, as this regression had existed for 1.5 years before it was brought to our attention.