### PR TITLE
Fix 'Extract to function' formatting/selection bugs.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3497,6 +3497,9 @@ export class DefaultClient implements Client {
         let workspaceEdits: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
         let replaceEditRange: vscode.Range | undefined;
         let hasProcessedReplace: boolean = false;
+        // NOTE: References to source/header are in reference to the more common case when it's
+        // invoked on the source file (alternatively named the first file). When invoked on the header file,
+        // the header file operates as if it were the source file (isSourceFile stays true).
         const sourceFormatUriAndRanges: VsCodeUriAndRange[] = [];
         const headerFormatUriAndRanges: VsCodeUriAndRange[] = [];
         let lineOffset: number = 0;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/11614 (incorrect header formatting) and https://github.com/microsoft/vscode-cpptools/issues/11619 (incorrect selection) and fixes other unreported issues (e.g. duplicate formatting calls and unnecessary document switching).
