### PR TITLE
'Create Declaration / Definition' command via 'Quick Fix...' hover 

### DIFF
--- a/Extension/src/LanguageServer/Providers/codeActionProvider.ts
+++ b/Extension/src/LanguageServer/Providers/codeActionProvider.ts
@@ -187,7 +187,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                 resultCodeActions.push(...docCodeActions);
                 return;
             } else if ((command.command === 'C_Cpp.CreateDeclarationOrDefinition' || command.command === 'C_Cpp.CopyDeclarationOrDefinition')
-                && (command.arguments ?? []).length === 0 && command.range != undefined) {
+                && (command.arguments ?? []).length === 0 && command.range !== undefined) {
                 const args: CreateDeclDefnCommandArguments = {
                     sender: 'codeAction',
                     range: command.range

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -689,20 +689,22 @@ async function onDisableAllTypeCodeAnalysisProblems(code: string, identifiersAnd
     return getActiveClient().handleDisableAllTypeCodeAnalysisProblems(code, identifiersAndUris);
 }
 
-async function onCopyDeclarationOrDefinition(sender?: any): Promise<void> {
+async function onCopyDeclarationOrDefinition(args?: any): Promise<void> {
+    const sender: any | undefined = util.isString(args?.sender) ? args.sender : args;
     const properties: { [key: string]: string } = {
         sender: util.getSenderType(sender)
     };
     telemetry.logLanguageServerEvent('CopyDeclDefn', properties);
-    return getActiveClient().handleCreateDeclarationOrDefinition(true);
+    return getActiveClient().handleCreateDeclarationOrDefinition(true, args?.range);
 }
 
-async function onCreateDeclarationOrDefinition(sender?: any): Promise<void> {
+async function onCreateDeclarationOrDefinition(args?: any): Promise<void> {
+    const sender: any | undefined = util.isString(args?.sender) ? args.sender : args;
     const properties: { [key: string]: string } = {
         sender: util.getSenderType(sender)
     };
     telemetry.logLanguageServerEvent('CreateDeclDefn', properties);
-    return getActiveClient().handleCreateDeclarationOrDefinition();
+    return getActiveClient().handleCreateDeclarationOrDefinition(false, args?.range);
 }
 
 function onAddToIncludePath(path: string): void {
@@ -711,7 +713,6 @@ function onAddToIncludePath(path: string): void {
         // suggestion to a different workspace.
         return clients.ActiveClient.handleAddToIncludePathCommand(path);
     }
-
 }
 
 function onEnableSquiggles(): void {


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode-cpptools/issues/11157

Note: this has a corresponding language server change.

**Problem:**
When 'Create Declaration / Definition' code action is invoked via `Quick Fix...` when hovering over a function that has `...` under it and the current selection or cursor position is in a different location from the function, no declaration or definition gets created. This is because the range which is used for processing the request comes from the current active selection or cursor position. If the range does not match the actual location of the function then the data for the request is invalid.

**Fix:**
During creating of code actions, save the range for the suggested 'Create Declaration / Definition' to use later as input for the range data.

**Test to verify fix:**

1. Select a line/character in the file other than the function to invoke "create definition..." on.
2. Hover over a function to "create definition..." on.
3. Click on "Quick Fix..." from the tool tip that pops up.
4. Select "Create definition..." from the code action (aka Quick Fix...) selections that pop up.
5. Result: definition is created.

**Regression test cases that invoke 'Create Declaration / Definition' from different entry points:**

- via `Quick Fix..` hovering over a function with `...` under it and the cursor or selection is in different location from function's location. (This is the case that was fixed in this changeset.)
- via `Light Bulb` after selecting a function with `...` under it and then clicking on the light bulb.
- via context menu by right-clicking on function and selecting `Create Declaration / Definition`. 
- via command palette by selecting a function and running command `Create Declaration / Definition`.