### PR TITLE
Fix Initializing in the status bar instead of Indexing.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2436,9 +2436,12 @@ export class DefaultClient implements Client {
             testHook.updateStatus(status);
         } else if (message.endsWith("Initializing")) {
             this.model.isInitializingWorkspace.Value = true;
+            this.model.isIndexingWorkspace.Value = false;
+            this.model.isParsingWorkspace.Value = false;
         } else if (message.endsWith("Indexing")) {
             this.model.isIndexingWorkspace.Value = true;
             this.model.isInitializingWorkspace.Value = false;
+            this.model.isParsingWorkspace.Value = false;
         } else if (message.endsWith("files")) {
             this.model.isParsingFiles.Value = true;
         } else if (message.endsWith("IntelliSense")) {


### PR DESCRIPTION
It needed to set `this.model.isIndexingWorkspace.Value = false;` otherwise the state was stuck at true and it didn't refire the Indexing event, so it was still at Initializing.