### PR TITLE
default to c++14 on mac for build and run active file

### DIFF
--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -189,10 +189,6 @@ export class CppBuildTaskProvider implements TaskProvider {
                     ['-fcolor-diagnostics', '-fansi-escape-codes', '-g', '${file}', '-o', programName] :
                     ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
 
-            // TODO: Remove when compiler query work goes in and we can determine the standard version from TypeScript
-            if (isClang && os.platform() === 'darwin') {
-                args.unshift('-std=c++14');
-            }
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);
             }
@@ -371,6 +367,8 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
             this.closeEmitter.fire(-1);
             return;
         }
+
+        // TODO: Remove when compiler query work goes in and we can determine the standard version from TypeScript
         if (this.buildOptions.taskUsesActiveFile && window.activeTextEditor?.document.languageId === 'cpp' && this.buildOptions.insertStd) {
             this.args.unshift('-std=gnu++14');
         }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -180,6 +180,8 @@ export class CppBuildTaskProvider implements TaskProvider {
                 isClang ?
                     ['-fcolor-diagnostics', '-fansi-escape-codes', '-g', '${file}', '-o', programName] :
                     ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
+
+            // TODO: Remove when compiler query work goes in and we can determine the standard version from TypeScript
             if (isClang && os.platform() === 'darwin') {
                 args.unshift('-std=c++14');
             }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -180,6 +180,9 @@ export class CppBuildTaskProvider implements TaskProvider {
                 isClang ?
                     ['-fcolor-diagnostics', '-fansi-escape-codes', '-g', '${file}', '-o', programName] :
                     ['-fdiagnostics-color=always', '-g', '${file}', '-o', programName];
+            if (isClang && os.platform() === 'darwin') {
+                args.unshift('-std=c++14');
+            }
             if (compilerArgs && compilerArgs.length > 0) {
                 args = args.concat(compilerArgs);
             }

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -31,6 +31,11 @@ export class CppBuildTask extends Task {
     isDefault?: boolean;
 }
 
+interface BuildOptions {
+    taskUsesActiveFile: boolean;
+    insertStd?: boolean;
+}
+
 export class CppBuildTaskProvider implements TaskProvider {
     static CppBuildScriptType: string = 'cppbuild';
 
@@ -163,6 +168,7 @@ export class CppBuildTaskProvider implements TaskProvider {
     private getTask: (compilerPath: string, appendSourceToName: boolean, compilerArgs?: string[], definition?: CppBuildTaskDefinition, detail?: string) => Task = (compilerPath: string, appendSourceToName: boolean, compilerArgs?: string[], definition?: CppBuildTaskDefinition, detail?: string) => {
         const compilerPathBase: string = path.basename(compilerPath);
         const isCl: boolean = compilerPathBase.toLowerCase() === "cl.exe";
+        const isClang: boolean = !isCl && compilerPathBase.toLowerCase().includes("clang");
         // Double-quote the command if it is not already double-quoted.
         let resolvedcompilerPath: string = isCl ? compilerPathBase : compilerPath;
         if (resolvedcompilerPath && !resolvedcompilerPath.startsWith("\"") && resolvedcompilerPath.includes(" ")) {
@@ -174,7 +180,6 @@ export class CppBuildTaskProvider implements TaskProvider {
             const taskLabel: string = ((appendSourceToName && !compilerPathBase.startsWith(ext.configPrefix)) ?
                 ext.configPrefix : "") + compilerPathBase + " " + localize("build_active_file", "build active file");
             const programName: string = util.defaultExePath();
-            const isClang: boolean = !isCl && compilerPathBase.toLowerCase().includes("clang");
             let args: string[] = isCl ?
                 ['/Zi', '/EHsc', '/nologo', `/Fe${programName}`, '${file}'] :
                 isClang ?
@@ -207,7 +212,7 @@ export class CppBuildTaskProvider implements TaskProvider {
         const task: CppBuildTask = new Task(definition, scope, definition.label, ext.CppSourceStr,
             new CustomExecution(async (resolvedDefinition: TaskDefinition): Promise<Pseudoterminal> =>
                 // When the task is executed, this callback will run. Here, we setup for running the task.
-                new CustomBuildTaskTerminal(resolvedcompilerPath, resolvedDefinition.args, resolvedDefinition.options, taskUsesActiveFile)
+                new CustomBuildTaskTerminal(resolvedcompilerPath, resolvedDefinition.args, resolvedDefinition.options, {taskUsesActiveFile, insertStd: isClang && os.platform() === 'darwin'})
             ), isCl ? '$msCompile' : '$gcc');
 
         task.group = TaskGroup.Build;
@@ -354,14 +359,17 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
     public get onDidClose(): Event<number> { return this.closeEmitter.event; }
     private endOfLine: string = "\r\n";
 
-    constructor(private command: string, private args: string[], private options: cp.ExecOptions | cp.SpawnOptions | undefined, private taskUsesActiveFile: boolean) {
+    constructor(private command: string, private args: string[], private options: cp.ExecOptions | cp.SpawnOptions | undefined, private buildOptions: BuildOptions) {
     }
 
     async open(_initialDimensions: TerminalDimensions | undefined): Promise<void> {
-        if (this.taskUsesActiveFile && !util.isCppOrCFile(window.activeTextEditor?.document.uri)) {
+        if (this.buildOptions.taskUsesActiveFile && !util.isCppOrCFile(window.activeTextEditor?.document.uri)) {
             this.writeEmitter.fire(localize("cannot.build.non.cpp", 'Cannot build and debug because the active file is not a C or C++ source file.') + this.endOfLine);
             this.closeEmitter.fire(-1);
             return;
+        }
+        if (this.buildOptions.taskUsesActiveFile && window.activeTextEditor?.document.languageId === 'cpp' && this.buildOptions.insertStd) {
+            this.args.unshift('-std=gnu++14');
         }
         telemetry.logLanguageServerEvent("cppBuildTaskStarted");
         // At this point we can start using the terminal.


### PR DESCRIPTION
This is a temporary workaround to enable users to compile the code in the getting started guide/walkthrough without having to create and edit tasks.json.