### PR TITLE
Add some missing calls to `notifyWhenLanguageClientReady`/`awaitUntilLanguageClientReady`

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -125,6 +125,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
         Promise<vscode.CallHierarchyIncomingCall[] | undefined | any> {
+        await this.client.awaitUntilLanguageClientReady();
         return new Promise<vscode.CallHierarchyIncomingCall[] | undefined | any>((resolve, reject) => {
             const CallHierarchyCallsToEvent: string = "CallHierarchyCallsTo";
             if (item === undefined) {
@@ -134,7 +135,6 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
             }
 
             const callback: () => Promise<void> = async () => {
-                await this.client.awaitUntilLanguageClientReady();
                 const params: CallHierarchyParams = {
                     textDocument: { uri: item.uri.toString() },
                     position: Position.create(item.range.start.line, item.range.start.character)
@@ -198,13 +198,12 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
         Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
+        await this.client.awaitUntilLanguageClientReady();
         const CallHierarchyCallsFromEvent: string = "CallHierarchyCallsFrom";
         if (item === undefined) {
             this.logTelemetry(CallHierarchyCallsFromEvent, CallHierarchyRequestStatus.Failed);
             return undefined;
         }
-
-        await this.client.awaitUntilLanguageClientReady();
 
         let result: vscode.CallHierarchyOutgoingCall[] | undefined;
         const params: CallHierarchyParams = {

--- a/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/documentSymbolProvider.ts
@@ -53,6 +53,7 @@ export class DocumentSymbolProvider implements vscode.DocumentSymbolProvider {
         }
         return documentSymbols;
     }
+
     public async provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[] | vscode.DocumentSymbol[]> {
         const client: Client = clients.getClientFor(document.uri);
         if (client instanceof DefaultClient) {

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -12,7 +12,9 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
     constructor(client: DefaultClient) {
         this.client = client;
     }
+
     public async provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): Promise<vscode.Location[] | undefined> {
+        await this.client.awaitUntilLanguageClientReady();
         return new Promise<vscode.Location[]>((resolve, reject) => {
             const callback: () => Promise<void> = async () => {
                 const params: FindAllReferencesParams = {
@@ -20,7 +22,6 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
                     textDocument: this.client.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document)
                 };
                 DefaultClient.referencesParams = params;
-                await this.client.awaitUntilLanguageClientReady();
                 // The current request is represented by referencesParams.  If a request detects
                 // referencesParams does not match the object used when creating the request, abort it.
                 if (params !== DefaultClient.referencesParams) {

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -19,6 +19,7 @@ export class RenameProvider implements vscode.RenameProvider {
         this.client = client;
     }
     public async provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): Promise<vscode.WorkspaceEdit> {
+        await this.client.awaitUntilLanguageClientReady();
         const settings: CppSettings = new CppSettings();
         if (settings.renameRequiresIdentifier && !util.isValidIdentifier(newName)) {
             vscode.window.showErrorMessage(localize("invalid.identifier.for.rename", "Invalid identifier provided for the Rename Symbol operation."));
@@ -40,7 +41,6 @@ export class RenameProvider implements vscode.RenameProvider {
                     textDocument: this.client.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document)
                 };
                 DefaultClient.referencesParams = params;
-                await this.client.awaitUntilLanguageClientReady();
                 // The current request is represented by referencesParams.  If a request detects
                 // referencesParams does not match the object used when creating the request, abort it.
                 if (params !== DefaultClient.referencesParams) {

--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -18,6 +18,7 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
             query: query
         };
 
+        await this.client.awaitUntilLanguageClientReady();
         const symbols: LocalizeSymbolInformation[] = await this.client.languageClient.sendRequest(GetSymbolInfoRequest, params, token);
         const resultSymbols: vscode.SymbolInformation[] = [];
         if (token.isCancellationRequested) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1154,6 +1154,7 @@ export class DefaultClient implements Client {
     }
 
     public async rescanCompilers(sender?: any): Promise<void> {
+        await this.awaitUntilLanguageClientReady();
         compilerDefaults = await this.requestCompiler();
         DefaultClient.updateClientConfigurations();
         if (compilerDefaults.knownCompilers !== undefined && compilerDefaults.knownCompilers.length > 0) {
@@ -2801,7 +2802,6 @@ export class DefaultClient implements Client {
         const params: QueryDefaultCompilerParams = {
             newTrustedCompilerPath: newCompilerPath ?? ""
         };
-        await this.awaitUntilLanguageClientReady();
         const results: configs.CompilerDefaults = await this.languageClient.sendRequest(QueryCompilerDefaultsRequest, params);
         vscode.commands.executeCommand('setContext', 'cpptools.scanForCompilersDone', true);
         vscode.commands.executeCommand('setContext', 'cpptools.scanForCompilersEmpty', results.knownCompilers === undefined || !results.knownCompilers.length);
@@ -3739,6 +3739,7 @@ export class DefaultClient implements Client {
             return;
         }
         trustedCompilerPaths.push(path);
+        await this.awaitUntilLanguageClientReady();
         compilerDefaults = await this.requestCompiler(path);
         DebugConfigurationProvider.ClearDetectedBuildTasks();
     }


### PR DESCRIPTION
I had recently worked around some native-side crashes, based on collected crash stacks.  But I didn't know the root causes. I now believe they were caused by certain messages being delivered to the native side before the `initialize` message had been received, so before settings were properly populated.

I had previously separated out our own initialization message from the default one, into a second initialization message, as we can't do any logging from the initial initialization handler.  This secondary initialization message introduced a slim window in which another message could potentially get queued before it, if that code didn't properly leverage `notifyWhenLanguageClientReady`/`awaitUntilLanguageClientReady` to wait until the language client was safe to use.

Some of these changes may be superfluous, as they may be happening after other successful waits for the language client to be ready.  The main ones I believe were causing the issues were related to custom configuration providers. I went ahead and 'shored up' any existing uses of the `languageClient` that I could find that did not have obvious protection against this scenario.