### PR TITLE
fix: Add typing guard for `advanced section` being modified or deleted

### DIFF
--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -81,8 +81,12 @@ class SettingsApp {
         // Set view state of advanced settings and add event
         const oldState: any = this.vsCodeApi.getState();
         const advancedShown: boolean = oldState && oldState.advancedShown;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        document.getElementById(elementId.advancedSection)!.style.display = advancedShown ? "block" : "none";
+
+        const advancedSection: HTMLElement | null = document.getElementById(elementId.advancedSection);
+        if (advancedSection) {
+            advancedSection.style.display = advancedShown ? "block" : "none";
+        }
+
         document.getElementById(elementId.showAdvanced)?.classList.toggle(advancedShown ? "collapse" : "expand", true);
         document.getElementById(elementId.showAdvanced)?.addEventListener("click", this.onShowAdvanced.bind(this));
         this.vsCodeApi.postMessage({


### PR DESCRIPTION
# What?

Remove the `eslint-disable` for the `advanced section` style modification and replace with a conditional check.

# Why?

The current code can be fragile if the id of that attribute is ever changed:
<img width="1098" alt="image" src="https://github.com/microsoft/vscode-cpptools/assets/37447884/72ed747b-a3e3-4e83-b836-44891e391fac">

Causes:

<img width="532" alt="image" src="https://github.com/microsoft/vscode-cpptools/assets/37447884/c4d6f543-a31c-4ea3-ae50-db33c81f9c87">



- I tried to add some basic unit test for this but since this is Web code, it would require me adding some heavy imports like JSDOM or doing a lot of mocking.


** I can help adding Jest JSDOM/ Playwright if this is warranted :) 
