### PR TITLE
chore: enable `no-array-constructor` ESLint rule (@typescript-eslint strict)

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
         "arrow-spacing": ["error", { "before": true, "after": true }],
         "semi-spacing": ["error", { "before": false, "after": true }],
         "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false, "ternaryOperandBinaryExpressions": false }],
+        "@typescript-eslint/no-array-constructor": "error",
         "@typescript-eslint/no-for-in-array": "error",
         "@typescript-eslint/no-misused-new": "error",
         "@typescript-eslint/no-misused-promises": "error",

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -839,7 +839,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         }
         const rawLaunchJson: any = await this.getRawLaunchJson();
         if (!rawLaunchJson.configurations) {
-            rawLaunchJson.configurations = new Array();
+            rawLaunchJson.configurations = [];
         }
         if (!rawLaunchJson.version) {
             rawLaunchJson.version = "2.0.0";

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -222,7 +222,7 @@ export class CppBuildTaskProvider implements TaskProvider {
 
     public async getJsonTasks(): Promise<CppBuildTask[]> {
         const rawJson: any = await this.getRawTasksJson();
-        const rawTasksJson: any = !rawJson.tasks ? new Array() : rawJson.tasks;
+        const rawTasksJson: any = !rawJson.tasks ? [] : rawJson.tasks;
         const buildTasksJson: CppBuildTask[] = rawTasksJson.map((task: any) => {
             if (!task.label || !task.type || task.type !== CppBuildTaskProvider.CppBuildScriptType) {
                 return null;
@@ -261,7 +261,7 @@ export class CppBuildTaskProvider implements TaskProvider {
     public async writeBuildTask(taskLabel: string, workspaceFolder?: WorkspaceFolder, setAsDefault: boolean = false): Promise<void> {
         const rawTasksJson: any = await this.getRawTasksJson(workspaceFolder);
         if (!rawTasksJson.tasks) {
-            rawTasksJson.tasks = new Array();
+            rawTasksJson.tasks = [];
         }
         // Check if the task exists in the user's task.json.
         if (rawTasksJson.tasks.find((task: any) => task.label && task.label === taskLabel)) {


### PR DESCRIPTION
# What?

enables the `@typescript-eslint/no-array-constructor` lint rule which is part of the strict config.

# Why?

The strict package adds a lot of type safety protections, this first rule we can see some redundant code being deleted.