### PR TITLE
remove extra adjustments to textEdit for CDD

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3509,12 +3509,10 @@ export class DefaultClient implements Client {
             for (const edit of result.edit.changes[file]) {
                 const range: vscode.Range = makeVscodeRange(edit.range);
                 // Get new lines from an edit for: #include header file.
-                if (lastEdit && lastEdit.newText.includes("#include")) {
-                    if (lastEdit.range.isEqual(range)) {
-                        // Destination file is empty.
-                        // The edit positions for #include header file and definition or declaration are the same.
-                        selectionPositionAdjustment = (lastEdit.newText.match(/\n/g) || []).length;
-                    }
+                if (lastEdit && lastEdit.newText.includes("#include") && lastEdit.range.isEqual(range)) {
+                    // Destination file is empty.
+                    // The edit positions for #include header file and definition or declaration are the same.
+                    selectionPositionAdjustment = (lastEdit.newText.match(/\n/g) || []).length;
                 }
                 lastEdit = new vscode.TextEdit(range, edit.newText);
                 const position: vscode.Position = new vscode.Position(edit.range.start.line, edit.range.start.character);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3500,7 +3500,6 @@ export class DefaultClient implements Client {
         const workspaceEdits: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
         let modifiedDocument: vscode.Uri | undefined;
         let lastEdit: vscode.TextEdit | undefined;
-        let editPositionAdjustment: number = 0;
         let selectionPositionAdjustment: number = 0;
         for (const file in result.edit.changes) {
             const uri: vscode.Uri = vscode.Uri.file(file);
@@ -3515,18 +3514,10 @@ export class DefaultClient implements Client {
                         // Destination file is empty.
                         // The edit positions for #include header file and definition or declaration are the same.
                         selectionPositionAdjustment = (lastEdit.newText.match(/\n/g) || []).length;
-                    } else {
-                        // Destination file is not empty.
-                        // VS Code workspace.applyEdit calculates the position of subsequent edits.
-                        // That is, the positions of text edits that are originally calculated by the language server
-                        // are adjusted based on the number of text edits applied by VS Code workspace.applyEdit.
-                        // Since the language server's refactoring API already pre-calculates the positions of multiple text edits,
-                        // re-adjust the new line of the next text edit for the VS Code applyEdit to calculate again.
-                        editPositionAdjustment = (lastEdit.newText.match(/\n/g) || []).length;
                     }
                 }
                 lastEdit = new vscode.TextEdit(range, edit.newText);
-                const position: vscode.Position = new vscode.Position(edit.range.start.line - editPositionAdjustment, edit.range.start.character);
+                const position: vscode.Position = new vscode.Position(edit.range.start.line, edit.range.start.character);
                 workspaceEdits.insert(uri, position, edit.newText);
             }
             modifiedDocument = uri;


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/10500, https://github.com/microsoft/vscode-cpptools/issues/10464

This change removes the adjustments that were previously added to account for two text edits.