### PR TITLE
Add server-originated notification to cancel reference

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -639,6 +639,7 @@ const SetTemporaryTextDocumentLanguageNotification: NotificationType<SetTemporar
 const ReportCodeAnalysisProcessedNotification: NotificationType<number> = new NotificationType<number>('cpptools/reportCodeAnalysisProcessed');
 const ReportCodeAnalysisTotalNotification: NotificationType<number> = new NotificationType<number>('cpptools/reportCodeAnalysisTotal');
 const DoxygenCommentGeneratedNotification: NotificationType<GenerateDoxygenCommentResult> = new NotificationType<GenerateDoxygenCommentResult>('cpptools/insertDoxygenComment');
+const CanceledReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/canceledReferences');
 
 let failureMessageShown: boolean = false;
 
@@ -2324,6 +2325,7 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(ReportCodeAnalysisProcessedNotification, (e) => this.updateCodeAnalysisProcessed(e));
         this.languageClient.onNotification(ReportCodeAnalysisTotalNotification, (e) => this.updateCodeAnalysisTotal(e));
         this.languageClient.onNotification(DoxygenCommentGeneratedNotification, (e) => void this.insertDoxygenComment(e));
+        this.languageClient.onNotification(CanceledReferencesNotification, this.cancelReferences);
     }
 
     private setTextDocumentLanguage(languageStr: string): void {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -937,9 +937,7 @@ export class CppProperties {
             if (!configuration.browse.path) {
                 if (settings.defaultBrowsePath) {
                     configuration.browse.path = settings.defaultBrowsePath;
-                } else if (configuration.includePath === undefined) {
-                    configuration.browse.path = [ "${workspaceFolder}" ];
-                } else if (configuration.includePath.length > 0) {
+                } else if (configuration.includePath) {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (configuration.includePath.findIndex((value: string, index: number) =>
@@ -947,6 +945,8 @@ export class CppProperties {
                     ) {
                         configuration.browse.path.push("${workspaceFolder}");
                     }
+                } else {
+                    configuration.browse.path = [ "${workspaceFolder}" ];
                 }
             } else {
                 configuration.browse.path = this.updateConfigurationPathsArray(configuration.browse.path, settings.defaultBrowsePath, env);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -937,7 +937,9 @@ export class CppProperties {
             if (!configuration.browse.path) {
                 if (settings.defaultBrowsePath) {
                     configuration.browse.path = settings.defaultBrowsePath;
-                } else if (configuration.includePath) {
+                } else if (configuration.includePath === undefined) {
+                    configuration.browse.path = [ "${workspaceFolder}" ];
+                } else if (configuration.includePath.length > 0) {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (configuration.includePath.findIndex((value: string, index: number) =>


### PR DESCRIPTION
Exposes the `cancelReferences` function in `client.ts` via a server-originated notification, allowing the server side to trigger cancelation of FAR-related features without getting out of sync with the progress UI on the TypeScript side.