### PR TITLE
Update `compilerPath` if c_cpp_properties.json exists

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -626,7 +626,7 @@ export class CppProperties {
 
     public async updateCompilerPathIfSet(path: string): Promise<void> {
         if (!this.propertiesFile) {
-            // properties file does not exist.
+            // Properties file does not exist.
             return;
         }
         return this.handleConfigurationEditJSONCommand(() => {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -625,6 +625,10 @@ export class CppProperties {
     }
 
     public async updateCompilerPathIfSet(path: string): Promise<void> {
+        if (!this.propertiesFile) {
+            // properties file does not exist.
+            return;
+        }
         return this.handleConfigurationEditJSONCommand(() => {
             this.parsePropertiesFile(); // Clear out any modifications we may have made internally.
             const config: Configuration | undefined = this.CurrentConfiguration;


### PR DESCRIPTION
This is a follow up to https://github.com/microsoft/vscode-cpptools/pull/11255.