### PR TITLE
Fix loading UI

### DIFF
--- a/Extension/src/LanguageServer/settingsPanel.ts
+++ b/Extension/src/LanguageServer/settingsPanel.ts
@@ -123,7 +123,7 @@ export class SettingsPanel {
                 localResourceRoots: [
                     vscode.Uri.file(util.extensionPath),
                     vscode.Uri.file(path.join(util.extensionPath, 'ui')),
-                    vscode.Uri.file(path.join(util.extensionPath, 'out', 'ui'))]
+                    vscode.Uri.file(path.join(util.extensionPath, 'dist', 'ui'))]
             }
         );
 
@@ -389,7 +389,7 @@ export class SettingsPanel {
             content = content.replace(
                 /{{cpp_image_uri}}/g,
                 cppImageUri.toString());
-            const settingsJsUri: vscode.Uri = this.panel.webview.asWebviewUri(vscode.Uri.file(path.join(util.extensionPath, 'out/ui/settings.js')));
+            const settingsJsUri: vscode.Uri = this.panel.webview.asWebviewUri(vscode.Uri.file(path.join(util.extensionPath, 'dist/ui/settings.js')));
             content = content.replace(
                 /{{settings_js_uri}}/g,
                 settingsJsUri.toString());

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -389,4 +389,5 @@ class SettingsApp {
     }
 }
 
-export const app: SettingsApp = new SettingsApp();
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const app: SettingsApp = new SettingsApp();


### PR DESCRIPTION
- UI content was not getting loaded because SettingsApp was getting exported, which shouldn't be. 
- Updated path to output of UI which is now to `dist` instead of `out` folder.