### PR TITLE
Fix addTrustedCompiler.

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -64,6 +64,11 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         this.type = type;
     }
 
+    public static ClearDetectedBuildTasks(): void {
+        DebugConfigurationProvider.detectedCppBuildTasks = [];
+        DebugConfigurationProvider.detectedCBuildTasks = [];
+    }
+
     /**
      * Returns a list of initial debug configurations based on contextual information, e.g. package.json or folder.
      * resolveDebugConfiguration will be automatically called after this function.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3736,15 +3736,13 @@ export class DefaultClient implements Client {
         this.model.referencesCommandMode.Value = mode;
     }
 
-    public addTrustedCompiler(path: string): Promise<void> {
+    public async addTrustedCompiler(path: string): Promise<void> {
         // Detect duplicate paths or invalid paths.
         if (trustedCompilerPaths.includes(path) || path === null || path === undefined) {
             return Promise.resolve();
         }
         trustedCompilerPaths.push(path);
-        return this.requestCompiler(path).then((result) => {
-            compilerDefaults = result;
-        });
+        compilerDefaults = await this.requestCompiler(path);
     }
 }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3741,7 +3741,7 @@ export class DefaultClient implements Client {
     public async addTrustedCompiler(path: string): Promise<void> {
         // Detect duplicate paths or invalid paths.
         if (trustedCompilerPaths.includes(path) || path === null || path === undefined) {
-            return Promise.resolve();
+            return;
         }
         trustedCompilerPaths.push(path);
         compilerDefaults = await this.requestCompiler(path);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -53,6 +53,7 @@ import {
 } from './codeAnalysis';
 import { DebugProtocolParams, getDiagnosticsChannel, getOutputChannelLogger, logDebugProtocol, Logger, logLocalized, showWarning, ShowWarningParams } from '../logger';
 import _ = require('lodash');
+import { DebugConfigurationProvider } from '../Debugger/configurationProvider';
 
 const deepCopy = (obj: any) => _.cloneDeep(obj);
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -3739,12 +3740,16 @@ export class DefaultClient implements Client {
     }
 
     public async addTrustedCompiler(path: string): Promise<void> {
-        // Detect duplicate paths or invalid paths.
-        if (trustedCompilerPaths.includes(path) || path === null || path === undefined) {
+        if (path === null || path === undefined) {
+            return;
+        }
+        if (trustedCompilerPaths.includes(path)) {
+            DebugConfigurationProvider.ClearDetectedBuildTasks();
             return;
         }
         trustedCompilerPaths.push(path);
         compilerDefaults = await this.requestCompiler(path);
+        DebugConfigurationProvider.ClearDetectedBuildTasks();
     }
 }
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -20,7 +20,7 @@ import * as nls from 'vscode-nls';
 import { setTimeout } from 'timers';
 import * as which from 'which';
 import { getOutputChannelLogger } from '../logger';
-import { addTrustedCompiler, DefaultClient } from './client';
+import { DefaultClient } from './client';
 import { UI, getUI } from './ui';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -908,7 +908,7 @@ export class CppProperties {
                 } else {
                     // add compiler to list of trusted compilers
                     if (i === this.CurrentConfigurationIndex) {
-                        addTrustedCompiler(configuration.compilerPath);
+                        this.client.addTrustedCompiler(configuration.compilerPath);
                     }
                 }
             } else {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -153,7 +153,7 @@ export async function deactivate(): Promise<void> {
     Telemetry.deactivate();
     disposables.forEach(d => d.dispose());
     if (languageServiceDisabled) {
-        return Promise.resolve();
+        return;
     }
     await LanguageServer.deactivate();
     disposeOutputChannels();


### PR DESCRIPTION
TypeScript changes related to https://github.com/microsoft/vscode-cpptools/issues/10943 .

- The previous code wasn't sending the added trusted compilers to the native side so the known compilers wasn't getting updated.
- The previous code was sending trusted compilers as an array when that isn't needed.