### PR TITLE
Fix configuration provider handling with intelliSenseEngine "disabled".

### DIFF
--- a/Extension/src/LanguageServer/customProviders.ts
+++ b/Extension/src/LanguageServer/customProviders.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import { CustomConfigurationProvider, SourceFileConfigurationItem, Version, WorkspaceBrowseConfiguration } from 'vscode-cpptools';
-import * as ext from './extension';
 import { CppSettings } from './settings';
 
 /**
@@ -158,7 +157,8 @@ export class CustomConfigurationProviderCollection {
     }
 
     public add(provider: CustomConfigurationProvider, version: Version): boolean {
-        if (new CppSettings(ext.getActiveClient().RootUri).intelliSenseEngine === "disabled") {
+        const settings: CppSettings = new CppSettings((vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) ? vscode.workspace.workspaceFolders[0]?.uri : undefined);
+        if (settings.intelliSenseEngine === "disabled") {
             console.warn("Language service is disabled. Provider will not be registered.");
             return false;
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/11795

If the 1st workspace folder has intelliSenseEngine disabled then clients aren't created and it was accessing the non-existent active client. This changes it to just use the 1st client's disabled settings (which is what is done for activation when determining whether any clients should be created). Having different intelliSenseEngine settings on different workspace folders doesn't appear to be fully supported currently (we could file an issue to track that but no users have complained so far).