### PR TITLE
remove all code related to storagePath

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1297,28 +1297,6 @@ export function isValidIdentifier(candidate: string): boolean {
     return true;
 }
 
-function getUniqueWorkspaceNameHelper(workspaceFolder: vscode.WorkspaceFolder, addSubfolder: boolean): string {
-    const workspaceFolderName: string = workspaceFolder ? workspaceFolder.name : "untitled";
-    if (!workspaceFolder || workspaceFolder.index < 1) {
-        return workspaceFolderName; // No duplicate names to search for.
-    }
-    for (let i: number = 0; i < workspaceFolder.index; ++i) {
-        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 && vscode.workspace.workspaceFolders[i].name === workspaceFolderName) {
-            return addSubfolder ? path.join(workspaceFolderName, String(workspaceFolder.index)) : // Use the index as a subfolder.
-                workspaceFolderName + String(workspaceFolder.index);
-        }
-    }
-    return workspaceFolderName; // No duplicate names found.
-}
-
-export function getUniqueWorkspaceName(workspaceFolder: vscode.WorkspaceFolder): string {
-    return getUniqueWorkspaceNameHelper(workspaceFolder, false);
-}
-
-export function getUniqueWorkspaceStorageName(workspaceFolder: vscode.WorkspaceFolder): string {
-    return getUniqueWorkspaceNameHelper(workspaceFolder, true);
-}
-
 export function isCodespaces(): boolean {
     return !!process.env["CODESPACES"];
 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/10191

The plumbing for storage path will be removed from the typescript and moved to the native side. This will allow us to not be limited by the storage path generated by VS Code.