### PR TITLE
Call Hierarchy Callers Of - add progress and cancellation

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -3,8 +3,9 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient } from '../client';
+import { DefaultClient, CancelReferencesNotification, workspaceReferences } from '../client';
 import { processDelayedDidOpen } from '../extension';
+import { CallHierarchyResultCallback } from '../references';
 import { Position, Range, RequestType, TextDocumentIdentifier } from 'vscode-languageclient';
 import { makeVscodeRange } from '../utils';
 
@@ -41,7 +42,7 @@ interface CallHierarchyItem {
     selectionRange: Range;
 }
 
-interface CallHierarchyParams {
+export interface CallHierarchyParams {
     textDocument: TextDocumentIdentifier;
     position: Position;
 }
@@ -70,15 +71,12 @@ interface CallHierarchyCallsItem {
     fromRanges: Range[];
 }
 
-interface CallHierarchyCallsItemResult {
+export interface CallHierarchyCallsItemResult {
     calls: CallHierarchyCallsItem[];
 }
 
 const CallHierarchyItemRequest: RequestType<CallHierarchyParams, CallHierarchyItemResult, void> =
     new RequestType<CallHierarchyParams, CallHierarchyItemResult, void>('cpptools/prepareCallHierarchy');
-
-const CallHierarchyCallsToRequest: RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void> =
-    new RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void>('cpptools/callHierarchyCallsTo');
 
 const CallHierarchyCallsFromRequest: RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void> =
     new RequestType<CallHierarchyParams, CallHierarchyCallsItemResult, void>('cpptools/callHierarchyCallsFrom');
@@ -114,23 +112,65 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
         Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
-        if (item === undefined) {
-            return undefined;
-        }
+        return new Promise<vscode.CallHierarchyIncomingCall[] | undefined>((resolve, reject) => {
+            if (item === undefined) {
+                resolve(undefined);
+                return;
+            }
 
-        await this.client.awaitUntilLanguageClientReady();
-        const params: CallHierarchyParams = {
-            textDocument: { uri: item.uri.toString() },
-            position: Position.create(item.range.start.line, item.range.start.character)
-        };
-        const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, token);
-        if (token.isCancellationRequested || response.calls === undefined) {
-            throw new vscode.CancellationError();
-        } else if (response.calls.length === 0) {
-            return undefined;
-        }
+            const callback: () => Promise<void> = async () => {
+                await this.client.awaitUntilLanguageClientReady();
+                const params: CallHierarchyParams = {
+                    textDocument: { uri: item.uri.toString() },
+                    position: Position.create(item.range.start.line, item.range.start.character)
+                };
+                DefaultClient.referencesParams = params;
+                // The current request is represented by referencesParams.  If a request detects
+                // referencesParams does not match the object used when creating the request, abort it.
+                if (params !== DefaultClient.referencesParams) {
+                    // Complete with nothing instead of rejecting, to avoid an error message from VS Code
+                    resolve(undefined);
+                }
+                DefaultClient.referencesRequestPending = true;
 
-        return this.createIncomingCalls(response.calls);
+                // Register a single-fire handler for the reply.
+                const resultCallback: CallHierarchyResultCallback = (result: CallHierarchyCallsItemResult | null) => {
+                    DefaultClient.referencesRequestPending = false;
+                    if (result === null || result?.calls === undefined || result?.calls.length === 0) {
+                        resolve(undefined);
+                    } else {
+                        resolve(this.createIncomingCalls(result.calls));
+                    }
+
+                    this.client.clearPendingReferencesCancellations();
+                };
+
+                workspaceReferences.setCallHierarchyResultsCallback(resultCallback);
+                workspaceReferences.startCallHierarchyIncomingCalls(params);
+
+                token.onCancellationRequested(e => {
+                    if (params === DefaultClient.referencesParams) {
+                        this.client.cancelReferences();
+                    }
+                });
+            };
+
+            if (DefaultClient.referencesRequestPending || workspaceReferences.symbolSearchInProgress) {
+                const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
+                DefaultClient.referencesPendingCancellations.push({
+                    reject: () => {
+                        // Complete with nothing instead of rejecting, to avoid an error message from VS Code
+                        resolve(undefined);
+                    }, callback
+                });
+                if (!cancelling) {
+                    workspaceReferences.referencesCanceled = true;
+                    this.client.languageClient.sendNotification(CancelReferencesNotification);
+                }
+            } else {
+                callback();
+            }
+        });
     }
 
     public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -111,8 +111,8 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
     }
 
     public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
