### PR TITLE
Fix multiple cpptools processes running with a multiroot workspace.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1204,7 +1204,7 @@ export class DefaultClient implements Client {
 
         try {
             let isFirstClient: boolean = false;
-            if (!languageClient || languageClientCrashedNeedsRestart) {
+            if (firstClientStarted === undefined || languageClientCrashedNeedsRestart) {
                 if (languageClientCrashedNeedsRestart) {
                     languageClientCrashedNeedsRestart = false;
                     // if we're recovering, the isStarted needs to be reset.


### PR DESCRIPTION
With a multi-root workspace, there's a race condition which can cause multiple cpptools processes to be started (which isn't supposed to happen and can cause other problems/bugs).
