### PR TITLE
Fix configuration status not appearing.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,6 +1,6 @@
 # C/C++ for Visual Studio Code Changelog
 
-## Version 1.15.3: March 20, 2023
+## Version 1.15.3: March 24, 2023
 ### Bug Fix
 * Fix handling of sccache and clcache. [#7616](https://github.com/microsoft/vscode-cpptools/issues/7616)
 * Fix an undefined reference regression. [PR #10824](https://github.com/microsoft/vscode-cpptools/pull/10824)

--- a/Extension/src/LanguageServer/ui.ts
+++ b/Extension/src/LanguageServer/ui.ts
@@ -355,18 +355,16 @@ export class OldUI implements UI {
             if (isCppPropertiesJson) {
                 vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
             }
+            const isCppOrRelated: boolean = isCppPropertiesJson || util.isCppOrRelated(activeEditor.document);
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButtonForActiveFile: boolean = (isCppPropertiesJson || util.isCppOrRelated(activeEditor.document))
-                && !!this.currentClient && this.currentClient.getShowConfigureIntelliSenseButton();
-            this.ShowConfiguration = showConfigureIntelliSenseButtonForActiveFile ||
-                (util.getWorkspaceIsCpp() &&
+            this.ShowConfiguration = isCppOrRelated || (util.getWorkspaceIsCpp() &&
                     (activeEditor.document.fileName.endsWith("tasks.json") ||
                     activeEditor.document.fileName.endsWith("launch.json")));
 
             if (this.showConfigureIntelliSenseButton) {
-                if (showConfigureIntelliSenseButtonForActiveFile) {
+                if (isCppOrRelated && !!this.currentClient && this.currentClient.getShowConfigureIntelliSenseButton()) {
                     this.configureIntelliSenseStatusItem.show();
                     if (!this.configureIntelliSenseTimeout) {
                         this.configureIntelliSenseTimeout = setTimeout(() => {

--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -460,18 +460,16 @@ export class NewUI implements UI {
             if (isCppPropertiesJson) {
                 vscode.languages.setTextDocumentLanguage(activeEditor.document, "jsonc");
             }
+            const isCppOrRelated: boolean = isCppPropertiesJson || util.isCppOrRelated(activeEditor.document);
 
             // It's sometimes desirable to see the config and icons when making changes to files with C/C++-related content.
             // TODO: Check some "AlwaysShow" setting here.
-            const showConfigureIntelliSenseButtonForActiveFile: boolean = (isCppPropertiesJson || util.isCppOrRelated(activeEditor.document))
-                && !!this.currentClient && this.currentClient.getShowConfigureIntelliSenseButton();
-            this.ShowConfiguration = showConfigureIntelliSenseButtonForActiveFile ||
-                (util.getWorkspaceIsCpp() &&
+            this.ShowConfiguration = isCppOrRelated || (util.getWorkspaceIsCpp() &&
                     (activeEditor.document.fileName.endsWith("tasks.json") ||
                     activeEditor.document.fileName.endsWith("launch.json")));
 
             if (this.showConfigureIntelliSenseButton) {
-                if (showConfigureIntelliSenseButtonForActiveFile) {
+                if (isCppOrRelated && !!this.currentClient && this.currentClient.getShowConfigureIntelliSenseButton()) {
                     this.configureIntelliSenseStatusItem.show();
                     if (!this.configureIntelliSenseTimeout) {
                         this.configureIntelliSenseTimeout = setTimeout(() => {


### PR DESCRIPTION
Follow up to (i.e. caused by) https://github.com/microsoft/vscode-cpptools/pull/10838 .