### PR TITLE
Call hierarchy - add file path to detail property

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -3,6 +3,7 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
+import * as path from 'path';
 import * as Telemetry from '../../telemetry';
 import { DefaultClient, CancelReferencesNotification, workspaceReferences } from '../client';
 import { processDelayedDidOpen } from '../extension';
@@ -225,8 +226,10 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
     }
 
     private makeVscodeCallHierarchyItem(item: CallHierarchyItem): vscode.CallHierarchyItem {
+        const containerDetail: string = (item.detail !== "") ? `${item.detail} - ` : "";
+        const fileDetail: string = `${path.basename(item.uri)} (${path.dirname(item.uri)})`;
         return new vscode.CallHierarchyItem(
-            item.kind, item.name, item.detail,
+            item.kind, item.name, containerDetail + fileDetail,
             vscode.Uri.file(item.uri),
             makeVscodeRange(item.range),
             makeVscodeRange(item.selectionRange));


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode-cpptools/issues/10997

This change adds the file path details to a call hierarchy item result.

**Before change:**
![image](https://github.com/microsoft/vscode-cpptools/assets/38734287/3594f25d-8214-4682-8976-4efca2632630)


**After change:**
![image](https://github.com/microsoft/vscode-cpptools/assets/38734287/0314b6db-139b-4e0e-8395-bb2c5fe98bc5)
