### PR TITLE
Fix references cancellation and preview

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -164,12 +164,8 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         // Reset anything that can be cleared before procossing the result.
         const progressBarDuration: number | undefined = workspaceReferences.getCallHierarchyProgressBarDuration();
         workspaceReferences.resetProgressBar();
-        if (cancellationTokenListener) {
-            cancellationTokenListener.dispose();
-        }
-        if (requestCanceledListener) {
-            requestCanceledListener.dispose();
-        }
+        cancellationTokenListener.dispose();
+        requestCanceledListener.dispose();
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.calls === undefined || requestCanceled !== undefined) {

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -116,14 +116,11 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
         // Listen to a cancellation for this request. When this request is cancelled,
         // use a local cancellation source to explicitly cancel a token.
-        let requestCanceled: CancellationSender | undefined;
         const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
         const cancellationTokenListener: vscode.Disposable = token.onCancellationRequested(() => {
-            requestCanceled = CancellationSender.ProviderToken;
             cancelSource.cancel();
         });
         const requestCanceledListener: vscode.Disposable = workspaceReferences.onCancellationRequested(sender => {
-            requestCanceled = sender;
             cancelSource.cancel();
         });
 

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -141,7 +141,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         }
 
         // Listen to a cancellation for this request. When this request is cancelled,
-        // use a local cancellation source to implicitly cancel a token.
+        // use a local cancellation source to explicitly cancel a token.
         let requestCanceled: CancellationSender | undefined;
         const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
         const cancellationTokenListener: vscode.Disposable = token.onCancellationRequested(() => {

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -134,7 +134,11 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         requestCanceledListener.dispose();
 
         if (cancelSource.token.isCancellationRequested || response.succeeded === undefined) {
-            throw new vscode.CancellationError();
+            // Return undefined instead of vscode.CancellationError to avoid the following error message from VS Code:
+            // "MISSING provider."
+            // TODO: per issue https://github.com/microsoft/vscode/issues/169698 vscode.CancellationError is expected,
+            // so when VS Code fixes the error use vscode.CancellationError again.
+            return undefined;
         } else if (response.item === undefined) {
             return undefined;
         }

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -164,6 +164,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         // Reset anything that can be cleared before procossing the result.
         const progressBarDuration: number | undefined = workspaceReferences.getCallHierarchyProgressBarDuration();
         workspaceReferences.resetProgressBar();
+        workspaceReferences.resetReferences();
         cancellationTokenListener.dispose();
         requestCanceledListener.dispose();
 

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -54,7 +54,7 @@ interface CallHierarchyItemResult {
 
     /**
      * If a request is cancelled, `succeeded` will be undefined to indicate no result was returned.
-     * Therfore, object is not defined as optional on the language server.
+     * Therefore, object is not defined as optional on the language server.
      */
     succeeded: boolean;
 }
@@ -81,7 +81,7 @@ enum CallHierarchyRequestStatus {
     Unknown,
     Succeeded,
     Canceled,
-    CaneledByUser,
+    CanceledByUser,
     Failed
 }
 
@@ -179,7 +179,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         };
         const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, cancelSource.token);
 
-        // Reset anything that can be cleared before procossing the result.
+        // Reset anything that can be cleared before processing the result.
         const progressBarDuration: number | undefined = workspaceReferences.getCallHierarchyProgressBarDuration();
         workspaceReferences.resetProgressBar();
         workspaceReferences.resetReferences();
@@ -189,7 +189,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.calls === undefined || requestCanceled !== undefined) {
             const requestStatus: CallHierarchyRequestStatus = requestCanceled === CancellationSender.User ?
-                CallHierarchyRequestStatus.CaneledByUser : CallHierarchyRequestStatus.Canceled;
+                CallHierarchyRequestStatus.CanceledByUser : CallHierarchyRequestStatus.Canceled;
             this.logTelemetry(CallHierarchyCallsToEvent, requestStatus, progressBarDuration);
             throw new vscode.CancellationError();
         } else if (response.calls.length !== 0) {
@@ -283,7 +283,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
             case CallHierarchyRequestStatus.Unknown: status = "Unknown"; break;
             case CallHierarchyRequestStatus.Succeeded: status = "Succeeded"; break;
             case CallHierarchyRequestStatus.Canceled: status = "Canceled"; break;
-            case CallHierarchyRequestStatus.CaneledByUser: status = "CaneledByUser"; break;
+            case CallHierarchyRequestStatus.CanceledByUser: status = "CanceledByUser"; break;
             case CallHierarchyRequestStatus.Failed: status = "Failed"; break;
         }
 

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -3,97 +3,73 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient, workspaceReferences, FindAllReferencesParams, RequestReferencesNotification, CancelReferencesNotification } from '../client';
-import { Position } from 'vscode-languageclient';
+import { DefaultClient, workspaceReferences } from '../client';
+import { Position, TextDocumentIdentifier } from 'vscode-languageclient';
 import * as refs from '../references';
