### PR TITLE
Show relative path for call hierarchy item if available

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -230,7 +230,9 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     private makeVscodeCallHierarchyItem(item: CallHierarchyItem): vscode.CallHierarchyItem {
         const containerDetail: string = (item.detail !== "") ? `${item.detail} - ` : "";
-        const fileDetail: string = `${path.basename(item.uri)} (${path.dirname(item.uri)})`;
+        const dirPath: string = path.relative(this.client.RootPath, path.dirname(item.uri));
+        const fileDetail: string = dirPath.length === 0 ?
+            `${path.basename(item.uri)}` : `${path.basename(item.uri)} (${dirPath})`;
         return new vscode.CallHierarchyItem(
             item.kind, item.name, containerDetail + fileDetail,
             vscode.Uri.file(item.uri),

--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -230,12 +230,21 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
 
     private makeVscodeCallHierarchyItem(item: CallHierarchyItem): vscode.CallHierarchyItem {
         const containerDetail: string = (item.detail !== "") ? `${item.detail} - ` : "";
-        const dirPath: string = path.relative(this.client.RootPath, path.dirname(item.uri));
+        const itemUri: vscode.Uri = vscode.Uri.file(item.uri);
+
+        // Get file detail
+        const isInWorkspace: boolean = this.client.RootUri !== undefined &&
+            itemUri.fsPath.startsWith(this.client.RootUri?.fsPath);
+        const dirPath: string = isInWorkspace ?
+            path.relative(this.client.RootPath, path.dirname(item.uri)) : path.dirname(item.uri);
         const fileDetail: string = dirPath.length === 0 ?
             `${path.basename(item.uri)}` : `${path.basename(item.uri)} (${dirPath})`;
+
         return new vscode.CallHierarchyItem(
-            item.kind, item.name, containerDetail + fileDetail,
-            vscode.Uri.file(item.uri),
+            item.kind,
+            item.name,
+            containerDetail + fileDetail,
+            itemUri,
             makeVscodeRange(item.range),
             makeVscodeRange(item.selectionRange));
     }


### PR DESCRIPTION
**GitHub issue:**
https://github.com/microsoft/vscode-cpptools/issues/11254

**Change:**
Show the path relative to workspace folder for file path info of call hierarchy items. Previously it showed full path.

**Before changes:**
![image](https://github.com/microsoft/vscode-cpptools/assets/38734287/0fe988da-2cd3-4f7e-888d-d92976086bfb)

**After changes:**
![image](https://github.com/microsoft/vscode-cpptools/assets/38734287/d74c27d3-447d-43e1-874b-7493f9ac43de)

