### PR TITLE
Prevent vcpkg code action from appearing in all unrelated code action menus

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -229,10 +229,6 @@ export async function activate(): Promise<void> {
     codeActionProvider = vscode.languages.registerCodeActionsProvider(selector, {
         provideCodeActions: async (document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): Promise<vscode.CodeAction[]> => {
             const ports: string[] = await lookupIncludeInVcpkg(document, range.start.line);
-            const actions: vscode.CodeAction[] = ports.map<vscode.CodeAction>(getVcpkgClipboardInstallAction);
-            if (ports.length <= 0) {
-                return [];
-            }
 
             if (!await clients.ActiveClient.getVcpkgEnabled()) {
                 return [];
@@ -243,12 +239,16 @@ export async function activate(): Promise<void> {
                 return [];
             }
 
+            if (ports.length <= 0) {
+                return [];
+            }
             telemetry.logLanguageServerEvent('codeActionsProvided', { "source": "vcpkg" });
 
             if (!await clients.ActiveClient.getVcpkgInstalled()) {
                 return [getVcpkgHelpAction()];
             }
 
+            const actions: vscode.CodeAction[] = ports.map<vscode.CodeAction>(getVcpkgClipboardInstallAction);
             return actions;
         }
     });

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -228,7 +228,6 @@ export async function activate(): Promise<void> {
     ];
     codeActionProvider = vscode.languages.registerCodeActionsProvider(selector, {
         provideCodeActions: async (document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): Promise<vscode.CodeAction[]> => {
-            const ports: string[] = await lookupIncludeInVcpkg(document, range.start.line);
 
             if (!await clients.ActiveClient.getVcpkgEnabled()) {
                 return [];
@@ -239,9 +238,11 @@ export async function activate(): Promise<void> {
                 return [];
             }
 
+            const ports: string[] = await lookupIncludeInVcpkg(document, range.start.line);
             if (ports.length <= 0) {
                 return [];
             }
+
             telemetry.logLanguageServerEvent('codeActionsProvided', { "source": "vcpkg" });
 
             if (!await clients.ActiveClient.getVcpkgInstalled()) {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -228,6 +228,12 @@ export async function activate(): Promise<void> {
     ];
     codeActionProvider = vscode.languages.registerCodeActionsProvider(selector, {
         provideCodeActions: async (document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext): Promise<vscode.CodeAction[]> => {
+            const ports: string[] = await lookupIncludeInVcpkg(document, range.start.line);
+            const actions: vscode.CodeAction[] = ports.map<vscode.CodeAction>(getVcpkgClipboardInstallAction);
+            if (ports.length <= 0) {
+                return [];
+            }
+
             if (!await clients.ActiveClient.getVcpkgEnabled()) {
                 return [];
             }
@@ -243,8 +249,6 @@ export async function activate(): Promise<void> {
                 return [getVcpkgHelpAction()];
             }
 
-            const ports: string[] = await lookupIncludeInVcpkg(document, range.start.line);
-            const actions: vscode.CodeAction[] = ports.map<vscode.CodeAction>(getVcpkgClipboardInstallAction);
             return actions;
         }
     });


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/11252

The vcpkg code action keeps appearing because it is not checking if the include code action is in the list of code actions. This PR will prevent vcpkg from being added to the list before this happens