+
+export interface FindAllReferencesParams {
+    position: Position;
+    textDocument: TextDocumentIdentifier;
+}
 
 export class FindAllReferencesProvider implements vscode.ReferenceProvider {
     private client: DefaultClient;
+
     constructor(client: DefaultClient) {
         this.client = client;
     }
-    public async provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): Promise<vscode.Location[] | undefined> {
-        return new Promise<vscode.Location[]>((resolve, reject) => {
-            const callback: () => Promise<void> = async () => {
-                const params: FindAllReferencesParams = {
-                    position: Position.create(position.line, position.character),
-                    textDocument: this.client.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document)
-                };
-                DefaultClient.referencesParams = params;
-                await this.client.awaitUntilLanguageClientReady();
-                // The current request is represented by referencesParams.  If a request detects
-                // referencesParams does not match the object used when creating the request, abort it.
-                if (params !== DefaultClient.referencesParams) {
-                    // Complete with nothing instead of rejecting, to avoid an error message from VS Code
-                    const locations: vscode.Location[] = [];
-                    resolve(locations);
-                    return;
-                }
-                DefaultClient.referencesRequestPending = true;
-                // Register a single-fire handler for the reply.
-                const resultCallback: refs.ReferencesResultCallback = (result: refs.ReferencesResult | null, doResolve: boolean) => {
-                    DefaultClient.referencesRequestPending = false;
-                    const locations: vscode.Location[] = [];
-                    if (result) {
-                        result.referenceInfos.forEach((referenceInfo: refs.ReferenceInfo) => {
-                            if (referenceInfo.type === refs.ReferenceType.Confirmed) {
-                                const uri: vscode.Uri = vscode.Uri.file(referenceInfo.file);
-                                const range: vscode.Range = new vscode.Range(referenceInfo.position.line, referenceInfo.position.character, referenceInfo.position.line, referenceInfo.position.character + result.text.length);
-                                locations.push(new vscode.Location(uri, range));
-                            }
-                        });
-                    }
-                    // If references were canceled while in a preview state, there is not an outstanding promise.
-                    if (doResolve) {
-                        resolve(locations);
-                    }
 
-                    this.client.clearPendingReferencesCancellations();
-                };
-                if (!workspaceReferences.referencesRefreshPending) {
-                    workspaceReferences.setResultsCallback(resultCallback);
-                    workspaceReferences.startFindAllReferences(params);
+    public async provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken):
+        Promise<vscode.Location[] | undefined> {
+        await this.client.awaitUntilLanguageClientReady();
+
+        // Cancel any current reference requests by firing a cancellation event to listeners.
+        workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.NewRequest);
+
+        // Listen to VS Code cancellation.
+        let requestCanceled: refs.CancellationSender = refs.CancellationSender.None;
+        token.onCancellationRequested(e => { requestCanceled = refs.CancellationSender.ProviderToken; });
+
+        // Process the request.
+        return new Promise<vscode.Location[]>((resolve, reject) => {
+            // Listen to cancellation from an incoming new request, user or language server.
+            workspaceReferences.onCancellationRequested(sender => { requestCanceled = sender; });
+
+            // Define the callback that will process results.
+            const resultCallback: refs.ReferencesResultCallback = (result: refs.ReferencesResult | null) => {
+                if (result === null) {
+                    // Nothing to resolve.
+                    reject(new vscode.CancellationError());
                 } else {
-                    // We are responding to a refresh (preview or final result)
-                    workspaceReferences.referencesRefreshPending = false;
-                    if (workspaceReferences.lastResults) {
-                        // This is a final result
-                        const lastResults: refs.ReferencesResult = workspaceReferences.lastResults;
-                        workspaceReferences.lastResults = null;
-                        resultCallback(lastResults, true);
-                    } else {
-                        // This is a preview (2nd or later preview)
-                        workspaceReferences.referencesRequestPending = true;
-                        workspaceReferences.setResultsCallback(resultCallback);
-                        this.client.languageClient.sendNotification(RequestReferencesNotification);
-                    }
+                    const locationsResult: vscode.Location[] = [];
+                    result.referenceInfos.forEach((referenceInfo: refs.ReferenceInfo) => {
+                        if (referenceInfo.type === refs.ReferenceType.Confirmed) {
+                            const uri: vscode.Uri = vscode.Uri.file(referenceInfo.file);
+                            const range: vscode.Range = new vscode.Range(referenceInfo.position.line, referenceInfo.position.character,
+                                referenceInfo.position.line, referenceInfo.position.character + result.text.length);
+                            locationsResult.push(new vscode.Location(uri, range));
+                        }
+                    });
+
+                    resolve(locationsResult);
                 }
-                token.onCancellationRequested(e => {
-                    if (params === DefaultClient.referencesParams) {
-                        this.client.cancelReferences();
-                    }
-                });
+                return;
             };
 
-            if (DefaultClient.referencesRequestPending || (workspaceReferences.symbolSearchInProgress && !workspaceReferences.referencesRefreshPending)) {
-                const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
-                DefaultClient.referencesPendingCancellations.push({
-                    reject: () => {
-                        // Complete with nothing instead of rejecting, to avoid an error message from VS Code
-                        const locations: vscode.Location[] = [];
-                        resolve(locations);
-                    }, callback
-                });
-                if (!cancelling) {
-                    DefaultClient.renamePending = false;
-                    workspaceReferences.referencesCanceled = true;
-                    if (!DefaultClient.referencesRequestPending) {
-                        workspaceReferences.referencesCanceledWhilePreviewing = true;
-                    }
-                    this.client.languageClient.sendNotification(CancelReferencesNotification);
-                }
+            if (requestCanceled === refs.CancellationSender.None) {
+                workspaceReferences.setReferencesResultsCallback(resultCallback);
+
+                // Send the request to language server.
+                const params: FindAllReferencesParams = {
+                    position: Position.create(position.line, position.character),
+                    textDocument: { uri: document.uri.toString() }
+                };
+                workspaceReferences.startFindAllReferences(params);
             } else {
-                callback();
+                // Only complete the request at this point if the request to language server
+                // has not been sent. Otherwise, the cancellation is handled when language
+                // server has completed/canceled its processing and sends the results.
+                resultCallback(null);
             }
         });
     }

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -44,7 +44,6 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {
-            workspaceReferences.resetFindAllReferences();
             throw new vscode.CancellationError();
         } else if (response.referenceInfos.length !== 0) {
             response.referenceInfos.forEach((referenceInfo: ReferenceInfo) => {

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -45,7 +45,9 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {
-            throw new vscode.CancellationError();
+            // Return undefined instead of vscode.CancellationError to avoid the following error message from VS Code:
+            // "Cannot destructure property 'range' of 'e.location' as it is undefined."
+            return undefined;
         } else if (response.referenceInfos.length !== 0) {
             response.referenceInfos.forEach((referenceInfo: ReferenceInfo) => {
                 if (referenceInfo.type === ReferenceType.Confirmed) {

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -38,6 +38,7 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
         const response: ReferencesResult = await this.client.languageClient.sendRequest(FindAllReferencesRequest, params, cancelSource.token);
 
         // Reset anything that can be cleared before procossing the result.
+        // Note: ReferencesManager.resetReferences is called in ReferencesManager.showResultsInPanelView
         workspaceReferences.resetProgressBar();
         cancellationTokenListener.dispose();
         requestCanceledListener.dispose();
@@ -59,7 +60,6 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
             workspaceReferences.showResultsInPanelView(response);
         }
 
-        workspaceReferences.resetFindAllReferences();
         return locationsResult;
     }
 }

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -23,7 +23,7 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
         workspaceReferences.cancelCurrentReferenceRequest(CancellationSender.NewRequest);
 
         // Listen to a cancellation for this request. When this request is cancelled,
-        // use a local cancellation source to implicitly cancel a token.
+        // use a local cancellation source to explicitly cancel a token.
         const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
         const cancellationTokenListener: vscode.Disposable = token.onCancellationRequested(() => { cancelSource.cancel(); });
         const requestCanceledListener: vscode.Disposable = workspaceReferences.onCancellationRequested(sender => { cancelSource.cancel(); });

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -5,14 +5,13 @@
 import * as vscode from 'vscode';
 import { DefaultClient, workspaceReferences } from '../client';
 import { Position, RequestType } from 'vscode-languageclient';
-import { ReferencesParams, ReferencesResult, ReferenceType, ReferenceInfo } from '../references';
+import { ReferencesParams, ReferencesResult, ReferenceType, ReferenceInfo, CancellationSender } from '../references';
 
 const FindAllReferencesRequest: RequestType<ReferencesParams, ReferencesResult, void> =
     new RequestType<ReferencesParams, ReferencesResult, void>('cpptools/findAllReferences');
 
 export class FindAllReferencesProvider implements vscode.ReferenceProvider {
     private client: DefaultClient;
-    private cancellationToken: vscode.CancellationTokenSource | undefined;
     private disposables: vscode.Disposable[] = [];
 
     constructor(client: DefaultClient) {
@@ -22,31 +21,29 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
     public async provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken):
         Promise<vscode.Location[] | undefined> {
         await this.client.awaitUntilLanguageClientReady();
+        workspaceReferences.cancelCurrentReferenceRequest(CancellationSender.NewRequest);
 
-        // Cancel the previous request and listen to a next cancellation.
-        if (this.cancellationToken) {
-            this.cancellationToken.cancel();
-        }
-        this.cancellationToken = new vscode.CancellationTokenSource();
-        const cancelToken: vscode.CancellationTokenSource = this.cancellationToken;
-        this.disposables.push(token.onCancellationRequested(() => { cancelToken.cancel(); }));
-        this.disposables.push(workspaceReferences.onCancellationRequested(sender => { cancelToken.cancel(); }));
+        // Listen to a cancellation for this request. When this request is cancelled,
+        // use a local cancellation source to implicitly cancel a token.
+        const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
+        this.disposables.push(token.onCancellationRequested(() => { cancelSource.cancel(); }));
+        this.disposables.push(workspaceReferences.onCancellationRequested(sender => { cancelSource.cancel(); }));
 
-        // Send request to the language server.
+        // Send the request to the language server.
         const locationsResult: vscode.Location[] = [];
         const params: ReferencesParams = {
             newName: "",
             position: Position.create(position.line, position.character),
             textDocument: { uri: document.uri.toString() }
         };
-        const response: ReferencesResult = await this.client.languageClient.sendRequest(FindAllReferencesRequest, params, cancelToken.token);
+        const response: ReferencesResult = await this.client.languageClient.sendRequest(FindAllReferencesRequest, params, cancelSource.token);
 
         // Reset anything that can be cleared before procossing the result.
         workspaceReferences.resetProgressBar();
         this.dispose();
 
         // Process the result.
-        if (cancelToken.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {
+        if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {
             workspaceReferences.resetFindAllReferences();
             throw new vscode.CancellationError();
         } else if (response.referenceInfos.length !== 0) {

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -39,12 +39,8 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
 
         // Reset anything that can be cleared before procossing the result.
         workspaceReferences.resetProgressBar();
-        if (cancellationTokenListener) {
-            cancellationTokenListener.dispose();
-        }
-        if (requestCanceledListener) {
-            requestCanceledListener.dispose();
-        }
+        cancellationTokenListener.dispose();
+        requestCanceledListener.dispose();
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -37,7 +37,7 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
         };
         const response: ReferencesResult = await this.client.languageClient.sendRequest(FindAllReferencesRequest, params, cancelSource.token);
 
-        // Reset anything that can be cleared before procossing the result.
+        // Reset anything that can be cleared before processing the result.
         // Note: ReferencesManager.resetReferences is called in ReferencesManager.showResultsInPanelView
         workspaceReferences.resetProgressBar();
         cancellationTokenListener.dispose();

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -47,6 +47,8 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
         if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {
             // Return undefined instead of vscode.CancellationError to avoid the following error message from VS Code:
             // "Cannot destructure property 'range' of 'e.location' as it is undefined."
+            // TODO: per issue https://github.com/microsoft/vscode/issues/169698
+            // vscode.CancellationError is expected, so when VS Code fixes the error use vscode.CancellationError again.
             return undefined;
         } else if (response.referenceInfos.length !== 0) {
             response.referenceInfos.forEach((referenceInfo: ReferenceInfo) => {

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -4,20 +4,17 @@
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
 import { DefaultClient, workspaceReferences } from '../client';
-import * as refs from '../references';
+import { ReferencesParams, ReferencesResult, CancellationSender, ReferenceType, getReferenceTagString, getReferenceItemIconPath } from '../references';
 import { CppSettings } from '../settings';
-import { Position, TextDocumentIdentifier } from 'vscode-languageclient';
+import { Position, RequestType } from 'vscode-languageclient';
 import * as nls from 'vscode-nls';
 import * as util from '../../common';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
-export interface RenameReferencesParams {
-    newName: string;
-    position: Position;
-    textDocument: TextDocumentIdentifier;
-}
+const RenameRequest: RequestType<ReferencesParams, ReferencesResult, void> =
+    new RequestType<ReferencesParams, ReferencesResult, void>('cpptools/rename');
 
 export class RenameProvider implements vscode.RenameProvider {
     private client: DefaultClient;
@@ -30,74 +27,45 @@ export class RenameProvider implements vscode.RenameProvider {
         Promise<vscode.WorkspaceEdit | undefined> {
         await this.client.awaitUntilLanguageClientReady();
 
-        // Cancel any current requests by firing a cancellation event to listeners.
-        workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.NewRequest);
-
         const settings: CppSettings = new CppSettings();
         if (settings.renameRequiresIdentifier && !util.isValidIdentifier(newName)) {
             vscode.window.showErrorMessage(localize("invalid.identifier.for.rename", "Invalid identifier provided for the Rename Symbol operation."));
             return undefined;
         }
 
-        // Listen to VS Code cancellation.
-        let requestCanceled: refs.CancellationSender = refs.CancellationSender.None;
-        token.onCancellationRequested(e => { requestCanceled = refs.CancellationSender.ProviderToken; });
+        let requestCanceled: CancellationSender | undefined;
+        workspaceReferences.onCancellationRequested(sender => { requestCanceled = sender; });
 
-        // Process the request.
-        return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
-            // Listen to cancellation from an incoming new request, user or language server.
-            workspaceReferences.onCancellationRequested(sender => { requestCanceled = sender; });
+        workspaceReferences.startRename();
+        const workspaceEditResult: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+        const params: ReferencesParams = {
+            newName: newName,
+            position: Position.create(position.line, position.character),
+            textDocument: { uri: document.uri.toString() }
+        };
+        const response: ReferencesResult = await this.client.languageClient.sendRequest(RenameRequest, params, token);
 
-            // Define the callback that will process results.
-            const resultsCallback: refs.ReferencesResultCallback = (result: refs.ReferencesResult | null) => {
-                workspaceReferences.renamePending = false;
+        workspaceReferences.resetProgressBar();
+        workspaceReferences.resetRename();
 
-                if (result === null ||
-                    (requestCanceled !== refs.CancellationSender.None && requestCanceled !== refs.CancellationSender.ProviderToken)) {
-                    // Request canceled either by language server, document was edited (user) or an incoming new request.
-                    // Note: cancellation from provider is not considered here because only text edits
-                    // are considered a cancellation which is handled in onDidChangeTextDocument.
-                    reject(new vscode.CancellationError());
-                } else {
-                    const workspaceEditResult: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                    for (const reference of result.referenceInfos) {
-                        const uri: vscode.Uri = vscode.Uri.file(reference.file);
-                        const range: vscode.Range = new vscode.Range(reference.position.line, reference.position.character,
-                            reference.position.line, reference.position.character + result.text.length);
-                        const metadata: vscode.WorkspaceEditEntryMetadata = {
-                            needsConfirmation: reference.type !== refs.ReferenceType.Confirmed,
-                            label: refs.getReferenceTagString(reference.type, false, true),
-                            iconPath: refs.getReferenceItemIconPath(reference.type, false)
-                        };
-                        workspaceEditResult.replace(uri, range, newName, metadata);
-                    }
-
-                    if (result.referenceInfos === null || result.referenceInfos.length === 0) {
-                        vscode.window.showErrorMessage(localize("unable.to.locate.selected.symbol", "A definition for the selected symbol could not be located."));
-                    }
-
-                    resolve(workspaceEditResult);
-                }
-                return;
-            };
-
-            if (requestCanceled === refs.CancellationSender.None) {
-                workspaceReferences.renamePending = true;
-                workspaceReferences.setReferencesResultsCallback(resultsCallback);
-
-                // Send the request to language server
-                const params: RenameReferencesParams = {
-                    newName: newName,
-                    position: Position.create(position.line, position.character),
-                    textDocument: { uri: document.uri.toString() }
+        if (token.isCancellationRequested || response.isCanceled || requestCanceled !== undefined) {
+            throw new vscode.CancellationError();
+        } else if (response.referenceInfos === null || response.referenceInfos.length === 0) {
+            vscode.window.showErrorMessage(localize("unable.to.locate.selected.symbol", "A definition for the selected symbol could not be located."));
+        } else {
+            for (const reference of response.referenceInfos) {
+                const uri: vscode.Uri = vscode.Uri.file(reference.file);
+                const range: vscode.Range = new vscode.Range(reference.position.line, reference.position.character,
+                    reference.position.line, reference.position.character + response.text.length);
+                const metadata: vscode.WorkspaceEditEntryMetadata = {
+                    needsConfirmation: reference.type !== ReferenceType.Confirmed,
+                    label: getReferenceTagString(reference.type, false, true),
+                    iconPath: getReferenceItemIconPath(reference.type, false)
                 };
-                workspaceReferences.startRename(params);
-            } else {
-                // Only complete the request at this point if the request to language server
-                // has not been sent. Otherwise, the cancellation is handled when language
-                // server has completed/canceled its processing and sends the results.
-                resultsCallback(null);
+                workspaceEditResult.replace(uri, range, newName, metadata);
             }
-        });
+        }
+
+        return workspaceEditResult;
     }
 }

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -3,110 +3,100 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { DefaultClient, workspaceReferences, ReferenceParams, CancelReferencesNotification } from '../client';
+import { DefaultClient, workspaceReferences } from '../client';
 import * as refs from '../references';
 import { CppSettings } from '../settings';
-import { Position } from 'vscode-languageclient';
+import { Position, TextDocumentIdentifier } from 'vscode-languageclient';
 import * as nls from 'vscode-nls';
 import * as util from '../../common';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
+export interface RenameReferencesParams {
+    newName: string;
+    position: Position;
+    textDocument: TextDocumentIdentifier;
+}
+
 export class RenameProvider implements vscode.RenameProvider {
     private client: DefaultClient;
+
     constructor(client: DefaultClient) {
         this.client = client;
     }
-    public async provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): Promise<vscode.WorkspaceEdit> {
+
+    public async provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken):
+        Promise<vscode.WorkspaceEdit | undefined> {
+        await this.client.awaitUntilLanguageClientReady();
+
+        // Cancel any current requests by firing a cancellation event to listeners.
+        workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.NewRequest);
+
         const settings: CppSettings = new CppSettings();
         if (settings.renameRequiresIdentifier && !util.isValidIdentifier(newName)) {
             vscode.window.showErrorMessage(localize("invalid.identifier.for.rename", "Invalid identifier provided for the Rename Symbol operation."));
-            const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-            return workspaceEdit;
+            return undefined;
         }
-        // Normally, VS Code considers rename to be an atomic operation.
-        // If the user clicks anywhere in the document, it attempts to cancel it.
-        // Because that prevents our rename UI, we ignore cancellation requests.
-        // VS Code will attempt to issue new rename requests while another is still active.
-        // When we receive another rename request, cancel the one that is in progress.
-        DefaultClient.renamePending = true;
-        ++DefaultClient.renameRequestsPending;
+
+        // Listen to VS Code cancellation.
+        let requestCanceled: refs.CancellationSender = refs.CancellationSender.None;
+        token.onCancellationRequested(e => { requestCanceled = refs.CancellationSender.ProviderToken; });
+
+        // Process the request.
         return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
-            const callback: () => Promise<void> = async () => {
-                const params: ReferenceParams = {
-                    newName: newName,
-                    position: Position.create(position.line, position.character),
-                    textDocument: this.client.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document)
-                };
-                DefaultClient.referencesParams = params;
-                await this.client.awaitUntilLanguageClientReady();
-                // The current request is represented by referencesParams.  If a request detects
-                // referencesParams does not match the object used when creating the request, abort it.
-                if (params !== DefaultClient.referencesParams) {
-                    if (--DefaultClient.renameRequestsPending === 0) {
-                        DefaultClient.renamePending = false;
+            // Listen to cancellation from an incoming new request, user or language server.
+            workspaceReferences.onCancellationRequested(sender => { requestCanceled = sender; });
+
+            // Define the callback that will process results.
+            const resultsCallback: refs.ReferencesResultCallback = (result: refs.ReferencesResult | null) => {
+                workspaceReferences.renamePending = false;
+
+                if (result === null ||
+                    (requestCanceled !== refs.CancellationSender.None && requestCanceled !== refs.CancellationSender.ProviderToken)) {
+                    // Request canceled either by language server, document was edited (user) or an incoming new request.
+                    // Note: cancellation from provider is not considered here because only text edits
+                    // are considered a cancellation which is handled in onDidChangeTextDocument.
+                    reject(new vscode.CancellationError());
+                } else {
+                    const workspaceEditResult: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+                    for (const reference of result.referenceInfos) {
+                        const uri: vscode.Uri = vscode.Uri.file(reference.file);
+                        const range: vscode.Range = new vscode.Range(reference.position.line, reference.position.character,
+                            reference.position.line, reference.position.character + result.text.length);
+                        const metadata: vscode.WorkspaceEditEntryMetadata = {
+                            needsConfirmation: reference.type !== refs.ReferenceType.Confirmed,
+                            label: refs.getReferenceTagString(reference.type, false, true),
+                            iconPath: refs.getReferenceItemIconPath(reference.type, false)
+                        };
+                        workspaceEditResult.replace(uri, range, newName, metadata);
                     }
 
-                    // Complete with nothing instead of rejecting, to avoid an error message from VS Code
-                    const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                    resolve(workspaceEdit);
-                    return;
-                }
-                DefaultClient.referencesRequestPending = true;
-                workspaceReferences.setResultsCallback((referencesResult: refs.ReferencesResult | null, doResolve: boolean) => {
-                    DefaultClient.referencesRequestPending = false;
-                    --DefaultClient.renameRequestsPending;
-                    const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                    const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
-                    if (cancelling) {
-                        this.client.clearPendingReferencesCancellations();
-                    } else {
-                        if (DefaultClient.renameRequestsPending === 0) {
-                            DefaultClient.renamePending = false;
-                        }
-                        // If rename UI was canceled, we will get a null result.
-                        // If null, return an empty list to avoid Rename failure dialog.
-                        if (referencesResult) {
-                            for (const reference of referencesResult.referenceInfos) {
-                                const uri: vscode.Uri = vscode.Uri.file(reference.file);
-                                const range: vscode.Range = new vscode.Range(reference.position.line, reference.position.character, reference.position.line, reference.position.character + referencesResult.text.length);
-                                const metadata: vscode.WorkspaceEditEntryMetadata = {
-                                    needsConfirmation: reference.type !== refs.ReferenceType.Confirmed,
-                                    label: refs.getReferenceTagString(reference.type, false, true),
-                                    iconPath: refs.getReferenceItemIconPath(reference.type, false)
-                                };
-                                workspaceEdit.replace(uri, range, newName, metadata);
-                            }
-                        }
-                    }
-                    if (referencesResult && (referencesResult.referenceInfos === null || referencesResult.referenceInfos.length === 0)) {
+                    if (result.referenceInfos === null || result.referenceInfos.length === 0) {
                         vscode.window.showErrorMessage(localize("unable.to.locate.selected.symbol", "A definition for the selected symbol could not be located."));
                     }
-                    resolve(workspaceEdit);
-                });
-                workspaceReferences.startRename(params);
+
+                    resolve(workspaceEditResult);
+                }
+                return;
             };
 
-            if (DefaultClient.referencesRequestPending || workspaceReferences.symbolSearchInProgress) {
-                const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
-                DefaultClient.referencesPendingCancellations.push({
-                    reject: () => {
-                        --DefaultClient.renameRequestsPending;
-                        // Complete with nothing instead of rejecting, to avoid an error message from VS Code
-                        const workspaceEdit: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                        resolve(workspaceEdit);
-                    }, callback
-                });
-                if (!cancelling) {
-                    workspaceReferences.referencesCanceled = true;
-                    if (!DefaultClient.referencesRequestPending) {
-                        workspaceReferences.referencesCanceledWhilePreviewing = true;
-                    }
-                    this.client.languageClient.sendNotification(CancelReferencesNotification);
-                }
+            if (requestCanceled === refs.CancellationSender.None) {
+                workspaceReferences.renamePending = true;
+                workspaceReferences.setReferencesResultsCallback(resultsCallback);
+
+                // Send the request to language server
+                const params: RenameReferencesParams = {
+                    newName: newName,
+                    position: Position.create(position.line, position.character),
+                    textDocument: { uri: document.uri.toString() }
+                };
+                workspaceReferences.startRename(params);
             } else {
-                callback();
+                // Only complete the request at this point if the request to language server
+                // has not been sent. Otherwise, the cancellation is handled when language
+                // server has completed/canceled its processing and sends the results.
+                resultsCallback(null);
             }
         });
     }

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -50,7 +50,7 @@ export class RenameProvider implements vscode.RenameProvider {
         };
         const response: ReferencesResult = await this.client.languageClient.sendRequest(RenameRequest, params, cancelSource.token);
 
-        // Reset anything that can be cleared before procossing the result.
+        // Reset anything that can be cleared before processing the result.
         workspaceReferences.resetProgressBar();
         workspaceReferences.resetReferences();
         requestCanceledListener.dispose();

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -52,7 +52,7 @@ export class RenameProvider implements vscode.RenameProvider {
 
         // Reset anything that can be cleared before procossing the result.
         workspaceReferences.resetProgressBar();
-        workspaceReferences.resetRename();
+        workspaceReferences.resetReferences();
         requestCanceledListener.dispose();
 
         // Process the result.

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -37,8 +37,8 @@ export class RenameProvider implements vscode.RenameProvider {
 
         // Listen to a cancellation for this request. When this request is cancelled,
         // use a local cancellation source to implicitly cancel a token.
+        // Don't listen to the token from the provider, as it will cancel when the cursor is moved to a different position.
         const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
-        this.disposables.push(token.onCancellationRequested(() => { cancelSource.cancel(); }));
         this.disposables.push(workspaceReferences.onCancellationRequested(sender => { cancelSource.cancel(); }));
 
         // Send the request to the language server.

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -35,7 +35,7 @@ export class RenameProvider implements vscode.RenameProvider {
         }
 
         // Listen to a cancellation for this request. When this request is cancelled,
-        // use a local cancellation source to implicitly cancel a token.
+        // use a local cancellation source to explicitly cancel a token.
         // Don't listen to the token from the provider, as it will cancel when the cursor is moved to a different position.
         const cancelSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
         const requestCanceledListener: vscode.Disposable = workspaceReferences.onCancellationRequested(sender => { cancelSource.cancel(); });

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -53,9 +53,7 @@ export class RenameProvider implements vscode.RenameProvider {
         // Reset anything that can be cleared before procossing the result.
         workspaceReferences.resetProgressBar();
         workspaceReferences.resetRename();
-        if (requestCanceledListener) {
-            requestCanceledListener.dispose();
-        }
+        requestCanceledListener.dispose();
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.referenceInfos === null || response.isCanceled) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -17,7 +17,7 @@ import { DocumentSymbolProvider } from './Providers/documentSymbolProvider';
 import { WorkspaceSymbolProvider } from './Providers/workspaceSymbolProvider';
 import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
-import { CallHierarchyProvider, CallHierarchyCallsItemResult } from './Providers/callHierarchyProvider';
+import { CallHierarchyProvider } from './Providers/callHierarchyProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
 import { InlayHintsProvider } from './Providers/inlayHintProvider';
 // End provider imports
@@ -607,7 +607,6 @@ const DebugLogNotification: NotificationType<LocalizeStringParams> = new Notific
 const InactiveRegionNotification: NotificationType<InactiveRegionParams> = new NotificationType<InactiveRegionParams>('cpptools/inactiveRegions');
 const CompileCommandsPathsNotification: NotificationType<CompileCommandsPaths> = new NotificationType<CompileCommandsPaths>('cpptools/compileCommandsPaths');
 const ReferencesNotification: NotificationType<refs.ReferencesResult> = new NotificationType<refs.ReferencesResult>('cpptools/references');
-const CallHierarchyNotification: NotificationType<CallHierarchyCallsItemResult> = new NotificationType<CallHierarchyCallsItemResult>('cpptools/callHierarchyCallsToResult');
 const ReportReferencesProgressNotification: NotificationType<refs.ReportReferencesProgressNotification> = new NotificationType<refs.ReportReferencesProgressNotification>('cpptools/reportReferencesProgress');
 const RequestCustomConfig: NotificationType<string> = new NotificationType<string>('cpptools/requestCustomConfig');
 const PublishIntelliSenseDiagnosticsNotification: NotificationType<PublishIntelliSenseDiagnosticsParams> = new NotificationType<PublishIntelliSenseDiagnosticsParams>('cpptools/publishIntelliSenseDiagnostics');
@@ -2264,9 +2263,8 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(ReportTagParseStatusNotification, (e) => this.updateTagParseStatus(e));
         this.languageClient.onNotification(InactiveRegionNotification, (e) => this.updateInactiveRegions(e));
         this.languageClient.onNotification(CompileCommandsPathsNotification, (e) => this.promptCompileCommands(e));
-        this.languageClient.onNotification(ReferencesNotification, (e) => this.processReferencesResult(e));
+        this.languageClient.onNotification(ReferencesNotification, (e) => this.processReferencesPreview(e));
         this.languageClient.onNotification(ReportReferencesProgressNotification, (e) => this.handleReferencesProgress(e));
-        this.languageClient.onNotification(CallHierarchyNotification, (e) => this.processCallHierarchyResult(e));
         this.languageClient.onNotification(RequestCustomConfig, (requestFile: string) => {
             const client: Client = clients.getClientFor(vscode.Uri.file(requestFile));
             if (client instanceof DefaultClient) {
@@ -3635,12 +3633,8 @@ export class DefaultClient implements Client {
         workspaceReferences.handleProgress(notificationBody);
     }
 
-    private processReferencesResult(referencesResult: refs.ReferencesResult): void {
-        workspaceReferences.processResults(referencesResult);
-    }
-
-    private processCallHierarchyResult(callHierarchyResult: CallHierarchyCallsItemResult): void {
-        workspaceReferences.processCallHierarchyResults(callHierarchyResult);
+    private processReferencesPreview(referencesResult: refs.ReferencesResult): void {
+        workspaceReferences.showResultsInPanelView(referencesResult);
     }
 
     public setReferencesCommandMode(mode: refs.ReferencesCommandMode): void {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3616,7 +3616,7 @@ export class DefaultClient implements Client {
             workspaceReferences.UpdateProgressUICounter(this.model.referencesCommandMode.Value);
 
             // If the search is find all references, preview partial results.
-            // This will cause language server to send partial results to display
+            // This will cause the language server to send partial results to display
             // in the "Other References" view or channel. Doing a preview should not complete
             // an in-progress request until it is finished or canceled.
             if (this.ReferencesCommandMode === refs.ReferencesCommandMode.Find) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -17,9 +17,9 @@ import { DocumentSymbolProvider } from './Providers/documentSymbolProvider';
 import { WorkspaceSymbolProvider } from './Providers/workspaceSymbolProvider';
 import { RenameProvider } from './Providers/renameProvider';
 import { FindAllReferencesProvider } from './Providers/findAllReferencesProvider';
+import { CallHierarchyProvider, CallHierarchyCallsItemResult } from './Providers/callHierarchyProvider';
 import { CodeActionProvider } from './Providers/codeActionProvider';
 import { InlayHintsProvider } from './Providers/inlayHintProvider';
-import { CallHierarchyCallsItemResult, CallHierarchyParams, CallHierarchyProvider } from './Providers/callHierarchyProvider';
 // End provider imports
 
 import { LanguageClientOptions, NotificationType, TextDocumentIdentifier, RequestType, ErrorAction, CloseAction, DidOpenTextDocumentParams, Range, Position } from 'vscode-languageclient';
@@ -372,17 +372,6 @@ export interface LocalizeSymbolInformation {
     suffix: LocalizeStringParams;
 }
 
-export interface ReferenceParams {
-    newName: string;
-    position: Position;
-    textDocument: TextDocumentIdentifier;
-}
-
-export interface FindAllReferencesParams {
-    position: Position;
-    textDocument: TextDocumentIdentifier;
-}
-
 export interface FormatParams {
     uri: string;
     range: Range;
@@ -595,13 +584,9 @@ const CustomConfigurationNotification: NotificationType<CustomConfigurationParam
 const CustomBrowseConfigurationNotification: NotificationType<CustomBrowseConfigurationParams> = new NotificationType<CustomBrowseConfigurationParams>('cpptools/didChangeCustomBrowseConfiguration');
 const ClearCustomConfigurationsNotification: NotificationType<WorkspaceFolderParams> = new NotificationType<WorkspaceFolderParams>('cpptools/clearCustomConfigurations');
 const ClearCustomBrowseConfigurationNotification: NotificationType<WorkspaceFolderParams> = new NotificationType<WorkspaceFolderParams>('cpptools/clearCustomBrowseConfiguration');
+const PreviewReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/previewReferences');
 const RescanFolderNotification: NotificationType<void> = new NotificationType<void>('cpptools/rescanFolder');
-export const RequestReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/requestReferences');
-export const CancelReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/cancelReferences');
 const FinishedRequestCustomConfig: NotificationType<FinishedRequestCustomConfigParams> = new NotificationType<FinishedRequestCustomConfigParams>('cpptools/finishedRequestCustomConfig');
-const FindAllReferencesNotification: NotificationType<FindAllReferencesParams> = new NotificationType<FindAllReferencesParams>('cpptools/findAllReferences');
-const CallHierarchyCallsToNotification: NotificationType<CallHierarchyParams> = new NotificationType<CallHierarchyParams>('cpptools/callHierarchyCallsTo');
-const RenameNotification: NotificationType<ReferenceParams> = new NotificationType<ReferenceParams>('cpptools/rename');
 const DidChangeSettingsNotification: NotificationType<SettingsParams> = new NotificationType<SettingsParams>('cpptools/didChangeSettings');
 const InitializationNotification: NotificationType<InitializationOptions> = new NotificationType<InitializationOptions>('cpptools/initialize');
 
@@ -640,11 +625,6 @@ const DoxygenCommentGeneratedNotification: NotificationType<GenerateDoxygenComme
 const CanceledReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/canceledReferences');
 
 let failureMessageShown: boolean = false;
-
-interface ReferencesCancellationState {
-    reject(): void;
-    callback(): void;
-}
 
 class ClientModel {
     public isInitializingWorkspace: DataBinding<boolean>;
@@ -860,13 +840,6 @@ export class DefaultClient implements Client {
 
     private configStateReceived: ConfigStateReceived = { compilers: false, compileCommands: false, configProviders: undefined, timeout: false };
     private showConfigureIntelliSenseButton: boolean = false;
-
-    public static referencesParams: ReferenceParams | FindAllReferencesParams | CallHierarchyParams |undefined;
-    public static referencesRequestPending: boolean = false;
-    public static referencesPendingCancellations: ReferencesCancellationState[] = [];
-
-    public static renameRequestsPending: number = 0;
-    public static renamePending: boolean = false;
 
     // The "model" that is displayed via the UI (status bar).
     private model: ClientModel = new ClientModel();
@@ -1410,18 +1383,6 @@ export class DefaultClient implements Client {
         }
     }
 
-    public sendCallHierarchyCallsToNotification(params: CallHierarchyParams): void {
-        this.languageClient.sendNotification(CallHierarchyCallsToNotification, params);
-    }
-
-    public sendFindAllReferencesNotification(params: FindAllReferencesParams): void {
-        this.languageClient.sendNotification(FindAllReferencesNotification, params);
-    }
-
-    public sendRenameNotification(params: ReferenceParams): void {
-        this.languageClient.sendNotification(RenameNotification, params);
-    }
-
     private getWorkspaceFolderSettings(workspaceFolderUri: vscode.Uri | undefined, settings: CppSettings, otherSettings: OtherSettings): WorkspaceFolderSettingsParams {
         const result: WorkspaceFolderSettingsParams = {
             uri: workspaceFolderUri?.toString(),
@@ -1750,8 +1711,8 @@ export class DefaultClient implements Client {
     public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
         if (util.isCpp(textDocumentChangeEvent.document)) {
             // If any file has changed, we need to abort the current rename operation
-            if (DefaultClient.renamePending) {
-                this.cancelReferences();
+            if (workspaceReferences.renamePending) {
+                workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.User);
             }
 
             const oldVersion: number | undefined = openFileVersions.get(textDocumentChangeEvent.document.uri.toString());
@@ -2326,7 +2287,7 @@ export class DefaultClient implements Client {
         this.languageClient.onNotification(ReportCodeAnalysisProcessedNotification, (e) => this.updateCodeAnalysisProcessed(e));
         this.languageClient.onNotification(ReportCodeAnalysisTotalNotification, (e) => this.updateCodeAnalysisTotal(e));
         this.languageClient.onNotification(DoxygenCommentGeneratedNotification, (e) => void this.insertDoxygenComment(e));
-        this.languageClient.onNotification(CanceledReferencesNotification, this.cancelReferences);
+        this.languageClient.onNotification(CanceledReferencesNotification, this.serverCanceledReferences);
     }
 
     private setTextDocumentLanguage(languageStr: string): void {
@@ -3654,56 +3615,20 @@ export class DefaultClient implements Client {
 
     public handleReferencesIcon(): void {
         this.notifyWhenLanguageClientReady(() => {
-            const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
-            if (!cancelling) {
-                workspaceReferences.UpdateProgressUICounter(this.model.referencesCommandMode.Value);
-                if (this.ReferencesCommandMode === refs.ReferencesCommandMode.Find) {
-                    if (!workspaceReferences.referencesRequestPending) {
-                        if (workspaceReferences.referencesRequestHasOccurred) {
-                            // References are not usable if a references request is pending,
-                            // So after the initial request, we don't send a 2nd references request until the next request occurs.
-                            if (!workspaceReferences.referencesRefreshPending) {
-                                workspaceReferences.referencesRefreshPending = true;
-                                vscode.commands.executeCommand("references-view.refresh");
-                            }
-                        } else {
-                            workspaceReferences.referencesRequestHasOccurred = true;
-                            workspaceReferences.referencesRequestPending = true;
-                            this.languageClient.sendNotification(RequestReferencesNotification);
-                        }
-                    }
-                }
+            workspaceReferences.UpdateProgressUICounter(this.model.referencesCommandMode.Value);
+
+            // If the search is find all references, preview partial results.
+            // This will cause language server to send partial results to display
+            // in the "Other References" view or channel. Doing a preview should not complete
+            // an in-progress request until it is finished or canceled.
+            if (this.ReferencesCommandMode === refs.ReferencesCommandMode.Find) {
+                this.languageClient.sendNotification(PreviewReferencesNotification);
             }
         });
     }
 
-    public clearPendingReferencesCancellations(): void {
-        if (DefaultClient.referencesPendingCancellations.length > 0) {
-            while (DefaultClient.referencesPendingCancellations.length > 1) {
-                const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-                DefaultClient.referencesPendingCancellations.pop();
-                pendingCancel.reject();
-            }
-            const pendingCancel: ReferencesCancellationState = DefaultClient.referencesPendingCancellations[0];
-            DefaultClient.referencesPendingCancellations.pop();
-            pendingCancel.callback();
-        }
-    }
-
-    public cancelReferences(): void {
-        DefaultClient.referencesParams = undefined;
-        DefaultClient.renamePending = false;
-        if (DefaultClient.referencesRequestPending || workspaceReferences.symbolSearchInProgress) {
-            const cancelling: boolean = DefaultClient.referencesPendingCancellations.length > 0;
-            DefaultClient.referencesPendingCancellations.push({
-                reject: () => { },
-                callback: () => { }
-            });
-            if (!cancelling) {
-                workspaceReferences.referencesCanceled = true;
-                languageClient.sendNotification(CancelReferencesNotification);
-            }
-        }
+    private serverCanceledReferences(): void {
+        workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.LanguageServer);
     }
 
     private handleReferencesProgress(notificationBody: refs.ReportReferencesProgressNotification): void {

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -243,7 +243,7 @@ export class ReferencesManager {
     public cancelCurrentReferenceRequest(sender: CancellationSender): void {
         // Notify the current listener its request was canceled.
         this.referenceRequestCanceled.fire(sender);
-        // Cancel the process in language server.
+        // Cancel the process in the language server.
         this.client.languageClient.sendNotification(CancelReferencesNotification);
     }
 

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -84,6 +84,9 @@ export enum CancellationSender {
     /* No cancellations */
     None,
 
+    /* Cancellation was from a new request */
+    NewRequest,
+
     /* Cancellation was from the provider cancellation token */
     ProviderToken,
 

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -11,7 +11,7 @@ import * as logger from '../logger';
 import { PersistentState } from './persistentState';
 import * as util from '../common';
 import { setInterval } from 'timers';
-import { NotificationType, Position, TextDocumentIdentifier } from 'vscode-languageclient';
+import { Position, TextDocumentIdentifier } from 'vscode-languageclient';
 import { FindAllRefsView } from './referencesView';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -87,17 +87,12 @@ export enum CancellationSender {
     /* Cancellation was from the provider cancellation token */
     ProviderToken,
 
-    /* Cancellation was from a new request */
-    NewRequest,
-
     /* Cancellation was from the language server */
     LanguageServer,
 
     /* Cancelaltion was from the user selecting the cancel button in the reference search progress bar */
     User
 }
-
-const CancelReferencesNotification: NotificationType<void> = new NotificationType<void>('cpptools/cancelReferences');
 
 export function referencesCommandModeToString(referencesCommandMode: ReferencesCommandMode): string {
     switch (referencesCommandMode) {
@@ -241,10 +236,8 @@ export class ReferencesManager {
     }
 
     public cancelCurrentReferenceRequest(sender: CancellationSender): void {
-        // Notify the current listener its request was canceled.
+        // Notify the current listener to cancel its request.
         this.referenceRequestCanceled.fire(sender);
-        // Cancel the process in the language server.
-        this.client.languageClient.sendNotification(CancelReferencesNotification);
     }
 
     public dispose(): void {

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -93,7 +93,7 @@ export enum CancellationSender {
     /* Cancellation was from the language server */
     LanguageServer,
 
-    /* Cancelaltion was from the user selecting the cancel button in the reference search progress bar */
+    /* Cancellation was from the user selecting the cancel button in the reference search progress bar */
     User
 }
 

--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -449,13 +449,8 @@ export class ReferencesManager {
         this.renamePending = true;
     }
 
-    public resetRename(): void {
+    public resetReferences(): void {
         this.renamePending = false;
-        this.initializeViews();
-        this.client.setReferencesCommandMode(ReferencesCommandMode.None);
-    }
-
-    public resetFindAllReferences(): void {
         this.initializeViews();
         this.client.setReferencesCommandMode(ReferencesCommandMode.None);
     }
@@ -508,6 +503,11 @@ export class ReferencesManager {
                     this.findAllRefsView.show(true);
                 }
             }
+        }
+
+        // If this is the final result, reset after process results.
+        if (referencesResult.isFinished || referencesResult.isCanceled) {
+            this.resetReferences();
         }
     }
 

--- a/Extension/src/LanguageServer/referencesModel.ts
+++ b/Extension/src/LanguageServer/referencesModel.ts
@@ -15,7 +15,10 @@ export class ReferencesModel {
         this.originalSymbol = resultsInput.text;
         this.groupByFile = groupByFile;
 
-        const results: ReferenceInfo[] = resultsInput.referenceInfos.filter(r => r.type !== ReferenceType.Confirmed);
+        // Only filter out confirmed references when operation has finished or canceled.
+        // Otherwise, show all results in the "Other References" view while previewing.
+        const results: ReferenceInfo[] = (resultsInput.isFinished || isCanceled) ?
+            resultsInput.referenceInfos.filter(r => r.type !== ReferenceType.Confirmed) : resultsInput.referenceInfos;
 
         // Build a single flat list of all leaf nodes
         // Currently, the hierarchy is built each time referencesTreeDataProvider requests nodes.

--- a/Extension/src/LanguageServer/referencesModel.ts
+++ b/Extension/src/LanguageServer/referencesModel.ts
@@ -15,9 +15,9 @@ export class ReferencesModel {
         this.originalSymbol = resultsInput.text;
         this.groupByFile = groupByFile;
 
-        // Only filter out confirmed references when operation has finished or canceled.
-        // Otherwise, show all results in the "Other References" view while previewing.
-        const results: ReferenceInfo[] = (resultsInput.isFinished || isCanceled) ?
+        // Only filter out confirmed references when operation has finished.
+        // Otherwise, show all results in the "Other References" view while previewing or if the request was canceled.
+        const results: ReferenceInfo[] = resultsInput.isFinished ?
             resultsInput.referenceInfos.filter(r => r.type !== ReferenceType.Confirmed) : resultsInput.referenceInfos;
 
         // Build a single flat list of all leaf nodes

--- a/Extension/src/LanguageServer/referencesView.ts
+++ b/Extension/src/LanguageServer/referencesView.ts
@@ -30,8 +30,8 @@ export class FindAllRefsView {
         vscode.commands.executeCommand('setContext', 'cpptools.hasReferencesResults', hasResults);
     }
 
-    setData(results: ReferencesResult, isCanceled: boolean, groupByFile: boolean): void {
-        this.referencesModel = new ReferencesModel(results, isCanceled, groupByFile, () => { this.referenceViewProvider.refresh(); });
+    setData(results: ReferencesResult, groupByFile: boolean): void {
+        this.referencesModel = new ReferencesModel(results, results.isCanceled, groupByFile, () => { this.referenceViewProvider.refresh(); });
         this.referenceViewProvider.setModel(this.referencesModel);
     }
 


### PR DESCRIPTION
This changeset simplifies how preview works for "find all references". It also makes cancellation more straightforward and sequential for "find all references", "rename" and "call hierarchy callers of" by changing their messages to the language server to a `RequestType` object. This avoids race conditions in reading cancellation states among the different requests and also avoids the chance of not resolving a request from reading/setting incorrect states due to race conditions.

This change also has a corresponding changeset on the language server code base.

**Changes for Preview and Cancel for Find All References**
- When doing a preview, the partial or preview results is now shown in the "Other References" view. This no longer resolves a current request to show any confirmed reference type from partial results in the VS Code References view.
- When cancelling, any in progress results are now shown in the "Other References" view. This is because cancelling the request will return an empty result object from the request message returned from the language server.
- A find all references request will now only complete when the language server has finished processing the request or when the processing gets cancelled.

**Request Changes**
- The typescript message sent to the language server for getting "find all references", "rename", and "call hierarchy callers of" is now a `RequestType` object. This is to ensure synchronization of a language server response to its typescript sender. This also removes the requirement of having to manually manage cancellation of requests.
- Cancellation is now done by calling cancel on a local cancellation token passed to the request to the language server rather than by sending a separate cancellation notification to the language server.
- A new request sends a cancellation event to cancel a current request by calling `ReferencesManager.cancelCurrentReferenceRequest`.

**Other Changes**
- Refactored some objects and variables to the appropriate classes/files that use them exclusively.