### PR TITLE
Fix a couple Configure IntelliSense bugs with config providers

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix handling of sccache and clcache. [#7616](https://github.com/microsoft/vscode-cpptools/issues/7616)
 * Fix an undefined reference regression. [PR #10824](https://github.com/microsoft/vscode-cpptools/pull/10824)
 * Fix bugs with the "Configure IntelliSense" button. [#10810](https://github.com/microsoft/vscode-cpptools/issues/10810), [#10822](https://github.com/microsoft/vscode-cpptools/issues/10822), [#10827](https://github.com/microsoft/vscode-cpptools/issues/10827)
+* Fix a deadlock with Find All References. [#10855](https://github.com/microsoft/vscode-cpptools/issues/10855)
 
 ## Version 1.15.2: March 12, 2023
 ### Enhancements

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1373,7 +1373,7 @@ export class DefaultClient implements Client {
                                 global.setTimeout(() => {
                                     client.configStateReceived.timeout = true;
                                     client.handleConfigStatusOrPrompt();
-                                }, 15000);
+                                }, 5000);
                             }
                         });
                         // The configurations will not be sent to the language server until the default include paths and frameworks have been set.
@@ -1819,9 +1819,13 @@ export class DefaultClient implements Client {
             }
             this.configStateReceived.configProviders.push(provider);
             const selectedProvider: string | undefined = this.configuration.CurrentConfigurationProvider;
-            if (!selectedProvider) {
+            if (!selectedProvider || this.showConfigureIntelliSenseButton) {
                 this.handleConfigStatusOrPrompt("configProviders");
-            } else if (isSameProviderExtensionId(selectedProvider, provider.extensionId)) {
+                if (!selectedProvider) {
+                    return;
+                }
+            }
+            if (isSameProviderExtensionId(selectedProvider, provider.extensionId)) {
                 this.onCustomConfigurationProviderRegistered(provider);
                 telemetry.logLanguageServerEvent("customConfigurationProvider", { "providerId": provider.extensionId });
             } else if (selectedProvider === provider.name) {
@@ -2674,7 +2678,9 @@ export class DefaultClient implements Client {
         }
         const rootFolder: vscode.WorkspaceFolder | undefined = this.RootFolder;
         const settings: CppSettings = new CppSettings(this.RootUri);
-        const configProviderNotSet: boolean = !settings.defaultConfigurationProvider && !this.configuration.CurrentConfiguration?.configurationProvider && !this.configuration.CurrentConfiguration?.configurationProviderInCppPropertiesJson;
+        const configProviderNotSet: boolean = !settings.defaultConfigurationProvider && !this.configuration.CurrentConfiguration?.configurationProvider &&
+            !this.configuration.CurrentConfiguration?.configurationProviderInCppPropertiesJson;// &&
+            //(this.lastCustomBrowseConfigurationProviderId === undefined || this.lastCustomBrowseConfigurationProviderId.Value === undefined);
         const compileCommandsNotSet: boolean = !settings.defaultCompileCommands && !this.configuration.CurrentConfiguration?.compileCommands && !this.configuration.CurrentConfiguration?.compileCommandsInCppPropertiesJson;
 
         // Handle config providers

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2679,8 +2679,8 @@ export class DefaultClient implements Client {
         const rootFolder: vscode.WorkspaceFolder | undefined = this.RootFolder;
         const settings: CppSettings = new CppSettings(this.RootUri);
         const configProviderNotSet: boolean = !settings.defaultConfigurationProvider && !this.configuration.CurrentConfiguration?.configurationProvider &&
-            !this.configuration.CurrentConfiguration?.configurationProviderInCppPropertiesJson;// &&
-            //(this.lastCustomBrowseConfigurationProviderId === undefined || this.lastCustomBrowseConfigurationProviderId.Value === undefined);
+            !this.configuration.CurrentConfiguration?.configurationProviderInCppPropertiesJson &&
+            (this.lastCustomBrowseConfigurationProviderId === undefined || this.lastCustomBrowseConfigurationProviderId.Value === undefined);
         const compileCommandsNotSet: boolean = !settings.defaultCompileCommands && !this.configuration.CurrentConfiguration?.compileCommands && !this.configuration.CurrentConfiguration?.compileCommandsInCppPropertiesJson;
 
         // Handle config providers

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1373,7 +1373,7 @@ export class DefaultClient implements Client {
                                 global.setTimeout(() => {
                                     client.configStateReceived.timeout = true;
                                     client.handleConfigStatusOrPrompt();
-                                }, 5000);
+                                }, 15000);
                             }
                         });
                         // The configurations will not be sent to the language server until the default include paths and frameworks have been set.


### PR DESCRIPTION
Bug: If no configuration provider was explicitly set and it was defaulting to 1 provider and that provider hadn't registered yet, then it would incorrectly show the "Configure IntelliSense" button.

Bug: Also, the "Configure IntelliSense" button had already been triggered due to a timeout or compile commands coming in (and with no browse cache) then an incoming provider being registered wasn't clearing the Configure button.
