### PR TITLE
Improvements to crash call stack logging.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1206,11 +1206,7 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
         if (lines.length >= 6 && util.getNumericLoggingLevel(settings.get<string>("loggingLevel")) >= 1) {
             const out: vscode.OutputChannel = getCrashCallStacksChannel();
             out.appendLine("");
-            out.append(localize({ key: "crash.callstack.info", comment: [
-                "{0} is the process name: either cpptools or cpptools-srv. {1} is the crash date and time, e.g. 4/24/2024, 4:44:52 PM. {2} is a signal name, e.g. SIGSEGV. The call stack lines appear on a new line after the ':'" ]},
-            "The {0} process crashed on {1} from signal {2} with call stack:",
-            isCppToolsSrv ? "cpptools-srv" : "cpptools", crashDate.toLocaleString(), signalType));
-            out.appendLine(crashCallStack);
+            out.appendLine(`${isCppToolsSrv ? "cpptools-srv" : "cpptools"}\n${crashDate.toLocaleString()}\n${signalType}${crashCallStack}`);
         }
     }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1205,8 +1205,7 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
         const settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("C_Cpp", null);
         if (lines.length >= 6 && util.getNumericLoggingLevel(settings.get<string>("loggingLevel")) >= 1) {
             const out: vscode.OutputChannel = getCrashCallStacksChannel();
-            out.appendLine("");
-            out.appendLine(`${isCppToolsSrv ? "cpptools-srv" : "cpptools"}\n${crashDate.toLocaleString()}\n${signalType}${crashCallStack}`);
+            out.appendLine(`\n${isCppToolsSrv ? "cpptools-srv" : "cpptools"}\n${crashDate.toLocaleString()}\n${signalType}${crashCallStack}`);
         }
     }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1138,7 +1138,7 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
     const offsetStr: string = isMac ? " + " : "+";
     const endOffsetStr: string = isMac ? " " : " <";
     const dotStr: string = "…";
-    const signalType: string = lines[0]; // signal type
+    const signalType: string = lines[0];
     let crashCallStack: string = "";
     for (let lineNum: number = 2; lineNum < lines.length - 3; ++lineNum) { // skip first/last lines
         crashCallStack += "\n";

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1200,9 +1200,10 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, er
         data = data.substring(0, 8191) + "…";
     }
 
+    logCppCrashTelemetry(data, addressData);
+
     if (data !== prevCppCrashData) {
         prevCppCrashData = data;
-        logCppCrashTelemetry(data, addressData);
 
         const settings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("C_Cpp", null);
         if (util.getNumericLoggingLevel(settings.get<string>("loggingLevel")) >= 1) {

--- a/Extension/src/logger.ts
+++ b/Extension/src/logger.ts
@@ -102,8 +102,9 @@ export function getDiagnosticsChannel(): vscode.OutputChannel {
 export function getCrashCallStacksChannel(): vscode.OutputChannel {
     if (!crashCallStacksChannel) {
         crashCallStacksChannel = vscode.window.createOutputChannel(localize("c.cpp.crash.call.stacks.title", "C/C++ Crash Call Stacks"));
-        crashCallStacksChannel.appendLine(localize("c.cpp.crash.call.stacks.description",
-            "The information below could be helpful to provide in a C/C++ extension bug report:"));
+        crashCallStacksChannel.appendLine(localize({ key: "c.cpp.crash.call.stacks.description", comment: [ "{0} is a URL."]},
+            "A C/C++ extension process has crashed. The crashing process name, date/time, signal, and call stack are below -- it would be helpful to include that in a C/C++ extension bug report at {0}.",
+            "https://github.com/Microsoft/vscode-cpptools/issues"));
     }
     return crashCallStacksChannel;
 }

--- a/Extension/src/logger.ts
+++ b/Extension/src/logger.ts
@@ -103,7 +103,7 @@ export function getCrashCallStacksChannel(): vscode.OutputChannel {
     if (!crashCallStacksChannel) {
         crashCallStacksChannel = vscode.window.createOutputChannel(localize("c.cpp.crash.call.stacks.title", "C/C++ Crash Call Stacks"));
         crashCallStacksChannel.appendLine(localize({ key: "c.cpp.crash.call.stacks.description", comment: ["{0} is a URL."] },
-            "A C/C++ extension process has crashed. The crashing process name, date/time, signal, and call stack are below -- it would be helpful to include that in a C/C++ extension bug report at {0}.",
+            "A C/C++ extension process has crashed. The crashing process name, date/time, signal, and call stack are below -- it would be helpful to include that in a bug report at {0}.",
             "https://github.com/Microsoft/vscode-cpptools/issues"));
     }
     return crashCallStacksChannel;

--- a/Extension/src/logger.ts
+++ b/Extension/src/logger.ts
@@ -102,7 +102,7 @@ export function getDiagnosticsChannel(): vscode.OutputChannel {
 export function getCrashCallStacksChannel(): vscode.OutputChannel {
     if (!crashCallStacksChannel) {
         crashCallStacksChannel = vscode.window.createOutputChannel(localize("c.cpp.crash.call.stacks.title", "C/C++ Crash Call Stacks"));
-        crashCallStacksChannel.appendLine(localize({ key: "c.cpp.crash.call.stacks.description", comment: [ "{0} is a URL."]},
+        crashCallStacksChannel.appendLine(localize({ key: "c.cpp.crash.call.stacks.description", comment: ["{0} is a URL."] },
             "A C/C++ extension process has crashed. The crashing process name, date/time, signal, and call stack are below -- it would be helpful to include that in a C/C++ extension bug report at {0}.",
             "https://github.com/Microsoft/vscode-cpptools/issues"));
     }

--- a/Extension/src/logger.ts
+++ b/Extension/src/logger.ts
@@ -74,6 +74,7 @@ export class Logger {
 
 export let outputChannel: vscode.OutputChannel | undefined;
 export let diagnosticsChannel: vscode.OutputChannel | undefined;
+export let crashCallStacksChannel: vscode.OutputChannel | undefined;
 export let debugChannel: vscode.OutputChannel | undefined;
 export let warningChannel: vscode.OutputChannel | undefined;
 export let sshChannel: vscode.OutputChannel | undefined;
@@ -96,6 +97,15 @@ export function getDiagnosticsChannel(): vscode.OutputChannel {
         diagnosticsChannel = vscode.window.createOutputChannel(localize("c.cpp.diagnostics", "C/C++ Diagnostics"));
     }
     return diagnosticsChannel;
+}
+
+export function getCrashCallStacksChannel(): vscode.OutputChannel {
+    if (!crashCallStacksChannel) {
+        crashCallStacksChannel = vscode.window.createOutputChannel(localize("c.cpp.crash.call.stacks.title", "C/C++ Crash Call Stacks"));
+        crashCallStacksChannel.appendLine(localize("c.cpp.crash.call.stacks.description",
+            "The information below could be helpful to provide in a C/C++ extension bug report:"));
+    }
+    return crashCallStacksChannel;
 }
 
 export function getSshChannel(): vscode.OutputChannel {


### PR DESCRIPTION
1. Avoid logging duplicates for repeated crashes in a row.
2. Only log if the loggingLevel is >= 1 (not None).
3. Print the call stack info to the C/C++ Crash Call Stacks output pane with a URL to report a bug.
4. Add the original crash date/time.
5. Stop truncating the printed logging to 8k characters.