### PR TITLE
Force module to node16 for ts-node

### DIFF
--- a/Extension/.scripts/tsconfig.json
+++ b/Extension/.scripts/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "module": "CommonJS",
+        "module": "node16",
         "moduleResolution": "node16",
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
This is needed if the system typescript is 5.2.2+
