### PR TITLE
Fix TypeScript defaultFormatter setting.

### DIFF
--- a/Extension/.vscode/settings.json
+++ b/Extension/.vscode/settings.json
@@ -37,7 +37,7 @@
     },
     "[typescript]": {
         "editor.tabSize": 4,
-        "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+        "editor.defaultFormatter": "vscode.typescript-language-features",
         "editor.formatOnSave": true,
         "files.insertFinalNewline": true,
         "editor.codeActionsOnSave": {


### PR DESCRIPTION
Using dbaeumer.vscode-eslint causes VS Code to give an error popup when formatting is done. Using vscode.typescript-language-features still enables eslint to give formatter linter errors...although there's the protential mismatch issue in which the formatter will create code he linter complains about.

@fearthecowboy If you have a better fix I can abandon this PR.