### PR TITLE
rename telemetry property

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1998,8 +1998,8 @@ export class DefaultClient implements Client {
         }
         try {
             DefaultClient.isStarted.reset();
-            const result = await this.provideCustomConfigurationAsync(docUri, requestFile, replaceExisting, provider);
-            telemetry.logLanguageServerEvent('provideCustomConfiguration', { providerId, result });
+            const status = await this.provideCustomConfigurationAsync(docUri, requestFile, replaceExisting, provider);
+            telemetry.logLanguageServerEvent('provideCustomConfiguration', { providerId, status });
         } finally {
             onFinished();
             DefaultClient.isStarted.resolve();


### PR DESCRIPTION
"result" seems to be a reserved name for telemetry, so none of the data is appearing.  Renaming to "status" which I know works (there are other events that have a property with this name).