### PR TITLE
Always add `workspaceFolder` to `browse.path` if unset

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -937,9 +937,7 @@ export class CppProperties {
             if (!configuration.browse.path) {
                 if (settings.defaultBrowsePath) {
                     configuration.browse.path = settings.defaultBrowsePath;
-                } else if (configuration.includePath === undefined) {
-                    configuration.browse.path = [ "${workspaceFolder}" ];
-                } else if (configuration.includePath.length > 0) {
+                } else if (configuration.includePath) {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (configuration.includePath.findIndex((value: string, index: number) =>
@@ -947,6 +945,8 @@ export class CppProperties {
                     ) {
                         configuration.browse.path.push("${workspaceFolder}");
                     }
+                } else {
+                    configuration.browse.path = [ "${workspaceFolder}" ];
                 }
             } else {
                 configuration.browse.path = this.updateConfigurationPathsArray(configuration.browse.path, settings.defaultBrowsePath, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -937,7 +937,9 @@ export class CppProperties {
             if (!configuration.browse.path) {
                 if (settings.defaultBrowsePath) {
                     configuration.browse.path = settings.defaultBrowsePath;
-                } else if (configuration.includePath) {
+                } else if (configuration.includePath === undefined) {
+                    configuration.browse.path = [ "${workspaceFolder}" ];
+                } else if (configuration.includePath.length > 0) {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (configuration.includePath.findIndex((value: string, index: number) =>


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/10914

Ensures `workspaceFolder` is added to the `browse.path`, even if `includePath` is not set.

It's possible for the user to indicate they don't want their `workspaceFolder` parsed, by providing their own `browse.path` value and not specifying the workspace folder in it.