### PR TITLE
Fix possible race condition that could lead to multiple didOpen's

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -352,14 +352,16 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
     if (client) {
         // Log warm start.
         if (clients.checkOwnership(client, document)) {
+            if (!client.isInitialized()) {
+                // This can randomly get hit when adding/removing workspace folders.
+                await client.awaitUntilLanguageClientReady();
+            }
+            // Do not call await between TrackedDocuments.has() and TrackedDocuments.add(),
+            // to avoid sending redundant didOpen notifications.
             if (!client.TrackedDocuments.has(document)) {
                 // If not yet tracked, process as a newly opened file.  (didOpen is sent to server in client.takeOwnership()).
-                clients.timeTelemetryCollector.setDidOpenTime(document.uri);
-                if (!client.isInitialized()) {
-                    // This can randomly get hit when adding/removing workspace folders.
-                    await client.awaitUntilLanguageClientReady();
-                }
                 client.TrackedDocuments.add(document);
+                clients.timeTelemetryCollector.setDidOpenTime(document.uri);
                 // Work around vscode treating ".C" or ".H" as c, by adding this file name to file associations as cpp
                 if (document.languageId === "c" && shouldChangeFromCToCpp(document)) {
                     const baseFileName: string = path.basename(document.fileName);
@@ -369,8 +371,8 @@ export async function processDelayedDidOpen(document: vscode.TextDocument): Prom
                     document = await vscode.languages.setTextDocumentLanguage(document, "cpp");
                 }
                 await client.provideCustomConfiguration(document.uri, undefined);
-                client.onDidOpenTextDocument(document);
-                await client.sendDidOpen(document);
+                // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
+                await client.takeOwnership(document);
                 return true;
             }
         }


### PR DESCRIPTION
I noticed this while reviewing https://github.com/microsoft/vscode-cpptools/pull/11085 , and had the mistaken impression that use of `requestWhenReady` would have addressed this.

Basically, the `has` check followed by the `add` is not 'thread'-safe if there is an `await` between those calls.

Added a call to `takeOwnership` instead of calling `sendDidOpen` directly, to ensure any other contents of `takeOwnership` also get called.  (i.e. `updateActiveDocumentTextOptions`)