### PR TITLE
Experimental features improvements.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3264,10 +3264,11 @@
                     "C_Cpp.experimentalFeatures": {
                         "type": "string",
                         "enum": [
+                            "default",
                             "enabled",
                             "disabled"
                         ],
-                        "default": "disabled",
+                        "default": "default",
                         "description": "%c_cpp.configuration.experimentalFeatures.description%",
                         "scope": "window"
                     },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -738,7 +738,7 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
-    "c_cpp.configuration.experimentalFeatures.description": "Controls whether \"experimental\" features are usable.",
+    "c_cpp.configuration.experimentalFeatures.description": "Controls whether \"experimental\" features are enabled, disabled, or enabled for a certain percentage of users (the default).",
     "c_cpp.configuration.suggestSnippets.markdownDescription": {
         "message": "If `true`, snippets are provided by the language server.",
         "comment": [

--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -3,7 +3,6 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { isExperimentEnabled } from '../../telemetry';
 import { DefaultClient, GetSymbolInfoRequest, LocalizeSymbolInformation, SymbolScope, WorkspaceSymbolParams } from '../client';
 import { getLocalizedString, getLocalizedSymbolScope } from '../localization';
 import { makeVscodeLocation } from '../utils';
@@ -21,8 +20,7 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
         }
 
         const params: WorkspaceSymbolParams = {
-            query: query,
-            experimentEnabled: await isExperimentEnabled('CppTools1')
+            query: query
         };
 
         const symbols: LocalizeSymbolInformation[] = await this.client.languageClient.sendRequest(GetSymbolInfoRequest, params, token);

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1461,7 +1461,7 @@ export class DefaultClient implements Client {
             workspaceSymbols: workspaceSettings.workspaceSymbols,
             simplifyStructuredComments: workspaceSettings.simplifyStructuredComments,
             intelliSenseUpdateDelay: workspaceSettings.intelliSenseUpdateDelay,
-            experimentalFeatures: await telemetry.isExperimentEnabled("CppTools2"),
+            experimentalFeatures: await telemetry.isExperimentEnabled("CppTools1"),
             enhancedColorization: workspaceSettings.enhancedColorization,
             intellisenseMaxCachedProcesses: workspaceSettings.intelliSenseMaxCachedProcesses,
             intellisenseMaxMemory: workspaceSettings.intelliSenseMaxMemory,

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1203,7 +1203,7 @@ export class DefaultClient implements Client {
 
         try {
             let isFirstClient: boolean = false;
-            if (firstClientStarted == undefined || languageClientCrashedNeedsRestart) {
+            if (firstClientStarted === undefined || languageClientCrashedNeedsRestart) {
                 if (languageClientCrashedNeedsRestart) {
                     languageClientCrashedNeedsRestart = false;
                     // if we're recovering, the isStarted needs to be reset.

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -353,7 +353,7 @@ export class CppSettings extends Settings {
     public get clangFormatStyle(): string | undefined { return changeBlankStringToUndefined(super.Section.get<string>("clang_format_style")); }
     public get clangFormatFallbackStyle(): string | undefined { return changeBlankStringToUndefined(super.Section.get<string>("clang_format_fallbackStyle")); }
     public get clangFormatSortIncludes(): boolean | undefined | null { return super.Section.get<boolean | null>("clang_format_sortIncludes"); }
-    public get experimentalFeatures(): boolean | undefined { return super.Section.get<string>("experimentalFeatures")?.toLowerCase() === "enabled"; }
+    public get experimentalFeatures(): string | undefined { return super.Section.get<string>("experimentalFeatures")?.toLowerCase(); }
     public get suggestSnippets(): boolean | undefined { return super.Section.get<boolean>("suggestSnippets"); }
     public get intelliSenseEngine(): string | undefined { return super.Section.get<string>("intelliSenseEngine")?.toLowerCase(); }
     public get intelliSenseEngineFallback(): boolean | undefined { return super.Section.get<string>("intelliSenseEngineFallback")?.toLowerCase() === "enabled"; }

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -80,8 +80,11 @@ export function getExperimentationService(): Promise<IExperimentationService> | 
 }
 
 export async function isExperimentEnabled(experimentName: string): Promise<boolean> {
-    if (new CppSettings().experimentalFeatures) {
+    const experimentEnabled: string | undefined = new CppSettings().experimentalFeatures;
+    if (experimentEnabled == "enabled") {
         return true;
+    } else if (experimentEnabled == "disabled") {
+        return false;
     }
     const experimentationService: IExperimentationService | undefined = await getExperimentationService();
     const isEnabled: boolean | undefined = experimentationService?.getTreatmentVariable<boolean>("vscode", experimentName);

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -81,9 +81,9 @@ export function getExperimentationService(): Promise<IExperimentationService> | 
 
 export async function isExperimentEnabled(experimentName: string): Promise<boolean> {
     const experimentEnabled: string | undefined = new CppSettings().experimentalFeatures;
-    if (experimentEnabled == "enabled") {
+    if (experimentEnabled === "enabled") {
         return true;
-    } else if (experimentEnabled == "disabled") {
+    } else if (experimentEnabled === "disabled") {
         return false;
     }
     const experimentationService: IExperimentationService | undefined = await getExperimentationService();


### PR DESCRIPTION
* Fixes/implements https://github.com/microsoft/vscode-cpptools/issues/12448 .
* Add support for making experimentalFeatures "disabled" work, adding a new "default" setting to behave how the previous "disabled" setting worked.
* Stop sending the experimental setting with workspace symbols, since it's needed earlier on.