### PR TITLE
Notify users if there's a pre-release version available.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1165,8 +1165,10 @@ export function UpdateInsidersAccess(): void {
 }
 
 export async function preReleaseCheck(): Promise<void> {
-    // First we need to make sure the user isn't already on a pre-release version.
-    if (util.getCppToolsTargetPopulation() === TargetPopulation.Public) {
+    const displayedPreReleasePrompt: PersistentState<boolean> = new PersistentState<boolean>("CPP.displayedPreReleasePrompt", false);
+
+    // First we need to make sure the user isn't already on a pre-release version and hasn't dismissed this prompt before.
+    if (!displayedPreReleasePrompt.Value && util.getCppToolsTargetPopulation() === TargetPopulation.Public) {
         // Get the info on the latest version from the marketplace to check if there is a pre-release version available.
         const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
             method: 'POST',
@@ -1182,6 +1184,7 @@ export async function preReleaseCheck(): Promise<void> {
 
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {
+            displayedPreReleasePrompt.Value = true;
             const message: string = localize("prerelease.message", "There is a new pre-release version of the C/C++ extension, would you like to install it?");
             const yes: string = localize("yes.button", "Yes");
             const no: string = localize("no.button", "No");

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1124,7 +1124,7 @@ export function getActiveClient(): Client {
     return clients.ActiveClient;
 }
 
-export async function UpdateInsidersAccess(): Promise<void> {
+export function UpdateInsidersAccess(): void {
     let installPrerelease: boolean = false;
 
     // Only move them to the new prerelease mechanism if using updateChannel of Insiders.
@@ -1158,9 +1158,15 @@ export async function UpdateInsidersAccess(): Promise<void> {
         }
     }
 
-    // First we need to make sure the user isn't already on a pre-release version
+    if (installPrerelease) {
+        void vscode.commands.executeCommand("workbench.extensions.installExtension", "ms-vscode.cpptools", { installPreReleaseVersion: true }).then(undefined, logAndReturn.undefined);
+    }
+}
+
+export async function PreReleaseCheck(): Promise<void> {
+    // First we need to make sure the user isn't already on a pre-release version.
     if (!util.packageJson.__metadata?.preRelease === true) {
-    // Get the info on the latest version from the marketplace to check if there is a pre-release version available 
+        // Get the info on the latest version from the marketplace to check if there is a pre-release version available.
         const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
             method: 'POST',
             headers: {
@@ -1175,13 +1181,13 @@ export async function UpdateInsidersAccess(): Promise<void> {
 
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {
-            const message: string = localize('prerelease.message', "Would you like to install the latest pre-release version of the C/C++ extension?");
+            const message: string = localize("prerelease.message", "There is a new pre-release version of the C/C++ extension, would you like to install it?");
             const yes: string = localize("yes.button", "Yes");
             const no: string = localize("no.button", "No");
             vscode.window.showInformationMessage(message, yes, no).then((selection) => {
                 switch (selection) {
                     case yes:
-                        installPrerelease = true;
+                        void vscode.commands.executeCommand("workbench.extensions.installExtension", "ms-vscode.cpptools", { installPreReleaseVersion: true }).then(undefined, logAndReturn.undefined);
                         break;
                     case no:
                         break;
@@ -1190,9 +1196,5 @@ export async function UpdateInsidersAccess(): Promise<void> {
                 }
             });
         }
-    }
-
-    if (installPrerelease) {
-        void vscode.commands.executeCommand("workbench.extensions.installExtension", "ms-vscode.cpptools", { installPreReleaseVersion: true }).then(undefined, logAndReturn.undefined);
     }
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1185,7 +1185,7 @@ export async function preReleaseCheck(): Promise<void> {
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {
             displayedPreReleasePrompt.Value = true;
-            const message: string = localize("prerelease.message", "There is a new pre-release version of the C/C++ extension, would you like to install it?");
+            const message: string = localize("prerelease.message", "There is a new pre-release version of the C/C++ extension. Would you like to install it?");
             const yes: string = localize("yes.button", "Yes");
             const no: string = localize("no.button", "No");
             void vscode.window.showInformationMessage(message, yes, no).then((selection) => {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1185,7 +1185,7 @@ export async function preReleaseCheck(): Promise<void> {
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {
             displayedPreReleasePrompt.Value = true;
-            const message: string = localize("prerelease.message", "A pre-release version of the C/C++ extension is available. Would you like to switch to using the pre-release version?");
+            const message: string = localize("prerelease.message", "A pre-release version of the C/C++ extension is available. Would you like to switch to it?");
             const yes: string = localize("yes.button", "Yes");
             const no: string = localize("no.button", "No");
             void vscode.window.showInformationMessage(message, yes, no).then((selection) => {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1185,7 +1185,7 @@ export async function preReleaseCheck(): Promise<void> {
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {
             displayedPreReleasePrompt.Value = true;
-            const message: string = localize("prerelease.message", "There is a new pre-release version of the C/C++ extension. Would you like to install it?");
+            const message: string = localize("prerelease.message", "A pre-release version of the C/C++ extension is available. Would you like to switch to using the pre-release version?");
             const yes: string = localize("yes.button", "Yes");
             const no: string = localize("no.button", "No");
             void vscode.window.showInformationMessage(message, yes, no).then((selection) => {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -70,6 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     util.checkDistro(info);
     await checkVsixCompatibility();
     LanguageServer.UpdateInsidersAccess();
+    await LanguageServer.PreReleaseCheck();
 
     const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
     let isOldMacOs: boolean = false;

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -70,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     util.checkDistro(info);
     await checkVsixCompatibility();
     LanguageServer.UpdateInsidersAccess();
-    await LanguageServer.PreReleaseCheck();
+    await LanguageServer.preReleaseCheck();
 
     const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
     let isOldMacOs: boolean = false;


### PR DESCRIPTION
Check if there's a pre-release available and that the user isn't already using it, and if so, pop up a prompt to see if they want to install it. A little tough to test this locally, but the parts I can't test I've taken from previous PRs/other MS vscode extensions. Any tips to test the pre-release check (from __metadata) and the install command (took it from a previous related PR) is very welcome, as well as any other comments on the code style/use since it's my first PR in the space.