### PR TITLE
chore: enable `no-useless-constructor` ESLint rule (@typescript-eslint strict)

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "semi-spacing": ["error", { "before": false, "after": true }],
         "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false, "ternaryOperandBinaryExpressions": false }],
+        "@typescript-eslint/no-useless-constructor": "error",
         "@typescript-eslint/no-for-in-array": "error",
         "@typescript-eslint/no-misused-new": "error",
         "@typescript-eslint/no-misused-promises": "error",

--- a/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
+++ b/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
@@ -26,9 +26,6 @@ abstract class AbstractDebugAdapterDescriptorFactory implements vscode.DebugAdap
 }
 
 export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-    constructor(context: vscode.ExtensionContext) {
-        super(context);
-    }
 
     async createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor> {
         const adapter: string = "./debugAdapters/bin/OpenDebugAD7" + (os.platform() === 'win32' ? ".exe" : "");
@@ -40,9 +37,6 @@ export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDes
 }
 
 export class CppvsdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-    constructor(context: vscode.ExtensionContext) {
-        super(context);
-    }
 
     async createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor | null> {
         if (os.platform() !== 'win32') {

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -39,8 +39,6 @@ interface BuildOptions {
 export class CppBuildTaskProvider implements TaskProvider {
     static CppBuildScriptType: string = 'cppbuild';
 
-    constructor() { }
-
     public async provideTasks(): Promise<CppBuildTask[]> {
         return this.getTasks(false);
     }

--- a/Extension/src/SSH/commandInteractors.ts
+++ b/Extension/src/SSH/commandInteractors.ts
@@ -46,8 +46,6 @@ export interface IInteractor {
 export class MitmInteractor implements IInteractor {
     static ID = 'mitm';
 
-    constructor() { }
-
     get id(): string {
         return MitmInteractor.ID;
     }

--- a/Extension/test/unit/examples/someclass.ts
+++ b/Extension/test/unit/examples/someclass.ts
@@ -48,9 +48,6 @@ export const AnotherTwo = Async(class AnotherTwo {
         this.works = true;
     }
     works = false;
-    constructor() {
-
-    }
 });
 
 export const AnotherThree = Async(class AnotherThree extends AnotherTwo.class {


### PR DESCRIPTION
# What?

enables the `@typescript-eslint/no-useless-constructor` lint rule which is part of the strict package.

# Why?

The strict package adds a lot of type safety protections, this first rule we can see some redundant code being deleted.


For example, overriding a constructor which just calls a super(), better to just leverage the base constructor.