### PR TITLE
Silence `console.log`s

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1836,7 +1836,7 @@ export class DefaultClient implements Client {
         if (!this.configurationProvider) {
             return;
         }
-        console.log("updateCustomBrowseConfiguration");
+
         const currentProvider: CustomConfigurationProvider1 | undefined = getCustomConfigProviders().get(this.configurationProvider);
         if (!currentProvider || !currentProvider.isReady || (requestingProvider && requestingProvider.extensionId !== currentProvider.extensionId)) {
             return;
@@ -1973,7 +1973,6 @@ export class DefaultClient implements Client {
         DefaultClient.isStarted.reset();
 
         const tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
-        console.log("provideCustomConfiguration");
 
         const params: QueryTranslationUnitSourceParams = {
             uri: docUri.toString(),
@@ -3080,10 +3079,8 @@ export class DefaultClient implements Client {
                     if (sanitized.browsePath.length === 0) {
                         sanitized.browsePath = ["${workspaceFolder}/**"];
                     }
-                    console.log("Falling back to last received browse configuration: ", JSON.stringify(sanitized, null, 2));
                     break;
                 }
-                console.log("No browse configuration is available.");
                 return;
             }
 
@@ -3097,7 +3094,6 @@ export class DefaultClient implements Client {
                     if (sanitized.browsePath.length === 0) {
                         sanitized.browsePath = ["${workspaceFolder}/**"];
                     }
-                    console.log("Falling back to last received browse configuration: ", JSON.stringify(sanitized, null, 2));
                     break;
                 }
                 return;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -145,7 +145,6 @@ function sendActivationTelemetry(): void {
  */
 export async function activate(): Promise<void> {
 
-    console.log("activating extension");
     sendActivationTelemetry();
     const checkForConflictingExtensions: PersistentState<boolean> = new PersistentState<boolean>("CPP." + util.packageJson.version + ".checkForConflictingExtensions", true);
     if (checkForConflictingExtensions.Value) {
@@ -157,7 +156,6 @@ export async function activate(): Promise<void> {
         }
     }
 
-    console.log("starting language server");
     clients = new ClientCollection();
     ui = getUI();
 
@@ -1202,7 +1200,6 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, er
 
 export function deactivate(): Thenable<void> {
     clients.timeTelemetryCollector.clear();
-    console.log("deactivating extension");
     telemetry.logLanguageServerEvent("LanguageServerShutdown");
     clearInterval(intervalTimer);
     commandDisposables.forEach(d => d.dispose());


### PR DESCRIPTION
Turns the `console.log` messages that happen regularly into output stream log messages. Leaves `console.log`s in exception handlers the way they are.

`console.log` will show up in the console window of all extension debug sessions. I'm the maintainer of [an extension](https://marketplace.visualstudio.com/items?itemName=nordic-semiconductor.nrf-connect) that integrates with the configuration provider API for the C++ extension. 

The amount of console log messages this extension generates that I have to filter out when debugging my own extension finally got annoying enough that I wanted to open a PR to try and force a change.

Note that I'm bypassing the localization mechanism for the output channel here. Not sure if this is acceptable.

Fixes most of #8389, but there are still a few `console.log`s left, so not sure if it's enough to mark it as closed.