### PR TITLE
Add permissions field to bot actions workflows

### DIFF
--- a/.github/workflows/by-design-closer-debugger .yml
+++ b/.github/workflows/by-design-closer-debugger .yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v3

--- a/.github/workflows/by-design-closer.yml
+++ b/.github/workflows/by-design-closer.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v3

--- a/.github/workflows/duplicate-closer.yml
+++ b/.github/workflows/duplicate-closer.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/enhancement-closer-no-milestone.yml
+++ b/.github/workflows/enhancement-closer-no-milestone.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/enhancement-closer-triage.yml
+++ b/.github/workflows/enhancement-closer-triage.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/enhancement-reopener.yml
+++ b/.github/workflows/enhancement-reopener.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/external-closer-debugger.yml
+++ b/.github/workflows/external-closer-debugger.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/feature-request-closer-no-milestone.yml
+++ b/.github/workflows/feature-request-closer-no-milestone.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/feature-request-closer-triage.yml
+++ b/.github/workflows/feature-request-closer-triage.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/feature-request-reopener.yml
+++ b/.github/workflows/feature-request-reopener.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/investigate-closer-debugger.yml
+++ b/.github/workflows/investigate-closer-debugger.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/investigate-costing-closer-debugger.yml
+++ b/.github/workflows/investigate-costing-closer-debugger.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/more-info-needed-closer-debugger.yml
+++ b/.github/workflows/more-info-needed-closer-debugger.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/more-info-needed-closer.yml
+++ b/.github/workflows/more-info-needed-closer.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/question-closer-debugger.yml
+++ b/.github/workflows/question-closer-debugger.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/question-closer.yml
+++ b/.github/workflows/question-closer.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2


### PR DESCRIPTION
Starting February 1, 2024 the default permission for the GITHUB_TOKEN will change from Read/Write to Read-only for all our Open Source GitHub orgs.