### PR TITLE
"Select IntelliSense Configuration" updates `compilerPath` in  c_cpp_properties.json

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1057,6 +1057,7 @@ export class DefaultClient implements Client {
             if (index === paths.length - 1) {
                 action = "disable";
                 settings.defaultCompilerPath = "";
+                await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
                 configurationSelected = true;
                 if (showSecondPrompt) {
                     void this.showPrompt(selectIntelliSenseConfig, true, sender);
@@ -1112,6 +1113,7 @@ export class DefaultClient implements Client {
                 configurationSelected = true;
                 action = "compiler browsed";
                 settings.defaultCompilerPath = result[0].fsPath;
+                await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
                 void vscode.commands.executeCommand('setContext', 'cpptools.trustedCompilerFound', true);
             } else {
                 configurationSelected = true;
@@ -1130,6 +1132,7 @@ export class DefaultClient implements Client {
                 } else {
                     action = "select compiler";
                     settings.defaultCompilerPath = util.isCl(paths[index]) ? "cl.exe" : paths[index];
+                    await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
                     void vscode.commands.executeCommand('setContext', 'cpptools.trustedCompilerFound', true);
                 }
             }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1057,7 +1057,7 @@ export class DefaultClient implements Client {
             if (index === paths.length - 1) {
                 action = "disable";
                 settings.defaultCompilerPath = "";
-                await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
+                await this.configuration.updateCompilerPathIfSet(settings.defaultCompilerPath);
                 configurationSelected = true;
                 if (showSecondPrompt) {
                     void this.showPrompt(selectIntelliSenseConfig, true, sender);
@@ -1113,7 +1113,7 @@ export class DefaultClient implements Client {
                 configurationSelected = true;
                 action = "compiler browsed";
                 settings.defaultCompilerPath = result[0].fsPath;
-                await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
+                await this.configuration.updateCompilerPathIfSet(settings.defaultCompilerPath);
                 void vscode.commands.executeCommand('setContext', 'cpptools.trustedCompilerFound', true);
             } else {
                 configurationSelected = true;
@@ -1132,7 +1132,7 @@ export class DefaultClient implements Client {
                 } else {
                     action = "select compiler";
                     settings.defaultCompilerPath = util.isCl(paths[index]) ? "cl.exe" : paths[index];
-                    await this.configuration.updateCompilerPath(settings.defaultCompilerPath);
+                    await this.configuration.updateCompilerPathIfSet(settings.defaultCompilerPath);
                     void vscode.commands.executeCommand('setContext', 'cpptools.trustedCompilerFound', true);
                 }
             }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -624,7 +624,7 @@ export class CppProperties {
         }, () => { }).catch(logAndReturn.undefined);
     }
 
-    public async updateCompilerPath(path: string): Promise<void> {
+    public async updateCompilerPathIfSet(path: string): Promise<void> {
         return this.handleConfigurationEditJSONCommand(() => {
             this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
             const config: Configuration | undefined = this.CurrentConfiguration;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -624,6 +624,21 @@ export class CppProperties {
         }, () => { }).catch(logAndReturn.undefined);
     }
 
+    public async updateCompilerPath(path: string): Promise<void> {
+        return this.handleConfigurationEditJSONCommand(() => {
+            this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
+            const config: Configuration | undefined = this.CurrentConfiguration;
+            // Update compiler path if it's already set.
+            if (config && config.compilerPath !== undefined) {
+                config.compilerPath = path;
+                this.writeToJson();
+            }
+            // Any time parsePropertiesFile is called, configurationJson gets
+            // reverted to an unprocessed state and needs to be reprocessed.
+            this.handleConfigurationChange();
+        }, returns.undefined);
+    }
+
     public async updateCustomConfigurationProvider(providerId: string): Promise<void> {
         if (!this.propertiesFile) {
             const settings: CppSettings = new CppSettings(this.rootUri);


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode-cpptools/issues/10808

This change updates the `compilerPath` in c_cpp_properties.json only if it is already set when a compiler is configured from the command "Select IntelliSense Configuration".