-        Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
-        const getIncomingCalls: any = new Promise<vscode.CallHierarchyIncomingCall[] | undefined>((resolve, reject) => {
+        Promise<vscode.CallHierarchyIncomingCall[] | undefined | any> {
+        new Promise<vscode.CallHierarchyIncomingCall[] | undefined | any>((resolve, reject) => {
             if (item === undefined) {
                 resolve(undefined);
                 return;
@@ -137,7 +137,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
                 const resultCallback: CallHierarchyResultCallback = (result: CallHierarchyCallsItemResult | null) => {
                     DefaultClient.referencesRequestPending = false;
                     if (result === null || result?.calls === undefined) {
-                        reject(undefined);
+                        reject(new vscode.CancellationError());
                     } else if (result?.calls.length === 0) {
                         resolve(undefined);
                     } else {
@@ -173,17 +173,6 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
                 callback();
             }
         });
-
-        let incomingCalls: vscode.CallHierarchyIncomingCall[] | undefined;
-        await getIncomingCalls.then((result: any) => {
-            incomingCalls = result;
-        }).catch((reason: any) => {
-            // The operation was cancelled by user or language server,
-            // return a cancellation error.
-            throw new vscode.CancellationError();
-        });
-
-        return incomingCalls;
     }
 
     public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -3,7 +3,7 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient, workspaceReferences, FindAllReferencesParams, ReferencesCancellationState, RequestReferencesNotification, CancelReferencesNotification } from '../client';
+import { DefaultClient, workspaceReferences, FindAllReferencesParams, RequestReferencesNotification, CancelReferencesNotification } from '../client';
 import { Position } from 'vscode-languageclient';
 import * as refs from '../references';
 
@@ -47,16 +47,8 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
                     if (doResolve) {
                         resolve(locations);
                     }
-                    if (DefaultClient.referencesPendingCancellations.length > 0) {
-                        while (DefaultClient.referencesPendingCancellations.length > 1) {
-                            const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-                            DefaultClient.referencesPendingCancellations.pop();
-                            pendingCancel.reject();
-                        }
-                        const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-                        DefaultClient.referencesPendingCancellations.pop();
-                        pendingCancel.callback();
-                    }
+
+                    this.client.clearPendingReferencesCancellations();
                 };
                 if (!workspaceReferences.referencesRefreshPending) {
                     workspaceReferences.setResultsCallback(resultCallback);

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -3,7 +3,7 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient, workspaceReferences, ReferencesCancellationState, RenameParams, CancelReferencesNotification } from '../client';
+import { DefaultClient, workspaceReferences, RenameParams, CancelReferencesNotification } from '../client';
 import * as refs from '../references';
 import { CppSettings } from '../settings';
 import { Position } from 'vscode-languageclient';
@@ -60,14 +60,7 @@ export class RenameProvider implements vscode.RenameProvider {
                     const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
                     const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
                     if (cancelling) {
-                        while (DefaultClient.referencesPendingCancellations.length > 1) {
-                            const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-                            DefaultClient.referencesPendingCancellations.pop();
-                            pendingCancel.reject();
-                        }
-                        const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-                        DefaultClient.referencesPendingCancellations.pop();
-                        pendingCancel.callback();
+                        this.client.clearPendingReferencesCancellations();
                     } else {
                         if (DefaultClient.renameRequestsPending === 0) {
                             DefaultClient.renamePending = false;

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -3,7 +3,7 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient, workspaceReferences, RenameParams, CancelReferencesNotification } from '../client';
+import { DefaultClient, workspaceReferences, ReferenceParams, CancelReferencesNotification } from '../client';
 import * as refs from '../references';
 import { CppSettings } from '../settings';
 import { Position } from 'vscode-languageclient';
@@ -34,7 +34,7 @@ export class RenameProvider implements vscode.RenameProvider {
         ++DefaultClient.renameRequestsPending;
         return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
             const callback: () => Promise<void> = async () => {
-                const params: RenameParams = {
+                const params: ReferenceParams = {
                     newName: newName,
                     position: Position.create(position.line, position.character),
                     textDocument: this.client.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document)

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -376,7 +376,7 @@ export interface LocalizeSymbolInformation {
     suffix: LocalizeStringParams;
 }
 
-export interface RenameParams {
+export interface ReferenceParams {
     newName: string;
     position: Position;
     textDocument: TextDocumentIdentifier;
@@ -605,7 +605,7 @@ export const CancelReferencesNotification: NotificationType<void> = new Notifica
 const FinishedRequestCustomConfig: NotificationType<FinishedRequestCustomConfigParams> = new NotificationType<FinishedRequestCustomConfigParams>('cpptools/finishedRequestCustomConfig');
 const FindAllReferencesNotification: NotificationType<FindAllReferencesParams> = new NotificationType<FindAllReferencesParams>('cpptools/findAllReferences');
 const CallHierarchyCallsToNotification: NotificationType<CallHierarchyParams> = new NotificationType<CallHierarchyParams>('cpptools/callHierarchyCallsTo');
-const RenameNotification: NotificationType<RenameParams> = new NotificationType<RenameParams>('cpptools/rename');
+const RenameNotification: NotificationType<ReferenceParams> = new NotificationType<ReferenceParams>('cpptools/rename');
 const DidChangeSettingsNotification: NotificationType<SettingsParams> = new NotificationType<SettingsParams>('cpptools/didChangeSettings');
 const InitializationNotification: NotificationType<InitializationOptions> = new NotificationType<InitializationOptions>('cpptools/initialize');
 
@@ -864,7 +864,7 @@ export class DefaultClient implements Client {
     private configStateReceived: ConfigStateReceived = { compilers: false, compileCommands: false, configProviders: undefined, timeout: false };
     private showConfigureIntelliSenseButton: boolean = false;
 
-    public static referencesParams: RenameParams | FindAllReferencesParams | CallHierarchyParams |undefined;
+    public static referencesParams: ReferenceParams | FindAllReferencesParams | CallHierarchyParams |undefined;
     public static referencesRequestPending: boolean = false;
     public static referencesPendingCancellations: ReferencesCancellationState[] = [];
 
@@ -1416,15 +1416,15 @@ export class DefaultClient implements Client {
         }
     }
 
-    public sendFindAllReferencesNotification(params: FindAllReferencesParams): void {
-        this.languageClient.sendNotification(FindAllReferencesNotification, params);
-    }
-
     public sendCallHierarchyCallsToNotification(params: CallHierarchyParams): void {
         this.languageClient.sendNotification(CallHierarchyCallsToNotification, params);
     }
 
-    public sendRenameNotification(params: RenameParams): void {
+    public sendFindAllReferencesNotification(params: FindAllReferencesParams): void {
+        this.languageClient.sendNotification(FindAllReferencesNotification, params);
+    }
+
+    public sendRenameNotification(params: ReferenceParams): void {
         this.languageClient.sendNotification(RenameNotification, params);
     }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -19,7 +19,7 @@ import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
 import { InlayHintsProvider } from './Providers/inlayHintProvider';
-import { CallHierarchyProvider } from './Providers/callHierarchyProvider';
+import { CallHierarchyCallsItemResult, CallHierarchyParams, CallHierarchyProvider } from './Providers/callHierarchyProvider';
 // End provider imports
 
 import { LanguageClientOptions, NotificationType, TextDocumentIdentifier, RequestType, ErrorAction, CloseAction, DidOpenTextDocumentParams, Range, Position } from 'vscode-languageclient';
@@ -604,6 +604,7 @@ export const RequestReferencesNotification: NotificationType<void> = new Notific
 export const CancelReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/cancelReferences');
 const FinishedRequestCustomConfig: NotificationType<FinishedRequestCustomConfigParams> = new NotificationType<FinishedRequestCustomConfigParams>('cpptools/finishedRequestCustomConfig');
 const FindAllReferencesNotification: NotificationType<FindAllReferencesParams> = new NotificationType<FindAllReferencesParams>('cpptools/findAllReferences');
+const CallHierarchyCallsToNotification: NotificationType<CallHierarchyParams> = new NotificationType<CallHierarchyParams>('cpptools/callHierarchyCallsTo');
 const RenameNotification: NotificationType<RenameParams> = new NotificationType<RenameParams>('cpptools/rename');
 const DidChangeSettingsNotification: NotificationType<SettingsParams> = new NotificationType<SettingsParams>('cpptools/didChangeSettings');
 const InitializationNotification: NotificationType<InitializationOptions> = new NotificationType<InitializationOptions>('cpptools/initialize');
@@ -625,6 +626,7 @@ const DebugLogNotification: NotificationType<LocalizeStringParams> = new Notific
 const InactiveRegionNotification: NotificationType<InactiveRegionParams> = new NotificationType<InactiveRegionParams>('cpptools/inactiveRegions');
 const CompileCommandsPathsNotification: NotificationType<CompileCommandsPaths> = new NotificationType<CompileCommandsPaths>('cpptools/compileCommandsPaths');
 const ReferencesNotification: NotificationType<refs.ReferencesResult> = new NotificationType<refs.ReferencesResult>('cpptools/references');
+const CallHierarchyNotification: NotificationType<CallHierarchyCallsItemResult> = new NotificationType<CallHierarchyCallsItemResult>('cpptools/callHierarchyCallsToResult');
 const ReportReferencesProgressNotification: NotificationType<refs.ReportReferencesProgressNotification> = new NotificationType<refs.ReportReferencesProgressNotification>('cpptools/reportReferencesProgress');
 const RequestCustomConfig: NotificationType<string> = new NotificationType<string>('cpptools/requestCustomConfig');
 const PublishIntelliSenseDiagnosticsNotification: NotificationType<PublishIntelliSenseDiagnosticsParams> = new NotificationType<PublishIntelliSenseDiagnosticsParams>('cpptools/publishIntelliSenseDiagnostics');
@@ -643,7 +645,7 @@ const CanceledReferencesNotification: NotificationType<void> = new NotificationT
 
 let failureMessageShown: boolean = false;
 
-export interface ReferencesCancellationState {
+interface ReferencesCancellationState {
     reject(): void;
     callback(): void;
 }
@@ -862,7 +864,7 @@ export class DefaultClient implements Client {
     private configStateReceived: ConfigStateReceived = { compilers: false, compileCommands: false, configProviders: undefined, timeout: false };
     private showConfigureIntelliSenseButton: boolean = false;
 
-    public static referencesParams: RenameParams | FindAllReferencesParams | undefined;
+    public static referencesParams: RenameParams | FindAllReferencesParams | CallHierarchyParams |undefined;
     public static referencesRequestPending: boolean = false;
     public static referencesPendingCancellations: ReferencesCancellationState[] = [];
 
@@ -1416,6 +1418,10 @@ export class DefaultClient implements Client {
 
     public sendFindAllReferencesNotification(params: FindAllReferencesParams): void {
         this.languageClient.sendNotification(FindAllReferencesNotification, params);
+    }
+
+    public sendCallHierarchyCallsToNotification(params: CallHierarchyParams): void {
+        this.languageClient.sendNotification(CallHierarchyCallsToNotification, params);
     }
 
     public sendRenameNotification(params: RenameParams): void {
@@ -2305,6 +2311,7 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(CompileCommandsPathsNotification, (e) => this.promptCompileCommands(e));
         this.languageClient.onNotification(ReferencesNotification, (e) => this.processReferencesResult(e));
         this.languageClient.onNotification(ReportReferencesProgressNotification, (e) => this.handleReferencesProgress(e));
+        this.languageClient.onNotification(CallHierarchyNotification, (e) => this.processCallHierarchyResult(e));
         this.languageClient.onNotification(RequestCustomConfig, (requestFile: string) => {
             const client: Client = clients.getClientFor(vscode.Uri.file(requestFile));
             if (client instanceof DefaultClient) {
@@ -3671,6 +3678,19 @@ export class DefaultClient implements Client {
         });
     }
 
+    public clearPendingReferencesCancellations(): void {
+        if (DefaultClient.referencesPendingCancellations.length > 0) {
+            while (DefaultClient.referencesPendingCancellations.length > 1) {
+                const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
+                DefaultClient.referencesPendingCancellations.pop();
+                pendingCancel.reject();
+            }
+            const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
+            DefaultClient.referencesPendingCancellations.pop();
+            pendingCancel.callback();
+        }
+    }
+
     public cancelReferences(): void {
         DefaultClient.referencesParams = undefined;
         DefaultClient.renamePending = false;
@@ -3693,6 +3713,10 @@ export class DefaultClient implements Client {
 
     private processReferencesResult(referencesResult: refs.ReferencesResult): void {
         workspaceReferences.processResults(referencesResult);
+    }
+
+    private processCallHierarchyResult(callHierarchyResult: CallHierarchyCallsItemResult): void {
+        workspaceReferences.processCallHierarchyResults(callHierarchyResult);
     }
 
     public setReferencesCommandMode(mode: refs.ReferencesCommandMode): void {

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 import * as vscode from 'vscode';
-import { DefaultClient, RenameParams, FindAllReferencesParams } from './client';
+import { DefaultClient, ReferenceParams, FindAllReferencesParams } from './client';
 import { FindAllRefsView } from './referencesView';
 import * as telemetry from '../telemetry';
 import * as nls from 'vscode-nls';
@@ -412,7 +412,7 @@ export class ReferencesManager {
         }
     }
 
-    public startRename(params: RenameParams): void {
+    public startRename(params: ReferenceParams): void {
         this.startRequest();
         if (this.referencesCanceled) {
             this.referencesCanceled = false;

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -12,6 +12,7 @@ import * as logger from '../logger';
 import { PersistentState } from './persistentState';
 import * as util from '../common';
 import { setInterval } from 'timers';
+import { CallHierarchyParams, CallHierarchyCallsItemResult } from './Providers/callHierarchyProvider';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -40,10 +41,12 @@ export interface ReferencesResult {
 }
 
 export type ReferencesResultCallback = (result: ReferencesResult | null, doResolve: boolean) => void;
+export type CallHierarchyResultCallback = (result: CallHierarchyCallsItemResult | null) => void;
 
 enum ReferencesProgress {
     Started,
     StartedRename,
+    StartedCallHierarchy,
     ProcessingSource,
     ProcessingTargets
 }
@@ -67,7 +70,8 @@ export enum ReferencesCommandMode {
     None,
     Find,
     Peek,
-    Rename
+    Rename,
+    CallHierarchy
 }
 
 export function referencesCommandModeToString(referencesCommandMode: ReferencesCommandMode): string {
@@ -78,6 +82,8 @@ export function referencesCommandModeToString(referencesCommandMode: ReferencesC
             return localize("peek.references", "Peek References");
         case ReferencesCommandMode.Rename:
             return localize("rename", "Rename");
+        case ReferencesCommandMode.CallHierarchy:
+            return localize("call.hierarchy", "Call Hierarchy");
         default:
             return "";
     }
@@ -194,6 +200,7 @@ export class ReferencesManager {
     private readonly ticksForDetectingPeek: number = 1000; // TODO: Might need tweaking?
 
     private resultsCallback?: ReferencesResultCallback;
+    private callHierarchyResultsCallback?: CallHierarchyResultCallback;
     private currentUpdateProgressTimer?: NodeJS.Timeout;
     private currentUpdateProgressResolve?: (value: unknown) => void;
     public groupByFile: PersistentState<boolean> = new PersistentState<boolean>("CPP.referencesGroupByFile", false);
@@ -241,6 +248,7 @@ export class ReferencesManager {
             switch (this.referencesCurrentProgress.referencesProgress) {
                 case ReferencesProgress.Started:
                 case ReferencesProgress.StartedRename:
+                case ReferencesProgress.StartedCallHierarchy:
                     progress.report({ message: localize("started", "Started."), increment: 0 });
                     break;
                 case ReferencesProgress.ProcessingSource:
@@ -312,10 +320,16 @@ export class ReferencesManager {
     private handleProgressStarted(referencesProgress: ReferencesProgress): void {
         this.referencesStartedWhileTagParsing = this.client.IsTagParsing;
 
-        const mode: ReferencesCommandMode =
-                (referencesProgress === ReferencesProgress.StartedRename) ? ReferencesCommandMode.Rename :
-                    (this.visibleRangesDecreased && (Date.now() - this.visibleRangesDecreasedTicks < this.ticksForDetectingPeek) ?
-                        ReferencesCommandMode.Peek : ReferencesCommandMode.Find);
+        let mode: ReferencesCommandMode = ReferencesCommandMode.None;
+        if (referencesProgress === ReferencesProgress.StartedCallHierarchy) {
+            mode = ReferencesCommandMode.CallHierarchy;
+        } else if (referencesProgress === ReferencesProgress.StartedRename) {
+            mode = ReferencesCommandMode.Rename;
+        } else if (this.visibleRangesDecreased && (Date.now() - this.visibleRangesDecreasedTicks < this.ticksForDetectingPeek)) {
+            mode = ReferencesCommandMode.Peek;
+        } else {
+            mode = ReferencesCommandMode.Find;
+        }
         this.client.setReferencesCommandMode(mode);
 
         this.referencesPrevProgressIncrement = 0;
@@ -324,12 +338,11 @@ export class ReferencesManager {
         this.currentUpdateProgressTimer = undefined;
         this.currentUpdateProgressResolve = undefined;
         let referencePreviousProgressUICounter: number = 0;
-
         this.clearViews();
 
         this.referencesDelayProgress = setInterval(() => {
-
-            this.referencesProgressOptions = { location: vscode.ProgressLocation.Notification, title: referencesCommandModeToString(this.client.ReferencesCommandMode), cancellable: true };
+            const progressTitle: string = referencesCommandModeToString(this.client.ReferencesCommandMode);
+            this.referencesProgressOptions = { location: vscode.ProgressLocation.Notification, title: progressTitle, cancellable: true };
             this.referencesProgressMethod = (progress: vscode.Progress<{message?: string; increment?: number }>, token: vscode.CancellationToken) =>
                 new Promise((resolve) => {
                     this.currentUpdateProgressResolve = resolve;
@@ -368,6 +381,7 @@ export class ReferencesManager {
         this.initializeViews();
 
         switch (notificationBody.referencesProgress) {
+            case ReferencesProgress.StartedCallHierarchy:
             case ReferencesProgress.StartedRename:
             case ReferencesProgress.Started:
                 if (this.client.ReferencesCommandMode === ReferencesCommandMode.Peek) {
@@ -381,35 +395,50 @@ export class ReferencesManager {
         }
     }
 
-    public startRename(params: RenameParams): void {
+    private startRequest(): void {
         this.lastResults = null;
         this.referencesFinished = false;
         this.referencesRequestHasOccurred = false;
         this.referencesRequestPending = false;
         this.referencesCanceledWhilePreviewing = false;
+    }
+
+    private cancelRequests(): void {
+        if (this.resultsCallback) {
+            this.resultsCallback(null, true);
+        }
+        if (this.callHierarchyResultsCallback) {
+            this.callHierarchyResultsCallback(null);
+        }
+    }
+
+    public startRename(params: RenameParams): void {
+        this.startRequest();
         if (this.referencesCanceled) {
             this.referencesCanceled = false;
-            if (this.resultsCallback) {
-                this.resultsCallback(null, true);
-            }
+            this.cancelRequests();
         } else {
             this.client.sendRenameNotification(params);
         }
     }
 
     public startFindAllReferences(params: FindAllReferencesParams): void {
-        this.lastResults = null;
-        this.referencesFinished = false;
-        this.referencesRequestHasOccurred = false;
-        this.referencesRequestPending = false;
-        this.referencesCanceledWhilePreviewing = false;
+        this.startRequest();
         if (this.referencesCanceled) {
             this.referencesCanceled = false;
-            if (this.resultsCallback) {
-                this.resultsCallback(null, true);
-            }
+            this.cancelRequests();
         } else {
             this.client.sendFindAllReferencesNotification(params);
+        }
+    }
+
+    public startCallHierarchyIncomingCalls(params: CallHierarchyParams): void {
+        this.startRequest();
+        if (this.referencesCanceled) {
+            this.referencesCanceled = false;
+            this.cancelRequests();
+        } else {
+            this.client.sendCallHierarchyCallsToNotification(params);
         }
     }
 
@@ -524,6 +553,40 @@ export class ReferencesManager {
     public setResultsCallback(callback: ReferencesResultCallback): void {
         this.symbolSearchInProgress = true;
         this.resultsCallback = callback;
+    }
+
+    public processCallHierarchyResults(callHierarchyResult: CallHierarchyCallsItemResult): void {
+        const referencesCanceled: boolean = this.referencesCanceled;
+
+        // Need to reset these before we call the callback, as the callback my trigger another request
+        // and we need to ensure these values are already reset before that happens.
+        this.referencesCanceled = false;
+        this.referencesRequestPending = false;
+        this.symbolSearchInProgress = false;
+        if (this.referencesDelayProgress) {
+            clearInterval(this.referencesDelayProgress);
+        }
+        if (this.currentUpdateProgressTimer) {
+            if (this.currentUpdateProgressTimer) {
+                clearInterval(this.currentUpdateProgressTimer);
+            }
+            if (this.currentUpdateProgressResolve) {
+                this.currentUpdateProgressResolve(undefined);
+            }
+            this.currentUpdateProgressResolve = undefined;
+            this.currentUpdateProgressTimer = undefined;
+        }
+        this.client.setReferencesCommandMode(ReferencesCommandMode.None);
+
+        // Execute the callback.
+        if (this.callHierarchyResultsCallback) {
+            this.callHierarchyResultsCallback(referencesCanceled ? null : callHierarchyResult);
+        }
+    }
+
+    public setCallHierarchyResultsCallback(callback: CallHierarchyResultCallback): void {
+        this.symbolSearchInProgress = true;
+        this.callHierarchyResultsCallback = callback;
     }
 
     public clearViews(): void {


### PR DESCRIPTION
This changeset is for the call hierarchy callers of operation.

- Add progress notification window to show the progress of a "callers of" search. UI is similar to the reference search progress notification window. Re-uses implementation of reference search notification progress but without the "preview" feature.
- Add the ability to cancel a "callers of" operation from the progress notification window. When it is canceled, no results are returned.

![image](https://github.com/microsoft/vscode-cpptools/assets/38734287/f2ba16ec-dd54-4c77-b1e9-69de94a808b1)

Note: this has a corresponding language server changeset.
