### PR TITLE
Strip '\r' from the end of each line when parsing the vcpkg database

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -109,7 +109,7 @@ async function lookupIncludeInVcpkg(document: vscode.TextDocument, line: number)
     if (!matches || !matches.length || !matches.groups) {
         return [];
     }
-    const missingHeader: string = matches.groups.includeFile.replace(/[\\\/]/g, '\\');
+    const missingHeader: string = matches.groups.includeFile.replace(/\//g, '\\');
 
     let portsWithHeader: string[] | undefined;
     const vcpkgDb: VcpkgDatabase = await vcpkgDbPromise;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -113,7 +113,6 @@ async function lookupIncludeInVcpkg(document: vscode.TextDocument, line: number)
 
     let portsWithHeader: string[] | undefined;
     const vcpkgDb: VcpkgDatabase = await vcpkgDbPromise;
-    console.log("vcpkgDb: " + JSON.stringify(vcpkgDb));
     if (vcpkgDb) {
         portsWithHeader = vcpkgDb[missingHeader];
     }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -58,7 +58,6 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
         const zip = new StreamZip.async({ file: util.getExtensionFilePath('VCPkgHeadersDatabase.zip') });
         try {
             const data = await zip.entryData('VCPkgHeadersDatabase.txt');
-            // Strip '\r' and '\n' from the end of each line if they exist.
             const lines = data.toString().split('\n');
             lines.forEach(line => {
                 const portFilePair: string[] = line.split(':');

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -59,10 +59,7 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
         try {
             const data = await zip.entryData('VCPkgHeadersDatabase.txt');
             // Strip '\r' and '\n' from the end of each line if they exist.
-            let lines = data.toString().split('\r\n');
-            if (lines.length === 1) {
-                lines = data.toString().split('\n');
-            }
+            let lines = data.toString().split('\n');
             lines.forEach(line => {
                 const portFilePair: string[] = line.split(':');
                 if (portFilePair.length !== 2) {
@@ -70,11 +67,12 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
                 }
 
                 const portName: string = portFilePair[0];
-                const relativeHeader: string = portFilePair[1];
+                const relativeHeader: string = portFilePair[1].trimEnd();
 
                 if (!database[relativeHeader]) {
                     database[relativeHeader] = [];
                 }
+                
                 database[relativeHeader].push(portName);
             });
         } catch {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -59,7 +59,7 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
         try {
             const data = await zip.entryData('VCPkgHeadersDatabase.txt');
             // Strip '\r' and '\n' from the end of each line if they exist.
-            let lines = data.toString().split('\n');
+            const lines = data.toString().split('\n');
             lines.forEach(line => {
                 const portFilePair: string[] = line.split(':');
                 if (portFilePair.length !== 2) {
@@ -72,7 +72,7 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
                 if (!database[relativeHeader]) {
                     database[relativeHeader] = [];
                 }
-                
+
                 database[relativeHeader].push(portName);
             });
         } catch {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -61,7 +61,7 @@ async function initVcpkgDatabase(): Promise<VcpkgDatabase> {
             // Strip '\r' and '\n' from the end of each line if they exist.
             let lines = data.toString().split('\r\n');
             if (lines.length === 1) {
-                lines =  data.toString().split('\n');
+                lines = data.toString().split('\n');
             }
             lines.forEach(line => {
                 const portFilePair: string[] = line.split(':');


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12413

We were incorrectly parsing our vcpkg header database when deciding to present the "Learn how to install a library for this header with vcpkg" code action.

The issue was due to not stripping the "\r" line endings that appear exclusively on Windows machines.

This fix will now strip the "\r\n" line endings on windows properly and if will only strip "\n" for linux/mac machines.

It should now display the following behavior on windows (see below):
![Screenshot 2024-06-26 125711](https://github.com/microsoft/vscode-cpptools/assets/111317156/2c01b8b2-743b-48a5-bf88-a69e0abd7e23)
