### PR TITLE
Update changelog for 1.19.7

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Version 1.19.7: March 8, 2024
 ### Bug Fixes
+* Fix a potential deadlock. [12051](https://github.com/microsoft/vscode-cpptools/issues/12051)
 * Fix a crash related to parsing concepts. [#12060](https://github.com/microsoft/vscode-cpptools/issues/12060)
-* Fix a potential deadlock.
 
 ## Version 1.19.6: March 6, 2024
 ### Enhancement

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.19.7: March 8, 2024
+### Bug Fixes
+* Fix a crash related to parsing concepts. [#12060](https://github.com/microsoft/vscode-cpptools/issues/12060)
+* Fix a potential deadlock.
+
 ## Version 1.19.6: March 6, 2024
 ### Enhancement
 * Performance improvement.

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.19.7: March 8, 2024
 ### Bug Fixes
-* Fix a potential deadlock. [12051](https://github.com/microsoft/vscode-cpptools/issues/12051)
+* Fix a potential deadlock. [#12051](https://github.com/microsoft/vscode-cpptools/issues/12051)
 * Fix a crash related to parsing concepts. [#12060](https://github.com/microsoft/vscode-cpptools/issues/12060)
 
 ## Version 1.19.6: March 6, 2024

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.19.6-main",
+    "version": "1.19.7-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
Update changelog and version number for 1.19.7.

The plan is to cherry-pick just this into the release branch.

This addresses will address a crash ( https://github.com/microsoft/vscode-cpptools/issues/12060 ) and we think may address a deadlock (https://github.com/microsoft/vscode-cpptools/issues/12051). Both fixes are on the native side.