### PR TITLE
Support server-side cancellation/error in CDD

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -333,8 +333,8 @@ export interface CreateDeclarationOrDefinitionParams {
 
 export interface CreateDeclarationOrDefinitionResult {
     edit: WorkspaceEdit;
-    clipboardText: string;
-    errorText: string;
+    clipboardText?: string;
+    errorText?: string;
 }
 
 interface ShowMessageWindowParams {
@@ -3524,7 +3524,9 @@ export class DefaultClient implements Client {
         const result: CreateDeclarationOrDefinitionResult = await this.languageClient.sendRequest(CreateDeclarationOrDefinitionRequest, params);
         // Create/Copy returned no result.
         if (result.edit === undefined) {
-            vscode.window.showInformationMessage(result.errorText); // Copy/Create Declaration/Definition was completely unsuccessful due to api failure.
+            // The only condition in which result.edit would be undefined is a
+            // server-initiated cancellation, in which case the object is actually
+            // a ResponseError.
             return;
         }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3526,7 +3526,7 @@ export class DefaultClient implements Client {
         if (result.edit === undefined) {
             // The only condition in which result.edit would be undefined is a
             // server-initiated cancellation, in which case the object is actually
-            // a ResponseError.
+            // a ResponseError. https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
             return;
         }
 


### PR DESCRIPTION
Minor changes to parallel fixes in native-side PR.  (472323)

Makes 2 fields optional.

Fixes a check for undefined that should only occur if an non-optional field is undefined, which is only possible in the error condition explained in the comment.