### PR TITLE
Remove work-around for folding ranges issue

### DIFF
--- a/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
+++ b/Extension/src/LanguageServer/Providers/foldingRangeProvider.ts
@@ -3,22 +3,13 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { ManualPromise } from '../../Utility/Async/manualPromise';
 import { CppFoldingRange, DefaultClient, FoldingRangeKind, GetFoldingRangesParams, GetFoldingRangesRequest, GetFoldingRangesResult } from '../client';
 import { CppSettings } from '../settings';
-
-interface FoldingRangeRequestInfo {
-    promise: ManualPromise<vscode.FoldingRange[] | undefined> | undefined;
-}
 
 export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
     private client: DefaultClient;
     public onDidChangeFoldingRangesEvent = new vscode.EventEmitter<void>();
     public onDidChangeFoldingRanges?: vscode.Event<void>;
-
-    // Mitigate an issue where VS Code sends us an inordinate number of requests
-    // for the same file without waiting for the prior request to complete or cancelling them.
-    private pendingRequests: Map<string, FoldingRangeRequestInfo> = new Map<string, FoldingRangeRequestInfo>();
 
     constructor(client: DefaultClient) {
         this.client = client;
@@ -31,36 +22,8 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
             return [];
         }
 
-        const pendingRequest: FoldingRangeRequestInfo | undefined = this.pendingRequests.get(document.uri.toString());
-        if (pendingRequest !== undefined) {
-            if (pendingRequest.promise === undefined) {
-                pendingRequest.promise = new ManualPromise<vscode.FoldingRange[] | undefined>();
-            }
-            console.log("Redundant folding ranges request received for: " + document.uri.toString());
-            return pendingRequest.promise;
-        }
-        const foldingRangeRequestInfo: FoldingRangeRequestInfo = {
-            promise: undefined
-        };
-        this.pendingRequests.set(document.uri.toString(), foldingRangeRequestInfo);
-
-        const promise: Promise<vscode.FoldingRange[] | undefined> = this.requestRanges(document.uri.toString(), token);
-        await promise;
-        this.pendingRequests.delete(document.uri.toString());
-        if (foldingRangeRequestInfo.promise !== undefined) {
-            promise.then(() => {
-                foldingRangeRequestInfo.promise?.resolve(promise);
-            }, () => {
-                foldingRangeRequestInfo.promise?.reject(new vscode.CancellationError());
-            });
-        }
-        return promise;
-    }
-
-    private async requestRanges(uri: string, token: vscode.CancellationToken): Promise<vscode.FoldingRange[] | undefined>
-    {
         const params: GetFoldingRangesParams = {
-            uri
+            uri: document.uri.toString()
         };
 
         const response: GetFoldingRangesResult = await this.client.languageClient.sendRequest(GetFoldingRangesRequest, params, token);
@@ -92,14 +55,6 @@ export class FoldingRangeProvider implements vscode.FoldingRangeProvider {
     }
 
     public refresh(): void {
-        // Consider all pending requests as being outdated. Cancel them all.
-        const oldPendingRequests: Map<string, FoldingRangeRequestInfo> = this.pendingRequests;
-        this.pendingRequests = new Map<string, FoldingRangeRequestInfo>();
         this.onDidChangeFoldingRangesEvent.fire();
-        oldPendingRequests.forEach((value: FoldingRangeRequestInfo | undefined, _key: string) => {
-            if (value !== undefined && value.promise !== undefined) {
-                value.promise.reject(new vscode.CancellationError());
-            }
-        });
     }
 }


### PR DESCRIPTION
This is in the context of: https://github.com/microsoft/vscode-cpptools/issues/12052
and: https://github.com/microsoft/vscode/issues/206841

This would restore our `FoldingRangeProvider` to extremely straight-forward functionality, and not attempt to work around a possible VS Code issue with many redundant requests.  It's possible that may worsen the behavior we see when the issue repros, but would also help clarify whether the issue is in VS Code itself.