### PR TITLE
Handle undefined environment variable

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -708,10 +708,6 @@ export class CppProperties {
         this.onSelectionChanged();
     }
 
-    private variableHasEnv(value: string): boolean {
-        return value.includes("env:");
-    }
-
     private resolveDefaults(entries: string[], defaultValue?: string[]): string[] {
         let result: string[] = [];
         entries.forEach(entry => {
@@ -767,7 +763,7 @@ export class CppProperties {
         paths = this.resolveDefaults(paths, defaultValue);
         paths.forEach(entry => {
             const resolvedVariable: string = util.resolveVariables(entry, env);
-            if (this.variableHasEnv(resolvedVariable)) {
+            if (resolvedVariable.includes("env:")) {
                 // Do not futher try to resolve a "${env:VAR}"
                 resolvedVariables.push(resolvedVariable);
             } else {
@@ -1497,7 +1493,7 @@ export class CppProperties {
         return success;
     }
 
-    public resolvePath(input_path: string | undefined, replaceAsterisks: boolean = true): string {
+    private resolvePath(input_path: string | undefined, replaceAsterisks: boolean = true): string {
         if (!input_path || input_path === "${default}") {
             return "";
         }
@@ -1521,8 +1517,9 @@ export class CppProperties {
             result = result.replace(/\*/g, "");
         }
 
-        // Make sure all paths result to an absolute path
-        if (!this.variableHasEnv(result) && !path.isAbsolute(result) && this.rootUri) {
+        // Make sure all paths result to an absolute path.
+        // Do not add the root path to an unresolved env variable.
+        if (!result.includes("env:") && !path.isAbsolute(result) && this.rootUri) {
             result = path.join(this.rootUri.fsPath, result);
         }
 


### PR DESCRIPTION
Issue https://github.com/microsoft/vscode-cpptools/issues/11447.

This fixes the processing of an environment variable in `CppProperties.resolveAndSplit` and `CppProperties.resolvePath`.

**Problem:**
In `util.resolvedVariable`, `process.env` returns undefined if an environment variable is not found or available, and `util.resolvedVariable` will return the match `${env:VAR}` if not resolved.  The `${env:VAR}` will then get split and appended to other paths incorrectly and processed as if it's the variable was resolved and would lead to incorrect values for other variables or paths.

**Fix:**
If an environment variable is not found or resolved, do not try to further change or process it.