### PR TITLE
Change default intelliSenseUpdateDelay to 1s

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -458,7 +458,7 @@
                     },
                     "C_Cpp.intelliSenseUpdateDelay": {
                         "type": "number",
-                        "default": 2000,
+                        "default": 1000,
                         "description": "%c_cpp.configuration.intelliSenseUpdateDelay.description%",
                         "scope": "application",
                         "minimum": 500,


### PR DESCRIPTION
Prior to 1.19.2, this setting was not being properly honored.  Changing it to 1s aligns it with the equivalent delay in VS.