### PR TITLE
configurationProvider.ts: use integratedTerminal for cl.exe

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -434,7 +434,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 if (newConfig.type === DebuggerType.cppdbg) {
                     newConfig.externalConsole = false;
                 } else {
-                    newConfig.console = "externalTerminal";
+                    newConfig.console = "integratedTerminal";
                 }
                 const isWindows: boolean = platformInfo.platform === 'win32';
                 // Extract the .exe path from the defined task.


### PR DESCRIPTION
Solves #11032

This patch will check if the compiler is `cl.exe` and use `integratedTerminal` instead of `externalTerminal`.