### PR TITLE
chore: disallow "unused eslint-disables"

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6125,7 +6125,7 @@
         "code": "ts-node -T .scripts/code.ts",
         "verify": "ts-node -T .scripts/verify.ts",
         "prep": "yarn copy-walkthrough-media && yarn generate-native-strings && yarn translations-generate",
-        "lint": "eslint -c .eslintrc.js src test ui .scripts",
+        "lint": "eslint -c .eslintrc.js --report-unused-disable-directives src test ui .scripts",
         "compile": "(yarn verify prep || yarn prep) && tsc --build tsconfig.json",
         "watch": "(yarn verify prep || yarn prep )&& tsc --build tsconfig.json --watch",
         "rebuild": "yarn clean && yarn prep && yarn compile",

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -4,8 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
-
 import { execSync } from 'child_process';
 import * as editorConfig from 'editorconfig';
 import * as fs from 'fs';

--- a/Extension/src/SSH/commandInteractors.ts
+++ b/Extension/src/SSH/commandInteractors.ts
@@ -322,7 +322,6 @@ export class ContinueOnInteractor implements IInteractor {
         return ContinueOnInteractor.ID;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async onData(data: string, _cancelToken?: vscode.CancellationToken): Promise<IInteraction> {
         const result: IInteraction = { postAction: 'keep' };
         const pattern: string = escapeStringForRegex(this.continueOn);

--- a/Extension/src/Utility/Async/constructor.ts
+++ b/Extension/src/Utility/Async/constructor.ts
@@ -6,7 +6,6 @@
 import { is } from '../System/guards';
 import { ConstructorReturn, Reject, Resolve, AsyncConstructor } from '../System/types';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function Async<TClass extends new (...args: ConstructorParameters<TClass>) => ConstructorReturn<TClass>>(ctor: TClass) {
     class AsyncConstructed extends Promise<TClass> {
         static class: TClass = ctor;

--- a/Extension/src/Utility/Async/factory.ts
+++ b/Extension/src/Utility/Async/factory.ts
@@ -3,8 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import { is } from '../System/guards';
 import { Reject, Resolve } from '../System/types';
 

--- a/Extension/src/Utility/Async/iterators.ts
+++ b/Extension/src/Utility/Async/iterators.ts
@@ -125,7 +125,7 @@ export function accumulator<T>(...iterables: Some<T>[]): AsynchIterable<T> {
                 }
 
             }
-            // eslint-disable-next-line no-unmodified-loop-condition
+
         } while (!completeWhenEmpty);
         signal.dispose(false);
 

--- a/Extension/src/Utility/Eventing/dispatcher.ts
+++ b/Extension/src/Utility/Eventing/dispatcher.ts
@@ -41,7 +41,6 @@ const asyncHandlers = new Map<string, Subscriber[]>();
 const queue = new Array<Event<any, any>>();
 const current = new Set<Callback>();
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const DispatcherBusy = new ManualSignal<void>();
 
 /** starts the processing of the event queue. */

--- a/Extension/src/Utility/Eventing/interfaces.ts
+++ b/Extension/src/Utility/Eventing/interfaces.ts
@@ -3,8 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/naming-convention */
-
 export interface EventData<TInput = any | undefined> {
     readonly name: string;
     completed?: Promise<unknown>;

--- a/Extension/src/Utility/Process/program.ts
+++ b/Extension/src/Utility/Process/program.ts
@@ -3,7 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/naming-convention */
 import { fail } from 'assert';
 import { Factory } from '../Async/factory';
 import { lazy } from '../Async/lazy';

--- a/Extension/src/Utility/Process/streams.ts
+++ b/Extension/src/Utility/Process/streams.ts
@@ -180,7 +180,7 @@ export class LineIterator implements AsyncIterable<string>, AsyncIterator<string
      * Iterator next function.
      * @returns the next line, or undefined if the iterator is done.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     async next(): Promise<IteratorResult<string>> {
         do {
             // is the current line (regardless of whether it's full or not) a match

--- a/Extension/src/Utility/System/finalize.ts
+++ b/Extension/src/Utility/System/finalize.ts
@@ -18,7 +18,6 @@ export function ignore<T>(fn: () => T | undefined) {
 }
 const finalized = new WeakSet();
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export let ActiveFinalizers = Promise.resolve();
 
 /** This closes/ends/stops/destroys/disposes of an object or a Promise<object>

--- a/Extension/src/Utility/System/guards.ts
+++ b/Extension/src/Utility/System/guards.ts
@@ -41,7 +41,6 @@ export class is {
         return !is.nullish(instance) && !!instance[Symbol.asyncIterator];
     }
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     static Constructor(instance: any): instance is Constructor {
         return typeof instance === 'function' && !!instance.prototype && !Object.getOwnPropertyNames(instance).includes('arguments') && instance.toString().match(/^function.*\{ \[native code\] \}|^class/g);
     }

--- a/Extension/src/Utility/System/info.ts
+++ b/Extension/src/Utility/System/info.ts
@@ -74,7 +74,7 @@ interface FunctionInfo {
     isAsync: boolean;
 
     /** a bound callable function for the member (saves us from having to do it later anyway) */
-    // eslint-disable-next-line @typescript-eslint/ban-types
+
     fn: Function;
 }
 

--- a/Extension/src/Utility/Text/characterCodes.ts
+++ b/Extension/src/Utility/Text/characterCodes.ts
@@ -3,7 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export const enum CharacterCodes {
     nullCharacter = 0,
     maxAsciiCharacter = 0x7F,

--- a/Extension/src/Utility/Text/scanner.ts
+++ b/Extension/src/Utility/Text/scanner.ts
@@ -971,7 +971,6 @@ export class Scanner implements Token {
     positionFromOffset(offset: number): Position {
         let position = { line: 0, column: 0, offset: 0 };
 
-        // eslint-disable-next-line keyword-spacing
         if (offset < 0 || offset > this.#length) {
             return { line: position.line, column: position.column };
         }

--- a/Extension/test/common/selectTests.ts
+++ b/Extension/test/common/selectTests.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Microsoft Corporation. All Rights Reserved.
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-/* eslint-disable no-cond-assign */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { readdir } from 'fs/promises';
 import { IOptions, glob as globSync } from 'glob';

--- a/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
+++ b/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
@@ -3,7 +3,7 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../../../../vscode.d.ts" />
 

--- a/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation. All Rights Reserved.
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-/* eslint-disable @typescript-eslint/no-unused-vars */
+
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../../../../vscode.d.ts" />
 

--- a/Extension/test/unit/async.test.ts
+++ b/Extension/test/unit/async.test.ts
@@ -70,7 +70,6 @@ describe('AsyncFactory', () => {
                 value.value = 200;
             };
 
-            // eslint-disable-next-line @typescript-eslint/ban-types
             return value as () => number;
         });
         const fn = await new f();

--- a/Extension/test/unit/commandLineParsing.test.ts
+++ b/Extension/test/unit/commandLineParsing.test.ts
@@ -3,8 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { deepEqual, throws } from 'assert';
 import { describe } from 'mocha';
 import { extractArgs } from '../../src/Utility/Process/commandLine';

--- a/Extension/test/unit/eventing.test.ts
+++ b/Extension/test/unit/eventing.test.ts
@@ -3,8 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import { ok, strictEqual } from 'assert';
 import { beforeEach, describe, it } from 'mocha';
 import { Async } from '../../src/Utility/Async/constructor';
@@ -55,7 +53,7 @@ class Something extends SomeBase {
 }
 
 // make an async constructor for the Something class
-// eslint-disable-next-line @typescript-eslint/naming-convention
+
 const AsyncSomething = Async(Something);
 
 describe('Event Emitters', () => {

--- a/Extension/test/unit/examples/someclass.ts
+++ b/Extension/test/unit/examples/someclass.ts
@@ -6,7 +6,6 @@
 import { Async } from '../../../src/Utility/Async/constructor';
 import { sleep } from '../../../src/Utility/Async/sleep';
 
-/* eslint-disable @typescript-eslint/naming-convention */
 export const Something = Async(class Something {
     hasBeenInitialized: boolean = false;
     constructor(public num: number) {

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -385,5 +385,4 @@ class SettingsApp {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const app: SettingsApp = new SettingsApp();


### PR DESCRIPTION
# What?

Fail the CI/Local build if we are using eslint-disable spuriously.


More information -> [here](https://eslint.org/docs/latest/use/command-line-interface#:~:text=%2D%2Dreport%2Dunused%2Ddisable%2Ddirectives,-This%20option%20causes&text=This%20can%20be%20useful%20to,which%20are%20no%20longer%20applicable.&text=When%20using%20this%20option%2C%20it,or%20custom%20rules%20are%20upgraded.)

# Why?

It can be confusing seeing an `eslint-disable` in code and there is no actual violation. Like found here: 

```
    // eslint-disable-next-line @typescript-eslint/no-explicit-any
    async next(): Promise<IteratorResult<string>> {
```


# How?

Unfortunately, eslint **only** errors if we have this as part of the CLI Arguments `--report-unused-disable-directives`.

```
/Users/marcinstrzyz/src/vscode-cpptools/Extension/test/unit/eventing.test.ts
   6:1  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
  58:1  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/naming-convention')

/Users/marcinstrzyz/src/vscode-cpptools/Extension/test/unit/examples/someclass.ts
  9:1  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/naming-convention')

/Users/marcinstrzyz/src/vscode-cpptools/Extension/ui/settings.ts
  388:1  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-unused-vars')
```


adding `reportUnusedDisableDirectives` to eslintrc only provides a warning.



