### PR TITLE
Make translations export work correctly in CI

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6134,7 +6134,7 @@
         "generate-native-strings": "ts-node -T ./.scripts/generateNativeStrings.ts",
         "generate-options-schema": "ts-node -T ./.scripts/generateOptionsSchema.ts",
         "copy-walkthrough-media": "ts-node -T ./.scripts/copyWalkthruMedia.ts",
-        "translations-export": "yarn generate-native-strings && gulp translations-export",
+        "translations-export": "yarn install && yarn prep && yarn generate-native-strings && gulp translations-export",
         "translations-generate": "set NODE_OPTIONS=--no-experimental-fetch && gulp translations-generate",
         "translations-import": "gulp translations-import",
         "import-edge-strings": "ts-node -T ./.scripts/import_edge_strings.ts",


### PR DESCRIPTION
Quick fix to call install & prep before the command.