### PR TITLE
Add @see and @sa Doxygen Tags with the "See Also:" label.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1577,6 +1577,8 @@
                                 "result",
                                 "returns",
                                 "retval",
+                                "sa",
+                                "see",
                                 "since",
                                 "tparam",
                                 "test",

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -214,7 +214,7 @@
         "text": "Returns:",
         "hint": "This label is for the return value description for a function. Usage example: 'Returns: Area of a shape.'"
     },
-    "sa_label": "See Also:",
+    "sa_label": "See also:",
     "since_label": "Since:",
     "template_parameters_label": "Template Parameters:",
     "test_label": "Test:",

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -214,6 +214,8 @@
         "text": "Returns:",
         "hint": "This label is for the return value description for a function. Usage example: 'Returns: Area of a shape.'"
     },
+    "sa_label": "See Also:",
+    "see_label": "See Also:",
     "since_label": "Since:",
     "template_parameters_label": "Template Parameters:",
     "test_label": "Test:",

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -215,7 +215,6 @@
         "hint": "This label is for the return value description for a function. Usage example: 'Returns: Area of a shape.'"
     },
     "sa_label": "See Also:",
-    "see_label": "See Also:",
     "since_label": "Since:",
     "template_parameters_label": "Template Parameters:",
     "test_label": "Test:",


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12384

The goal of this PR is to add additional section tags that will appear in the hover tooltip for Doxygen comments. Now users can use the @see and @sa doxygen tags in their code.

According the Doxygen documentation (https://www.doxygen.nl/manual/commands.html#cmdsa): "sa" is short for "See Also:" and is meant to cross reference other functions in the code. An example of this could be the following:

```cpp
/**
 * @brief Adds two integers.
 *
 * This function takes two integers as parameters and returns their sum.
 *
 * @param a First integer
 * @param b Second integer
 * @pre Sum of the integers
 * @sa subtract()
 */
int add(int a, int b) {
    return a + b;
}
```

Where \sa is referring to the subtract() function and puts it in context of the add function (see below):
![image](https://github.com/microsoft/vscode-cpptools/assets/111317156/9643819c-ab32-4c93-83ec-e7e23c2ec3d6)
