### PR TITLE
Set user scope compiler path if no trusted compiler is set.

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     "rules": {
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "error",
+        "@typescript-eslint/await-thenable": "error",
         "camelcase": "off",
         "@typescript-eslint/naming-convention": [
             "error",
@@ -43,6 +44,7 @@ module.exports = {
         ],
         "@typescript-eslint/no-for-in-array": "error",
         "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-misused-promises": "error",
         "@typescript-eslint/no-namespace": "error",
         "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-extra-non-null-assertion": "error",

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.15.3: March 20, 2023
+### Bug Fix
+* Fix handling of sccache and clcache. [#7616](https://github.com/microsoft/vscode-cpptools/issues/7616)
+* Fix an undefined reference regression. [PR #10824](https://github.com/microsoft/vscode-cpptools/pull/10824)
+* Fix bugs with the "Configure IntelliSense" button. [#10810](https://github.com/microsoft/vscode-cpptools/issues/10810), [#10822](https://github.com/microsoft/vscode-cpptools/issues/10822), [#10827](https://github.com/microsoft/vscode-cpptools/issues/10827)
+
 ## Version 1.15.2: March 12, 2023
 ### Enhancements
 * Add a "Configure IntelliSense" status bar warning. [#10685](https://github.com/microsoft/vscode-cpptools/issues/10685)

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -448,6 +448,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 const isCl: boolean = compilerName === "cl.exe";
                 newConfig.cwd = isWindows && !isCl && !process.env.PATH?.includes(path.dirname(compilerPath)) ? path.dirname(compilerPath) : "${fileDirname}";
 
+                // eslint-disable-next-line @typescript-eslint/no-misused-promises
                 return new Promise<CppDebugConfiguration | undefined>(async resolve => {
                     if (platformInfo.platform === "darwin") {
                         return resolve(newConfig);

--- a/Extension/src/Debugger/extension.ts
+++ b/Extension/src/Debugger/extension.ts
@@ -53,8 +53,11 @@ export async function initialize(context: vscode.ExtensionContext): Promise<void
 
     // Register DebugConfigurationProviders for "Run and Debug" play button.
     const debugProvider: DebugConfigurationProvider = new DebugConfigurationProvider(assetProvider, DebuggerType.all);
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.BuildAndDebugFile", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => { await debugProvider.buildAndDebug(textEditor); }));
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.BuildAndRunFile", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => { await debugProvider.buildAndRun(textEditor); }));
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     disposables.push(vscode.commands.registerTextEditorCommand("C_Cpp.AddDebugConfiguration", async (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => {
         const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(textEditor.document.uri);
         if (!folder) {
@@ -148,9 +151,9 @@ async function enableSshTargetsView(): Promise<void> {
     }
     await vscode.commands.executeCommand('setContext', 'cpptools.enableSshTargetsView', true);
     sshConfigWatcher = chokidar.watch(getSshConfigurationFiles(), { ignoreInitial: true })
-        .on('add', () => vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
-        .on('change', () => vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
-        .on('unlink', () => vscode.commands.executeCommand(refreshCppSshTargetsViewCmd));
+        .on('add', () => void vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
+        .on('change', () => void vscode.commands.executeCommand(refreshCppSshTargetsViewCmd))
+        .on('unlink', () => void vscode.commands.executeCommand(refreshCppSshTargetsViewCmd));
     sshTargetsViewEnabled = true;
 }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1917,7 +1917,7 @@ export class DefaultClient implements Client {
             });
 
             // Set up a timeout to use previously received configuration and resume parsing if the provider times out
-            global.setTimeout(async () => {
+            global.setTimeout(() => {
                 if (!hasCompleted) {
                     hasCompleted = true;
                     this.sendCustomBrowseConfiguration(null, undefined, Version.v0, true);
@@ -2289,10 +2289,10 @@ export class DefaultClient implements Client {
     private registerNotifications(): void {
         console.assert(this.languageClient !== undefined, "This method must not be called until this.languageClient is set in \"onReady\"");
 
-        this.languageClient.onNotification(ReloadWindowNotification, () => util.promptForReloadWindowDueToSettingsChange());
+        this.languageClient.onNotification(ReloadWindowNotification, () => void util.promptForReloadWindowDueToSettingsChange());
         this.languageClient.onNotification(UpdateTrustedCompilersNotification, (e) => addTrustedCompiler(e.compilerPath));
         this.languageClient.onNotification(LogTelemetryNotification, logTelemetry);
-        this.languageClient.onNotification(ReportStatusNotification, async (e) => this.updateStatus(e));
+        this.languageClient.onNotification(ReportStatusNotification, (e) => void this.updateStatus(e));
         this.languageClient.onNotification(ReportTagParseStatusNotification, (e) => this.updateTagParseStatus(e));
         this.languageClient.onNotification(InactiveRegionNotification, (e) => this.updateInactiveRegions(e));
         this.languageClient.onNotification(CompileCommandsPathsNotification, (e) => this.promptCompileCommands(e));
@@ -2314,10 +2314,10 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(SemanticTokensChanged, (e) => this.semanticTokensProvider?.invalidateFile(e));
         this.languageClient.onNotification(InlayHintsChanged, (e) => this.inlayHintsProvider?.invalidateFile(e));
         this.languageClient.onNotification(IntelliSenseSetupNotification, (e) => this.logIntelliSenseSetupTime(e));
-        this.languageClient.onNotification(SetTemporaryTextDocumentLanguageNotification, (e) => this.setTemporaryTextDocumentLanguage(e));
+        this.languageClient.onNotification(SetTemporaryTextDocumentLanguageNotification, (e) => void this.setTemporaryTextDocumentLanguage(e));
         this.languageClient.onNotification(ReportCodeAnalysisProcessedNotification, (e) => this.updateCodeAnalysisProcessed(e));
         this.languageClient.onNotification(ReportCodeAnalysisTotalNotification, (e) => this.updateCodeAnalysisTotal(e));
-        this.languageClient.onNotification(DoxygenCommentGeneratedNotification, (e) => this.insertDoxygenComment(e));
+        this.languageClient.onNotification(DoxygenCommentGeneratedNotification, (e) => void this.insertDoxygenComment(e));
     }
 
     private setTextDocumentLanguage(languageStr: string): void {

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -241,7 +241,7 @@ export class ClientCollection {
         }
         const key: string = folder ? util.asFolder(folder.uri) : defaultClientKey;
         this.languageClients.set(key, newClient);
-        getCustomConfigProviders().forEach(provider => newClient.onRegisterCustomConfigurationProvider(provider));
+        getCustomConfigProviders().forEach(provider => void newClient.onRegisterCustomConfigurationProvider(provider));
         return newClient;
     }
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -20,7 +20,7 @@ import * as nls from 'vscode-nls';
 import { setTimeout } from 'timers';
 import * as which from 'which';
 import { getOutputChannelLogger } from '../logger';
-import { compilerPaths, DefaultClient } from './client';
+import { addTrustedCompiler, DefaultClient } from './client';
 import { UI, getUI } from './ui';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -908,7 +908,7 @@ export class CppProperties {
                 } else {
                     // add compiler to list of trusted compilers
                     if (i === this.CurrentConfigurationIndex) {
-                        util.addTrustedCompiler(compilerPaths, configuration.compilerPath);
+                        addTrustedCompiler(configuration.compilerPath);
                     }
                 }
             } else {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1064,7 +1064,7 @@ export class CppProperties {
     }
 
     // onBeforeOpen will be called after c_cpp_properties.json have been created (if it did not exist), but before the document is opened.
-    public handleConfigurationEditCommand(onBeforeOpen: (() => void) | undefined, showDocument: (document: vscode.TextDocument, column?: vscode.ViewColumn) => void, viewColumn?: vscode.ViewColumn): void {
+    public handleConfigurationEditCommand(onBeforeOpen: (() => void) | undefined, showDocument: ((document: vscode.TextDocument, column?: vscode.ViewColumn) => Thenable<vscode.TextEditor>) | (() => void), viewColumn?: vscode.ViewColumn): void {
         const otherSettings: OtherSettings = new OtherSettings(this.rootUri);
         if (otherSettings.workbenchSettingsEditor  === "ui") {
             this.handleConfigurationEditUICommand(onBeforeOpen, showDocument, viewColumn);
@@ -1074,7 +1074,7 @@ export class CppProperties {
     }
 
     // onBeforeOpen will be called after c_cpp_properties.json have been created (if it did not exist), but before the document is opened.
-    public async handleConfigurationEditJSONCommand(onBeforeOpen: (() => void) | undefined, showDocument: (document: vscode.TextDocument, column?: vscode.ViewColumn) => void, viewColumn?: vscode.ViewColumn): Promise<void> {
+    public async handleConfigurationEditJSONCommand(onBeforeOpen: (() => void) | undefined, showDocument: ((document: vscode.TextDocument, column?: vscode.ViewColumn) => Thenable<vscode.TextEditor>) | (() => void), viewColumn?: vscode.ViewColumn): Promise<void> {
         await this.ensurePropertiesFile();
         console.assert(this.propertiesFile);
         if (onBeforeOpen) {
@@ -1107,7 +1107,7 @@ export class CppProperties {
     }
 
     // onBeforeOpen will be called after c_cpp_properties.json have been created (if it did not exist), but before the document is opened.
-    public async handleConfigurationEditUICommand(onBeforeOpen: (() => void) | undefined, showDocument: (document: vscode.TextDocument, column?: vscode.ViewColumn) => void, viewColumn?: vscode.ViewColumn): Promise<void> {
+    public async handleConfigurationEditUICommand(onBeforeOpen: (() => void) | undefined, showDocument: ((document: vscode.TextDocument, column?: vscode.ViewColumn) => Thenable<vscode.TextEditor>) | (() => void), viewColumn?: vscode.ViewColumn): Promise<void> {
         await this.ensurePropertiesFile();
         if (this.propertiesFile) {
             if (onBeforeOpen) {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -179,7 +179,7 @@ export async function activate(): Promise<void> {
     // There may have already been registered CustomConfigurationProviders.
     // Request for configurations from those providers.
     clients.forEach(client => {
-        getCustomConfigProviders().forEach(provider => client.onRegisterCustomConfigurationProvider(provider));
+        getCustomConfigProviders().forEach(provider => void client.onRegisterCustomConfigurationProvider(provider));
     });
 
     disposables.push(vscode.workspace.onDidChangeConfiguration(onDidChangeSettings));
@@ -362,6 +362,7 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
 
 function onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]): void {
     // Process delayed didOpen for any visible editors we haven't seen before
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     editors.forEach(async (editor) => {
         if (util.isCpp(editor.document)) {
             const client: Client = clients.getClientFor(editor.document.uri);

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -315,7 +315,7 @@ export class OldUI implements UI {
     private configureIntelliSenseTimeout?: NodeJS.Timeout;
 
     public async ShowConfigureIntelliSenseButton(show: boolean, client?: Client): Promise<void> {
-        if (!telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
+        if (!await telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
             return;
         }
         this.showConfigureIntelliSenseButton = show;

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -16,7 +16,7 @@ import * as util from '../common';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
-let uiPromise: Promise<UI>;
+let uiPromise: Promise<UI> | undefined;
 let ui: UI;
 
 export interface UI {

--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -420,7 +420,7 @@ export class NewUI implements UI {
     private configureIntelliSenseTimeout?: NodeJS.Timeout;
 
     public async ShowConfigureIntelliSenseButton(show: boolean, client?: Client): Promise<void> {
-        if (!telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
+        if (!await telemetry.showStatusBarIntelliSenseButton() || client !== this.currentClient) {
             return;
         }
         this.showConfigureIntelliSenseButton = show;

--- a/Extension/src/SSH/sshCommandRunner.ts
+++ b/Extension/src/SSH/sshCommandRunner.ts
@@ -259,6 +259,7 @@ export function runInteractiveSshTerminalCommand(args: ITerminalCommandArgs): Pr
     const { systemInteractor, command, interactors, nickname, token } = args;
     let logIsPaused: boolean = false;
     const loggingLevel: string | undefined = new CppSettings().loggingLevel;
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return new Promise(async (resolve, reject) => {
         let stdout: string = '';
         let windowListener: vscode.Disposable | undefined;
@@ -445,7 +446,7 @@ export function runInteractiveSshTerminalCommand(args: ITerminalCommandArgs): Pr
                     return;
                 }
 
-                terminalDataHandlingQueue = terminalDataHandlingQueue.finally(() => handleTerminalOutput(e));
+                terminalDataHandlingQueue = terminalDataHandlingQueue.finally(() => void handleTerminalOutput(e));
             });
             terminal = systemInteractor.createTerminal(options);
 

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -762,6 +762,7 @@ interface ProcessOutput {
 }
 
 async function spawnChildProcessImpl(program: string, args: string[], continueOn?: string, cancellationToken?: vscode.CancellationToken): Promise<ProcessOutput> {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return new Promise(async (resolve, reject) => {
         // Do not use CppSettings to avoid circular require()
         const settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("C_Cpp", null);

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -910,15 +910,6 @@ export async function promptReloadWindow(message: string): Promise<void> {
     }
 }
 
-export async function addTrustedCompiler(compilers: string[], path: string): Promise<string[]> {
-    // Detect duplicate paths or invalid paths.
-    if (compilers.includes(path) || path === null || path === undefined) {
-        return compilers;
-    }
-    compilers.push(path);
-    return compilers;
-}
-
 export function createTempFileWithPostfix(postfix: string): Promise<tmp.FileResult> {
     return new Promise<tmp.FileResult>((resolve, reject) => {
         tmp.file({ postfix: postfix }, (err, path, fd, cleanupCallback) => {

--- a/Extension/src/cppTools.ts
+++ b/Extension/src/cppTools.ts
@@ -65,7 +65,7 @@ export class CppTools implements CppToolsTestApi {
                     getOutputChannel().appendLine(localize("provider.registered", "Custom configuration provider '{0}' registered", added.name));
                 }
                 this.providers.push(added);
-                LanguageServer.getClients().forEach(client => client.onRegisterCustomConfigurationProvider(added));
+                LanguageServer.getClients().forEach(client => void client.onRegisterCustomConfigurationProvider(added));
                 this.addNotifyReadyTimer(added);
             }
         } else {
@@ -99,7 +99,7 @@ export class CppTools implements CppToolsTestApi {
             if (!p.isReady) {
                 console.warn("didChangeCustomConfiguration was invoked before notifyReady");
             }
-            LanguageServer.getClients().forEach(client => client.updateCustomConfigurations(p));
+            LanguageServer.getClients().forEach(client => void client.updateCustomConfigurations(p));
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomConfiguration' ignored");
         } else {
@@ -112,7 +112,7 @@ export class CppTools implements CppToolsTestApi {
         const p: CustomConfigurationProvider1 | undefined = providers.get(provider);
 
         if (p) {
-            LanguageServer.getClients().forEach(client => client.updateCustomBrowseConfiguration(p));
+            LanguageServer.getClients().forEach(client => void client.updateCustomBrowseConfiguration(p));
         } else if (this.failedRegistrations.find(p => p === provider)) {
             console.warn("provider not successfully registered, 'didChangeCustomBrowseConfiguration' ignored");
         } else {


### PR DESCRIPTION
- Also, updated the changelog for 1.15.3.
- Also, did some refactoring since the exported compilerPaths variable was not debuggable for some unknown reason.
- Fix a missing await to call to async telemetry.showStatusBarIntelliSenseButton (which otherwise would always return true), and add linter check "@typescript-eslint/no-misused-promises": "error", to catch any future issues like this. Lines marked ` // eslint-disable-next-line @typescript-eslint/no-misused-promises` I didn't know to resolve, but we could deal with those later.