### PR TITLE
Open the modified header for 'Extract to function'.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3612,7 +3612,7 @@ export class DefaultClient implements Client {
             // The header needs to be open and shown or the formatting will fail
             // (due to issues/requirements in the cpptools process).
             // It also seems strange and undesirable to have the header modified
-            // without being opened because user may otherwise users may not realize that
+            // without being opened because otherwise users may not realize that
             // the header had changed (unless they view source control differences).
             await vscode.window.showTextDocument(headerFormatUriAndRanges[0].uri, { preserveFocus: true });
         }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3608,6 +3608,15 @@ export class DefaultClient implements Client {
             return;
         }
 
+        if (headerFormatUriAndRanges.length > 0) {
+            // The header needs to be open and shown or the formatting will fail
+            // (due to issues/requirements in the cpptools process).
+            // It also seems strange and undesirable to have the header modified
+            // without being opened because user may otherwise users may not realize that
+            // the header had changed (unless they view source control differences).
+            await vscode.window.showTextDocument(headerFormatUriAndRanges[0].uri, { preserveFocus: true });
+        }
+
         // Apply the extract to function text edits.
         await vscode.workspace.applyEdit(workspaceEdits, { isRefactoring: true });
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/11669 (formatting not working if the header wasn't open). Also, fix the issue where the header would change and never open (if files.refactoring.autoSave were enabled), so users may not realize the file had change (unless they viewed a source control diff).