### PR TITLE
Fix C_Cpp.autocomplete description.

### DIFF
--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -470,9 +470,9 @@
         ]
     },
     "c_cpp.configuration.autocomplete.markdownDescription": {
-        "message": "Controls the auto-completion provider. If `disabled` and you want word-based completion, you will also need to set `\"[cpp]\": {\"editor.wordBasedSuggestions\": true}` (and similarly for `c` and `cuda-cpp` languages).",
+        "message": "Controls the auto-completion provider. If `disabled` and you want word-based completion, you will also need to set `\"[cpp]\": {\"editor.wordBasedSuggestions\": <value>}` (and similarly for `c` and `cuda-cpp` languages).",
         "comment": [
-            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered -- except for text \"value\", which is a placeholder that should be translated."
         ]
     },
     "c_cpp.configuration.autocomplete.default.description": "Uses the active IntelliSense engine.",


### PR DESCRIPTION
Recent VS Code versions changed the settings values, see https://github.com/microsoft/vscode/pull/197690