### PR TITLE
Fix configure IntelliSense UI bugs with non-C/C++ files (and other small fixes)

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1119,7 +1119,7 @@ export class DefaultClient implements Client {
             // Clear the prompt state.
             // TODO: Add some way to change this state to true.
             const rootFolder: vscode.WorkspaceFolder | undefined = this.RootFolder;
-            if (rootFolder) {
+            if (rootFolder && fromStatusBarButton) {
                 if (configurationSelected || configProviderCount > 0) {
                     const ask: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("Client.registerProvider", true, rootFolder);
                     ask.Value = false;
@@ -1127,6 +1127,9 @@ export class DefaultClient implements Client {
                 if (configurationSelected || compileCommandsCount > 0) {
                     const ask: PersistentFolderState<boolean> = new PersistentFolderState<boolean>("CPP.showCompileCommandsSelection", true, rootFolder);
                     ask.Value = false;
+                }
+                if (!configurationSelected) {
+                    this.handleConfigStatusOrPrompt();
                 }
             }
         }

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -8,6 +8,7 @@ import { Middleware } from 'vscode-languageclient';
 import { Client } from './client';
 import * as vscode from 'vscode';
 import { clients, onDidChangeActiveTextEditor, processDelayedDidOpen } from './extension';
+import * as util from '../common';
 
 export function createProtocolFilter(): Middleware {
     // Disabling lint for invoke handlers
@@ -18,6 +19,9 @@ export function createProtocolFilter(): Middleware {
 
     return {
         didOpen: async (document, sendMessage) => {
+            if (util.isCpp(document)) {
+                util.setWorkspaceIsCpp();
+            }
             const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(e => e.document === document);
             if (editor) {
                 // If the file was visible editor when we were activated, we will not get a call to

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -11,6 +11,7 @@ import { NewUI } from './ui_new';
 import { ReferencesCommandMode, referencesCommandModeToString } from './references';
 import { getCustomConfigProviders, CustomConfigurationProviderCollection, isSameProviderExtensionId } from './customProviders';
 import * as telemetry from '../telemetry';
+import * as util from '../common';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -310,7 +311,6 @@ export class OldUI implements UI {
     }
 
     private showConfigureIntelliSenseButton: boolean = false;
-    private cppHasBeenActive: boolean = false;
 
     public async ShowConfigureIntelliSenseButton(show: boolean, client?: Client): Promise<void> {
         if (!telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
@@ -320,16 +320,8 @@ export class OldUI implements UI {
             this.showConfigureIntelliSenseButton = true;
             const activeEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
             telemetry.logLanguageServerEvent('configureIntelliSenseStatusBar');
-            if (activeEditor) {
-                const isCpp: boolean = activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp");
-                const isCppPropertiesJson: boolean = (activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") && activeEditor.document.fileName.endsWith("c_cpp_properties.json");
-                if (isCppPropertiesJson || isCpp) {
-                    this.cppHasBeenActive = true;
-                }
-                if ((isCpp || isCppPropertiesJson ||
-                    (activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")))) {
-                    this.configureIntelliSenseStatusItem.show();
-                }
+            if (activeEditor && util.isCppOrRelated(activeEditor.document)) {
+                this.configureIntelliSenseStatusItem.show();
             }
         } else {
             this.showConfigureIntelliSenseButton = false;
@@ -345,28 +337,16 @@ export class OldUI implements UI {
                 this.configureIntelliSenseStatusItem.hide();
             }
         } else {
-            let isCppPropertiesJson: boolean = false;
-            if (activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") {
-                isCppPropertiesJson = activeEditor.document.fileName.endsWith("c_cpp_properties.json");
-                if (isCppPropertiesJson) {
-                    vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
-                }
+            const isCppPropertiesJson: boolean = util.isCppPropertiesJson(activeEditor.document);
+            if (isCppPropertiesJson) {
+                vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
             }
-            const isCpp: boolean = (activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp"));
-            if (isCppPropertiesJson || isCpp) {
-                this.cppHasBeenActive = true;
-            }
-
-            const isCppOutput: boolean = activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools");
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput ||
-                (this.cppHasBeenActive &&
-                    (activeEditor.document.fileName.endsWith("settings.json") ||
-                    activeEditor.document.fileName.endsWith(".code-workspace")));
+            const showConfigureIntelliSenseButton: boolean = isCppPropertiesJson || util.isCppOrRelated(activeEditor.document);
             this.ShowConfiguration = showConfigureIntelliSenseButton ||
-                (this.cppHasBeenActive &&
+                (util.getWorkspaceIsCpp() &&
                     (activeEditor.document.fileName.endsWith("tasks.json") ||
                     activeEditor.document.fileName.endsWith("launch.json")));
 

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -106,8 +106,9 @@ export class OldUI implements UI {
         this.ShowReferencesIcon = false;
 
         this.configureIntelliSenseStatusItem = vscode.window.createStatusBarItem(`c.cpp.configureIntelliSenseStatus.statusbar`, vscode.StatusBarAlignment.Right, 901);
-        this.configureIntelliSenseStatusItem.name = localize("c.cpp.configureIntelliSenseStatus.statusbar", "Configure IntelliSense");
-        this.configureIntelliSenseStatusItem.text = `$(warning) ${this.configureIntelliSenseStatusItem.name}`;
+        this.configureIntelliSenseStatusItem.name = localize("c.cpp.configureIntelliSenseStatus.cppText", "C/C++ Configure IntelliSense");
+        const configureIntelliSenseText: string = localize("c.cpp.configureIntelliSenseStatus.text", "Configure IntelliSense");
+        this.configureIntelliSenseStatusItem.text = `$(warning) ${configureIntelliSenseText}`;
         this.configureIntelliSenseStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
         this.configureIntelliSenseStatusItem.command = {
             command: "C_Cpp.SelectIntelliSenseConfiguration",
@@ -315,8 +316,14 @@ export class OldUI implements UI {
         }
         if (show) {
             this.showConfigureIntelliSenseButton = true;
-            this.configureIntelliSenseStatusItem.show();
+            const activeEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
             telemetry.logLanguageServerEvent('configureIntelliSenseStatusBar');
+            if (activeEditor &&
+                ((activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp")) ||
+                ((activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") && activeEditor.document.fileName.endsWith("c_cpp_properties.json")) ||
+                (activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")))) {
+                this.configureIntelliSenseStatusItem.show();
+            }
         } else {
             this.showConfigureIntelliSenseButton = false;
             this.configureIntelliSenseStatusItem.hide();
@@ -344,12 +351,12 @@ export class OldUI implements UI {
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput ||
-                activeEditor.document.fileName.endsWith("settings.json") ||
-                activeEditor.document.fileName.endsWith(".code-workspace");
+            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput;
             this.ShowConfiguration = showConfigureIntelliSenseButton ||
                 activeEditor.document.fileName.endsWith("tasks.json") ||
-                activeEditor.document.fileName.endsWith("launch.json");
+                activeEditor.document.fileName.endsWith("launch.json") ||
+                activeEditor.document.fileName.endsWith("settings.json") ||
+                activeEditor.document.fileName.endsWith(".code-workspace");
 
             if (this.showConfigureIntelliSenseButton) {
                 if (showConfigureIntelliSenseButton) {

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -95,7 +95,7 @@ export class OldUI implements UI {
         this.configStatusBarItem.tooltip = configTooltip;
         this.ShowConfiguration = true;
 
-        this.referencesStatusBarItem = vscode.window.createStatusBarItem("c.cpp.references.statusbar", vscode.StatusBarAlignment.Right, 901);
+        this.referencesStatusBarItem = vscode.window.createStatusBarItem("c.cpp.references.statusbar", vscode.StatusBarAlignment.Right, 0);
         this.referencesStatusBarItem.name = localize("c.cpp.references.statusbar", "C/C++ References Status");
         this.referencesStatusBarItem.tooltip = "";
         this.referencesStatusBarItem.command = {

--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -109,8 +109,9 @@ export class NewUI implements UI {
         this.ShowReferencesIcon = false;
 
         this.configureIntelliSenseStatusItem = vscode.window.createStatusBarItem(`c.cpp.configureIntelliSenseStatus.statusbar`, vscode.StatusBarAlignment.Right, 901);
-        this.configureIntelliSenseStatusItem.name = localize("c.cpp.configureIntelliSenseStatus.statusbar", "Configure IntelliSense");
-        this.configureIntelliSenseStatusItem.text = `$(warning) ${this.configureIntelliSenseStatusItem.name}`;
+        this.configureIntelliSenseStatusItem.name = localize("c.cpp.configureIntelliSenseStatus.cppText", "C/C++ Configure IntelliSense");
+        const configureIntelliSenseText: string = localize("c.cpp.configureIntelliSenseStatus.text", "Configure IntelliSense");
+        this.configureIntelliSenseStatusItem.text = `$(warning) ${configureIntelliSenseText}`;
         this.configureIntelliSenseStatusItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
         this.configureIntelliSenseStatusItem.command = {
             command: "C_Cpp.SelectIntelliSenseConfiguration",
@@ -422,8 +423,14 @@ export class NewUI implements UI {
         }
         if (show) {
             this.showConfigureIntelliSenseButton = true;
-            this.configureIntelliSenseStatusItem.show();
+            const activeEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
             telemetry.logLanguageServerEvent('configureIntelliSenseStatusBar');
+            if (activeEditor &&
+                ((activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp")) ||
+                ((activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") && activeEditor.document.fileName.endsWith("c_cpp_properties.json")) ||
+                (activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")))) {
+                this.configureIntelliSenseStatusItem.show();
+            }
         } else {
             this.showConfigureIntelliSenseButton = false;
             this.configureIntelliSenseStatusItem.hide();
@@ -451,12 +458,12 @@ export class NewUI implements UI {
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput ||
-                activeEditor.document.fileName.endsWith("settings.json") ||
-                activeEditor.document.fileName.endsWith(".code-workspace");
+            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput;
             this.ShowConfiguration = showConfigureIntelliSenseButton ||
                 activeEditor.document.fileName.endsWith("tasks.json") ||
-                activeEditor.document.fileName.endsWith("launch.json");
+                activeEditor.document.fileName.endsWith("launch.json") ||
+                activeEditor.document.fileName.endsWith("settings.json") ||
+                activeEditor.document.fileName.endsWith(".code-workspace");
 
             if (this.showConfigureIntelliSenseButton) {
                 if (showConfigureIntelliSenseButton) {

--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -108,7 +108,7 @@ export class NewUI implements UI {
         };
         this.ShowReferencesIcon = false;
 
-        this.configureIntelliSenseStatusItem = vscode.window.createStatusBarItem(`c.cpp.configureIntelliSenseStatus.statusbar`, vscode.StatusBarAlignment.Right, 901);
+        this.configureIntelliSenseStatusItem = vscode.window.createStatusBarItem(`c.cpp.configureIntelliSenseStatus.statusbar`, vscode.StatusBarAlignment.Right, 0);
         this.configureIntelliSenseStatusItem.name = localize("c.cpp.configureIntelliSenseStatus.cppText", "C/C++ Configure IntelliSense");
         const configureIntelliSenseText: string = localize("c.cpp.configureIntelliSenseStatus.text", "Configure IntelliSense");
         this.configureIntelliSenseStatusItem.text = `$(warning) ${configureIntelliSenseText}`;

--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -417,6 +417,8 @@ export class NewUI implements UI {
     }
 
     private showConfigureIntelliSenseButton: boolean = false;
+    private cppHasBeenActive: boolean = false;
+
     public async ShowConfigureIntelliSenseButton(show: boolean, client?: Client): Promise<void> {
         if (!telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
             return;
@@ -425,11 +427,16 @@ export class NewUI implements UI {
             this.showConfigureIntelliSenseButton = true;
             const activeEditor: vscode.TextEditor | undefined = vscode.window.activeTextEditor;
             telemetry.logLanguageServerEvent('configureIntelliSenseStatusBar');
-            if (activeEditor &&
-                ((activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp")) ||
-                ((activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") && activeEditor.document.fileName.endsWith("c_cpp_properties.json")) ||
-                (activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")))) {
-                this.configureIntelliSenseStatusItem.show();
+            if (activeEditor) {
+                const isCpp: boolean = activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp");
+                const isCppPropertiesJson: boolean = (activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") && activeEditor.document.fileName.endsWith("c_cpp_properties.json");
+                if (isCppPropertiesJson || isCpp) {
+                    this.cppHasBeenActive = true;
+                }
+                if ((isCpp || isCppPropertiesJson ||
+                    (activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")))) {
+                    this.configureIntelliSenseStatusItem.show();
+                }
             }
         } else {
             this.showConfigureIntelliSenseButton = false;
@@ -445,8 +452,6 @@ export class NewUI implements UI {
                 this.configureIntelliSenseStatusItem.hide();
             }
         } else {
-            const isCpp: boolean = (activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp"));
-
             let isCppPropertiesJson: boolean = false;
             if (activeEditor.document.languageId === "json" || activeEditor.document.languageId === "jsonc") {
                 isCppPropertiesJson = activeEditor.document.fileName.endsWith("c_cpp_properties.json");
@@ -454,16 +459,23 @@ export class NewUI implements UI {
                     vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
                 }
             }
+            const isCpp: boolean = (activeEditor.document.uri.scheme === "file" && (activeEditor.document.languageId === "c" || activeEditor.document.languageId === "cpp" || activeEditor.document.languageId === "cuda-cpp"));
+            if (isCppPropertiesJson || isCpp) {
+                this.cppHasBeenActive = true;
+            }
+
             const isCppOutput: boolean = activeEditor.document.uri.scheme === "output" && activeEditor.document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools");
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput;
+            const showConfigureIntelliSenseButton: boolean = isCpp || isCppPropertiesJson || isCppOutput ||
+                (this.cppHasBeenActive &&
+                    (activeEditor.document.fileName.endsWith("settings.json") ||
+                    activeEditor.document.fileName.endsWith(".code-workspace")));
             this.ShowConfiguration = showConfigureIntelliSenseButton ||
-                activeEditor.document.fileName.endsWith("tasks.json") ||
-                activeEditor.document.fileName.endsWith("launch.json") ||
-                activeEditor.document.fileName.endsWith("settings.json") ||
-                activeEditor.document.fileName.endsWith(".code-workspace");
+                (this.cppHasBeenActive &&
+                    (activeEditor.document.fileName.endsWith("tasks.json") ||
+                    activeEditor.document.fileName.endsWith("launch.json")));
 
             if (this.showConfigureIntelliSenseButton) {
                 if (showConfigureIntelliSenseButton) {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -193,6 +193,30 @@ export function isEditorFileCpp(file: string): boolean {
     return editor.document.languageId === "cpp";
 }
 
+// If it's C, C++, or Cuda.
+export function isCpp(document: vscode.TextDocument): boolean {
+    return document.uri.scheme === "file" &&
+        (document.languageId === "c" || document.languageId === "cpp" || document.languageId === "cuda-cpp");
+}
+export function isCppPropertiesJson(document: vscode.TextDocument): boolean {
+    return document.uri.scheme === "file" && (document.languageId === "json" || document.languageId === "jsonc") &&
+        (document.fileName.endsWith("c_cpp_properties.json"));
+}
+let isWorkspaceCpp: boolean = false;
+export function setWorkspaceIsCpp(): void {
+    if (!isWorkspaceCpp) {
+        isWorkspaceCpp = true;
+    }
+}
+export function getWorkspaceIsCpp(): boolean {
+    return isWorkspaceCpp;
+}
+export function isCppOrRelated(document: vscode.TextDocument): boolean {
+    return isCpp(document) || isCppPropertiesJson(document) || (document.uri.scheme === "output" && document.uri.fsPath.startsWith("extension-output-ms-vscode.cpptools")) ||
+        (isWorkspaceCpp && document.uri.scheme === "file" && (document.languageId === "json" || document.languageId === "jsonc") &&
+        (document.fileName.endsWith("settings.json") || document.fileName.endsWith(".code-workspace")));
+}
+
 let isExtensionNotReadyPromptDisplayed: boolean = false;
 export const extensionNotReadyString: string = localize("extension.not.ready", 'The C/C++ extension is still installing. See the output window for more information.');
 

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -115,6 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
             if (await util.checkFileExists(config)) {
                 const doc: vscode.TextDocument = await vscode.workspace.openTextDocument(config);
                 vscode.languages.setTextDocumentLanguage(doc, "jsonc");
+                util.setWorkspaceIsCpp();
             }
         }
     }


### PR DESCRIPTION
- Fix https://github.com/microsoft/vscode-cpptools/issues/10827

  - Check for the valid file cases before showing the "Configure IntelliSense" UI -- previously it was only checking after the active file was changed.
  - Only show it for settings files if a C/C++ file or json has been made active.
  - Change the "name" to "C/C++ Configure IntelliSense" (shown in the right-click menu not the visible text/title) -- so users know which extension is adding that if they want to disable/hide it.
- Refactor isCpp checks. 
- Also, the fixes below were just 1 line fixes so I included them in this:
  - Fix a bug where the "Configure IntelliSense" would not disappear until reload window is done in the case where it's only being shown due mimicking the prompt for using compile commands or config provider and the dropdown is exited without a selection.
  - Fix a bug where the persistent state for showing the compile commands of config provider prompt would get cleared after the compiler selection dropdown was shown, even if not invoked from the "Configure IntelliSense" button.
  - Move the status bar location to the left of the configuration item so that it's less likely to disappear due to lack of space: part of https://github.com/microsoft/vscode-cpptools/issues/10810 .