### PR TITLE
Updates for 1.20.4 (#12273)

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.20.4: March 2, 2024
+### Bug Fixes
+* Fix a couple crashes.
+
 ## Version 1.20.3: April 30, 2024
 ### Enhancement
 * Log `cpptools` and `cpptool-srv` crash call stacks in the 'C/C++ Crash Call Stacks' Output channel for bug reporting (on x64 Linux and x64/arm64 Mac).

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.20.3-main",
+    "version": "1.20.4-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -962,7 +962,19 @@ function reportMacCrashes(): void {
 }
 
 export function usesCrashHandler(): boolean {
-    return process.platform !== "win32" && (process.platform === "darwin" || os.arch() === "x64");
+    if (os.platform() === "darwin") {
+        if (os.arch() === "arm64") {
+            return true;
+        } else {
+            const releaseParts: string[] = os.release().split(".");
+            if (releaseParts.length >= 1) {
+                // Avoid potentially intereferring with the older macOS crash handler.
+                return parseInt(releaseParts[0]) < 19;
+            }
+            return true;
+        }
+    }
+    return os.platform() !== "win32" && os.arch() === "x64";
 }
 
 export function watchForCrashes(crashDirectory: string): void {


### PR DESCRIPTION
* Don't use the crash handler on macOS < 19.
* Update version and changelog.