### PR TITLE
Use `selectionRange` for call hierarchy request input

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -30,7 +30,7 @@ interface CallHierarchyItem {
     /**
      * The resource identifier of this item.
      */
-    uri: string;
+    file: string;
 
     /**
      * The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
@@ -230,10 +230,10 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     private makeVscodeCallHierarchyItem(item: CallHierarchyItem): vscode.CallHierarchyItem {
         const containerDetail: string = (item.detail !== "") ? `${item.detail} - ` : "";
-        const fileDetail: string = `${path.basename(item.uri)} (${path.dirname(item.uri)})`;
+        const fileDetail: string = `${path.basename(item.file)} (${path.dirname(item.file)})`;
         return new vscode.CallHierarchyItem(
             item.kind, item.name, containerDetail + fileDetail,
-            vscode.Uri.file(item.uri),
+            vscode.Uri.file(item.file),
             makeVscodeRange(item.range),
             makeVscodeRange(item.selectionRange));
     }

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -175,7 +175,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         let result: vscode.CallHierarchyIncomingCall[] | undefined;
         const params: CallHierarchyParams = {
             textDocument: { uri: item.uri.toString() },
-            position: Position.create(item.range.start.line, item.range.start.character)
+            position: Position.create(item.selectionRange.start.line, item.selectionRange.start.character)
         };
         const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsToRequest, params, cancelSource.token);
 
@@ -213,7 +213,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         let result: vscode.CallHierarchyOutgoingCall[] | undefined;
         const params: CallHierarchyParams = {
             textDocument: { uri: item.uri.toString() },
-            position: Position.create(item.range.start.line, item.range.start.character)
+            position: Position.create(item.selectionRange.start.line, item.selectionRange.start.character)
         };
         const response: CallHierarchyCallsItemResult = await this.client.languageClient.sendRequest(CallHierarchyCallsFromRequest, params, token);
 

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -28,7 +28,7 @@ interface CallHierarchyItem {
     detail: string;
 
     /**
-     * The resource identifier of this item.
+     * The file path of this item.
      */
     file: string;
 


### PR DESCRIPTION
**GitHub issue:**
https://github.com/microsoft/vscode-cpptools/issues/11247

This is a corresponding change to a language server change, which has the actual fix to https://github.com/microsoft/vscode-cpptools/issues/11247.

**Change:**
Use the property `selectionRange` as the position input for a call hierarchy incoming/outgoing request. Previously `selectionRange` and `range` had the same values. A changed in language server now populates `range` with the function definition range if the data is available.