### PR TITLE
include miDebuggerArgs in attach option

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4230,6 +4230,11 @@
                 "description": "%c_cpp.debuggers.miDebuggerPath.description%",
                 "default": "/usr/bin/gdb"
               },
+              "miDebuggerArgs": {
+                "type": "string",
+                "description": "%c_cpp.debuggers.miDebuggerArgs.description%",
+                "default": ""
+              },
               "miDebuggerServerAddress": {
                 "type": "string",
                 "description": "%c_cpp.debuggers.miDebuggerServerAddress.description%",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -874,6 +874,11 @@
           "description": "%c_cpp.debuggers.miDebuggerPath.description%",
           "default": "/usr/bin/gdb"
         },
+        "miDebuggerArgs": {
+          "type": "string",
+          "description": "%c_cpp.debuggers.miDebuggerArgs.description%",
+          "default": ""
+        },
         "miDebuggerServerAddress": {
           "type": "string",
           "description": "%c_cpp.debuggers.miDebuggerServerAddress.description%",


### PR DESCRIPTION
From my testing, the extension accepts `miDebuggerArgs` for `"request": "attach"`, but the scheme isn't up-to-date.