### PR TITLE
Apply '@typescript-eslint/strict' linting rules

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/eslint-recommended"
-        //"plugin:@typescript-eslint/strict", // I want to enable this. Lots of little changes will happen.
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/strict",
     ],
     "env": {
         "browser": true,
@@ -59,6 +59,8 @@ module.exports = {
                 }
             }
         ],
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-extraneous-class": "off",
         "no-case-declarations": "off",
         "no-useless-escape": "off",
         "no-floating-decimal": "error",

--- a/Extension/.scripts/common.ts
+++ b/Extension/.scripts/common.ts
@@ -152,7 +152,7 @@ export async function read(filename: string) {
     return content.toString();
 }
 
-export async function readJson(filename: string, fallback?: {}): Promise<CommentJSONValue> {
+export async function readJson(filename: string, fallback = {}): Promise<CommentJSONValue> {
     try {
         return parse(await read(filename));
     } catch {

--- a/Extension/.scripts/generateOptionsSchema.ts
+++ b/Extension/.scripts/generateOptionsSchema.ts
@@ -56,7 +56,7 @@ function updateDefaults(object: any, defaults: any): any {
 
 function refReplace(definitions: any, ref: any): any {
     // $ref is formatted as "#/definitions/ObjectName"
-    const referenceStringArray: string[] = ref['$ref'].split('/');
+    const referenceStringArray: string[] = ref.$ref.split('/');
 
     // Getting "ObjectName"
     const referenceName: string = referenceStringArray[referenceStringArray.length - 1];
@@ -71,7 +71,7 @@ function refReplace(definitions: any, ref: any): any {
     ref = appendFieldsToObject(reference, ref);
 
     // Remove $ref field
-    delete ref['$ref'];
+    delete ref.$ref;
 
     return ref;
 }

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -661,6 +661,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 const newSourceFileMapSource: string = util.resolveVariables(sourceFileMapSource, undefined);
                 if (sourceFileMapSource !== newSourceFileMapSource) {
                     message = "\t" + localize("replacing.sourcepath", "Replacing {0} '{1}' with '{2}'.", "sourcePath", sourceFileMapSource, newSourceFileMapSource);
+                    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                     delete config.sourceFileMap[sourceFileMapSource];
                     source = newSourceFileMapSource;
                 }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -461,12 +461,9 @@ enum SemanticTokenTypes {
 
 enum SemanticTokenModifiers {
     // These are camelCase as the enum names are used directly as strings in our legend.
-    // eslint-disable-next-line no-bitwise
-    static = (1 << 0),
-    // eslint-disable-next-line no-bitwise
-    global = (1 << 1),
-    // eslint-disable-next-line no-bitwise
-    local = (1 << 2)
+    static = 0b001,
+    global = 0b010,
+    local = 0b100
 }
 
 interface IntelliSenseSetup {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -494,7 +494,7 @@ export class CppProperties {
                 for (const [dep, execCmd] of nodeAddonMap) {
                     if (dep in packageJson.dependencies) {
                         try {
-                            let stdout: string | void = await util.execChildProcess(execCmd, rootPath);
+                            let stdout: string = await util.execChildProcess(execCmd, rootPath);
                             if (!stdout) {
                                 continue;
                             }
@@ -1413,12 +1413,12 @@ export class CppProperties {
 
             // Remove disallowed variable overrides
             if (this.configurationJson.env) {
-                delete this.configurationJson.env['workspaceRoot'];
-                delete this.configurationJson.env['workspaceFolder'];
-                delete this.configurationJson.env['workspaceFolderBasename'];
-                delete this.configurationJson.env['execPath'];
-                delete this.configurationJson.env['pathSeparator'];
-                delete this.configurationJson.env['default'];
+                delete this.configurationJson.env.workspaceRoot;
+                delete this.configurationJson.env.workspaceFolder;
+                delete this.configurationJson.env.workspaceFolderBasename;
+                delete this.configurationJson.env.execPath;
+                delete this.configurationJson.env.pathSeparator;
+                delete this.configurationJson.env.default;
             }
 
             // Warning: There is a chance that this is incorrect in the event that the c_cpp_properties.json file was created before

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -138,7 +138,7 @@ export class CppBuildTaskProvider implements TaskProvider {
                 (path.basename(info.path) === "cl.exe") && compiler_condition(info));
             knownCompilers = knownCompilers.filter(info =>
                 (info === cl_to_add) || (path.basename(info.path) !== "cl.exe" && compiler_condition(info)));
-            knownCompilers.map<void>(info => {
+            knownCompilers.forEach(info => {
                 knownCompilerPathsSet.add(info.path);
             });
         }

--- a/Extension/src/LanguageServer/settingsTracker.ts
+++ b/Extension/src/LanguageServer/settingsTracker.ts
@@ -49,7 +49,7 @@ export class SettingsTracker {
             }
 
             // Iterate through dotted "sub" settings.
-            const collectSettingsRecursive = (key: string, val: Object, depth: number) => {
+            const collectSettingsRecursive = (key: string, val: Record<string, any>, depth: number) => {
                 if (depth > 4) {
                     // Limit settings recursion to 4 dots (not counting the first one in: `C_Cpp.`)
                     return;

--- a/Extension/src/SSH/sshCommandToConfig.ts
+++ b/Extension/src/SSH/sshCommandToConfig.ts
@@ -177,7 +177,7 @@ function parseFlags(input: string[], entries: { [key: string]: string }): number
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-        const next: void | IParsedOption = parser.getopt();
+        const next: IParsedOption | undefined = parser.getopt();
         if (!next) {
             break;
         }

--- a/Extension/src/Utility/Eventing/emitter.ts
+++ b/Extension/src/Utility/Eventing/emitter.ts
@@ -84,7 +84,7 @@ export abstract class Emitter {
    * @param eventName - the string name of the event
    * @param options - options for the event trigger
    */
-    protected newEvent(eventName: string, options?: EventOptions): () => Promise<void | EventStatus>;
+    protected newEvent(eventName: string, options?: EventOptions): () => Promise<undefined | EventStatus>;
 
     /**
    * Creates a named event function for triggering events in an {@link Emitter}

--- a/Extension/src/Utility/Eventing/interfaces.ts
+++ b/Extension/src/Utility/Eventing/interfaces.ts
@@ -18,7 +18,7 @@ export interface Descriptor {
 
 export type Unsubscribe = () => void;
 
-export type Callback<TOutput = unknown> = (event: EventData<TOutput>, ...args: any[]) => Promise<TOutput> | Promise<EventStatus> | Promise<undefined> | TOutput | EventStatus | undefined | void | Promise<void>;
+export type Callback<TOutput = unknown> = (event: EventData<TOutput>, ...args: any[]) => Promise<TOutput> | Promise<EventStatus> | Promise<undefined> | TOutput | EventStatus | undefined | Promise<void>;
 
 export type PickByType<T, TKeepType> = {
     [P in keyof T as T[P] extends TKeepType ? P : never]: T[P]

--- a/Extension/src/Utility/Process/process.ts
+++ b/Extension/src/Utility/Process/process.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 
 import { ChildProcess, spawn } from 'child_process';
 import { basename, resolve } from 'path';

--- a/Extension/src/Utility/Sandbox/sandbox.ts
+++ b/Extension/src/Utility/Sandbox/sandbox.ts
@@ -23,6 +23,7 @@ export function createSandbox(): <T>(code: string, context?: any) => T {
                 sandbox
             );
             for (const key of Object.keys(context)) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete sandbox[key];
             }
         } else {

--- a/Extension/src/Utility/System/guards.ts
+++ b/Extension/src/Utility/System/guards.ts
@@ -61,6 +61,7 @@ export class is {
         return instance instanceof Socket;
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-types
     static function(instance: any): instance is Function {
         return typeof instance === 'function';
     }

--- a/Extension/src/Utility/System/info.ts
+++ b/Extension/src/Utility/System/info.ts
@@ -75,6 +75,7 @@ interface FunctionInfo {
 
     /** a bound callable function for the member (saves us from having to do it later anyway) */
 
+    // eslint-disable-next-line @typescript-eslint/ban-types
     fn: Function;
 }
 

--- a/Extension/src/Utility/Text/scanner.ts
+++ b/Extension/src/Utility/Text/scanner.ts
@@ -117,9 +117,11 @@ export enum Kind {
     Comma,
     QuestionDot,
     LessThan,
+    // eslint-disable-next-line @typescript-eslint/prefer-literal-enum-member
     OpenAngle = LessThan,
     LessThanSlash,
     GreaterThan,
+    // eslint-disable-next-line @typescript-eslint/prefer-literal-enum-member
     CloseAngle = GreaterThan,
     LessThanEquals,
     GreaterThanEquals,

--- a/Extension/src/types/posix-getopt.d.ts
+++ b/Extension/src/types/posix-getopt.d.ts
@@ -13,7 +13,7 @@ declare module 'posix-getopt' {
 
     export class BasicParser {
         constructor(template: string, arguments: readonly string[], skipArgs?: number);
-        getopt(): IParsedOption | void;
+        getopt(): IParsedOption | undefined;
         optind(): number;
     }
 }

--- a/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
@@ -62,6 +62,7 @@ suite("resolveVariables", () => {
             process.env[processKey] = "bar";
             actual = resolveVariables(input, {});
         } finally {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete process.env[processKey];
         }
         assert.equal(actual, "foobar");

--- a/Extension/test/unit/commandLineParsing.test.ts
+++ b/Extension/test/unit/commandLineParsing.test.ts
@@ -179,9 +179,9 @@ describe('Command Lines', () => {
             }
 
             if (variable !== undefined) {
-                process.env['var'] = variable;
+                process.env.var = variable;
             } else {
-                delete process.env['var'];
+                delete process.env.var;
             }
             stop = true;
 
@@ -203,7 +203,7 @@ describe('Command Lines', () => {
             if (variable !== undefined) {
                 process.env['var'] = variable;
             } else {
-                delete process.env['var'];
+                delete process.env.var;
             }
             stop = true;
 

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -56,9 +56,9 @@ const elementId: { [key: string]: string } = {
 };
 
 interface VsCodeApi {
-    postMessage(msg: {}): void;
-    setState(state: {}): void;
-    getState(): {};
+    postMessage(msg: Record<string, any>): void;
+    setState(state: Record<string, any>): void;
+    getState(): any;
 }
 
 declare function acquireVsCodeApi(): VsCodeApi;


### PR DESCRIPTION
Rather than adding new rules one-at-a-time, we're so close that we can now enable the  `@typescript-eslint/strict` linting ruleset.

