### PR TITLE
Fix Add Configuration with snippets disabled.

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -1228,7 +1228,7 @@ class LinuxConfigurationProvider extends DefaultConfigurationProvider {
 }
 
 function convertConfigurationSnippetToCompletionItem(snippet: IConfigurationSnippet): vscode.CompletionItem {
-    const item: vscode.CompletionItem = new vscode.CompletionItem(snippet.label, vscode.CompletionItemKind.Snippet);
+    const item: vscode.CompletionItem = new vscode.CompletionItem(snippet.label, vscode.CompletionItemKind.Module);
 
     item.insertText = snippet.bodyText;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/12059

This causes the C/C++ debug configs to match the "type" used by the other configs:

<img width="261" alt="image" src="https://github.com/microsoft/vscode-cpptools/assets/19859882/228ca932-c089-4672-b0ff-dd3c0c5aa6f3">
