### PR TITLE
Add fragments field to task.json to persist legacy command line argument behavior.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -320,6 +320,10 @@
                         "type": "array",
                         "description": "%c_cpp.taskDefinitions.args.description%"
                     },
+                    "fragments": {
+                        "type": "array",
+                        "description": "%c_cpp.taskDefinitions.fragments.description%"
+                    },
                     "options": {
                         "type": "object",
                         "description": "%c_cpp.taskDefinitions.options.description%",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -928,6 +928,7 @@
     "c_cpp.taskDefinitions.name.description": "The name of the task.",
     "c_cpp.taskDefinitions.command.description": "The path to either a compiler or script that performs compilation.",
     "c_cpp.taskDefinitions.args.description": "Additional arguments to pass to the compiler or compilation script.",
+    "c_cpp.taskDefinitions.fragments.description": "Additional arguments to pass to the compiler that are expected to receive shell processing. For example, '*.c' should expand to all .c files in the working directory.",
     "c_cpp.taskDefinitions.options.description": "Additional command options.",
     "c_cpp.taskDefinitions.options.cwd.description": "The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
     "c_cpp.taskDefinitions.detail.description": "Additional details of the task.",

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -394,7 +394,7 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
         const exePath: string | undefined = util.resolveVariables(util.findExePathInArgs(this.args));
         util.createDirIfNotExistsSync(exePath);
 
-        if (this.fragments.length > 0 && this.args.length == 0) {
+        if (this.fragments.length > 0 && this.args.length === 0) {
             this.args = this.fragments;
             this.args.forEach((value) => {
                 activeCommand = activeCommand + " " + value;
@@ -410,7 +410,7 @@ class CustomBuildTaskTerminal implements Pseudoterminal {
                 activeCommand = activeCommand + " " + value;
             });
             this.args.push(...this.fragments);
-        } else if (this.args.length > 0 && this.fragments.length == 0) {
+        } else if (this.args.length > 0 && this.fragments.length === 0) {
             this.args.forEach((value, index) => {
                 value = util.quoteArgument(util.resolveVariables(value));
                 activeCommand = activeCommand + " " + value;


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12001