### PR TITLE
Fix incorrect workspace parsing status.

### DIFF
--- a/Extension/src/LanguageServer/ui_new.ts
+++ b/Extension/src/LanguageServer/ui_new.ts
@@ -175,6 +175,10 @@ export class NewUI implements UI {
 
     private dbTimeout?: NodeJS.Timeout;
     private setIsParsingWorkspace(val: boolean): void {
+        if (!val && this.isParsingWorkspacePaused) {
+            // Unpause before handling the no longer parsing state.
+            this.setIsParsingWorkspacePaused(false);
+        }
         this.isParsingWorkspace = val;
         const showIcon: boolean = val || this.isParsingFiles;
 


### PR DESCRIPTION
My repro was with a config provider workspace. It might be the same bug as https://github.com/microsoft/vscode-cpptools/issues/10749 , but I'm not sure yet.