### PR TITLE
Fix bug with Configure IntelliSense appearing when it shouldn't.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2700,7 +2700,8 @@ export class DefaultClient implements Client {
         }
 
         // Handle compile commands
-        if (rootFolder && configProviderNotSet && compileCommandsNotSet && this.compileCommandsPaths.length > 0 && (statusBarIndicatorEnabled || sender === "compileCommands")) {
+        if (rootFolder && configProviderNotSet && !this.configStateReceived.configProviders &&
+            compileCommandsNotSet && this.compileCommandsPaths.length > 0 && (statusBarIndicatorEnabled || sender === "compileCommands")) {
             const ask: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("CPP.showCompileCommandsSelection", true, rootFolder);
             if (ask.Value) {
                 if (statusBarIndicatorEnabled) {


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-cpptools/issues/10822 .

The bug reproed when the compile commands info was received before a configuration provider registered. The fix checks !this.configStateReceived.configProviders since that gets set if a configuration provider was cached previously.