### PR TITLE
Add a maximum search results for goto symbol

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3079,10 +3079,7 @@
                         "scope": "machine"
                     },
                     "C_Cpp.maxSymbolSearchResults": {
-                        "type": [
-                            "integer",
-                            "null"
-                        ],
+                        "type": "integer",
                         "markdownDescription": "%c_cpp.configuration.maxSymbolSearchResults.markdownDescription%",
                         "default": 5000,
                         "minimum": 500,

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3078,6 +3078,17 @@
                         "maximum": 65536,
                         "scope": "machine"
                     },
+                    "C_Cpp.maxSymbolSearchResults": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "markdownDescription": "%c_cpp.configuration.maxSymbolSearchResults.markdownDescription%",
+                        "default": 5000,
+                        "minimum": 500,
+                        "maximum": 10000,
+                        "scope": "window"
+                    },
                     "C_Cpp.intelliSense.maxCachedProcesses": {
                         "type": [
                             "integer",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -67,7 +67,7 @@
         ]
     },
     "c_cpp.configuration.maxSymbolSearchResults.markdownDescription": {
-        "message": "The maximum number of results to show for Go to Symbol in Workspace. The default is `5000`.",
+        "message": "The maximum number of results to show for 'Go to Symbol in Workspace'. The default is `5000`.",
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -67,7 +67,7 @@
         ]
     },
     "c_cpp.configuration.maxSymbolSearchResults.markdownDescription": {
-        "message": "The maximum number of results to show for Go to Symbol. The default is 5000.",
+        "message": "The maximum number of results to show for Go to Symbol in Workspace. The default is `5000`.",
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -67,7 +67,7 @@
         ]
     },
     "c_cpp.configuration.maxSymbolSearchResults.markdownDescription": {
-        "message": "The maximum number of results to show for GoTo Symbol. The default is 5000.",
+        "message": "The maximum number of results to show for Go to Symbol. The default is 5000.",
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -66,6 +66,12 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
+    "c_cpp.configuration.maxSymbolSearchResults.markdownDescription": {
+        "message": "The maximum number of results to show for GoTo Symbol. The default is 5000.",
+        "comment": [
+            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+        ]
+    },
     "c_cpp.configuration.intelliSense.maxCachedProcesses.markdownDescription": {
         "message": "The maximum number of IntelliSense processes to keep running. The default of `null` (empty) uses value inherited from `#C_Cpp.maxCachedProcesses#`.",
         "comment": [

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1458,6 +1458,7 @@ export class DefaultClient implements Client {
             maxConcurrentThreads: workspaceSettings.maxConcurrentThreads,
             maxCachedProcesses: workspaceSettings.maxCachedProcesses,
             maxMemory: workspaceSettings.maxMemory,
+            maxSymbolSearchResults: workspaceSettings.maxSymbolSearchResults,
             loggingLevel: workspaceSettings.loggingLevel,
             workspaceParsingPriority: workspaceSettings.workspaceParsingPriority,
             workspaceSymbols: workspaceSettings.workspaceSymbols,

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -314,7 +314,7 @@ export class CppSettings extends Settings {
 
     public get maxConcurrentThreads(): number | undefined | null { return super.Section.get<number | null>("maxConcurrentThreads"); }
     public get maxMemory(): number | undefined | null { return super.Section.get<number | null>("maxMemory"); }
-    public get maxSymbolSearchResults(): number | undefined | null { return super.Section.get<number | null>("maxSymbolSearchResults"); }
+    public get maxSymbolSearchResults(): number | undefined { return super.Section.get<number>("maxSymbolSearchResults"); }
     public get maxCachedProcesses(): number | undefined | null { return super.Section.get<number | null>("maxCachedProcesses"); }
     public get intelliSenseMaxCachedProcesses(): number | undefined | null { return super.Section.get<number | null>("intelliSense.maxCachedProcesses"); }
     public get intelliSenseMaxMemory(): number | undefined | null { return super.Section.get<number | null>("intelliSense.maxMemory"); }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -142,6 +142,7 @@ export interface SettingsParams {
     maxConcurrentThreads: number | null | undefined;
     maxCachedProcesses: number | null | undefined;
     maxMemory: number | null | undefined;
+    maxSymbolSearchResults: number | null | undefined;
     loggingLevel: string | undefined;
     workspaceParsingPriority: string | undefined;
     workspaceSymbols: string | undefined;
@@ -313,6 +314,7 @@ export class CppSettings extends Settings {
 
     public get maxConcurrentThreads(): number | undefined | null { return super.Section.get<number | null>("maxConcurrentThreads"); }
     public get maxMemory(): number | undefined | null { return super.Section.get<number | null>("maxMemory"); }
+    public get maxSymbolSearchResults(): number | undefined | null { return super.Section.get<number | null>("maxSymbolSearchResults"); }
     public get maxCachedProcesses(): number | undefined | null { return super.Section.get<number | null>("maxCachedProcesses"); }
     public get intelliSenseMaxCachedProcesses(): number | undefined | null { return super.Section.get<number | null>("intelliSense.maxCachedProcesses"); }
     public get intelliSenseMaxMemory(): number | undefined | null { return super.Section.get<number | null>("intelliSense.maxMemory"); }


### PR DESCRIPTION
Updates to goto symbol experiment - add a `c_cpp.maxSymbolSearchResults` setting to cap the maximum number of results returned to the user

Needs the native code PR as well. 