### PR TITLE
Strip quotes from debug configurations and fix an issue with quotes in paths

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -1162,16 +1162,16 @@ abstract class DefaultConfigurationProvider implements IConfigurationAssetProvid
 
 class WindowsConfigurationProvider extends DefaultConfigurationProvider {
     private executable: string = "a.exe";
-    private pipeProgram: string = "<" + localize("path.to.pipe.program", "full path to pipe program such as {0}", "plink.exe").replace(/"/g, '\\"') + ">";
+    private pipeProgram: string = "<" + localize("path.to.pipe.program", "full path to pipe program such as {0}", "plink.exe").replace(/"/g, '') + ">";
     private MIMode: string = 'gdb';
     private setupCommandsBlock: string = `"setupCommands": [
     {
-        "description": "${localize("enable.pretty.printing", "Enable pretty-printing for {0}", "gdb").replace(/"/g, '\\"')}",
+        "description": "${localize("enable.pretty.printing", "Enable pretty-printing for {0}", "gdb").replace(/"/g, '')}",
         "text": "-enable-pretty-printing",
         "ignoreFailures": true
     },
     {
-        "description": "${localize("enable.intel.disassembly.flavor", "Set Disassembly Flavor to {0}", "Intel").replace(/"/g, '\\"')}",
+        "description": "${localize("enable.intel.disassembly.flavor", "Set Disassembly Flavor to {0}", "Intel").replace(/"/g, '')}",
         "text": "-gdb-set disassembly-flavor intel",
         "ignoreFailures": true
     }
@@ -1205,12 +1205,12 @@ class LinuxConfigurationProvider extends DefaultConfigurationProvider {
     private MIMode: string = 'gdb';
     private setupCommandsBlock: string = `"setupCommands": [
     {
-        "description": "${localize("enable.pretty.printing", "Enable pretty-printing for {0}", "gdb").replace(/"/g, '\\"')}",
+        "description": "${localize("enable.pretty.printing", "Enable pretty-printing for {0}", "gdb").replace(/"/g, '')}",
         "text": "-enable-pretty-printing",
         "ignoreFailures": true
     },
     {
-        "description": "${localize("enable.intel.disassembly.flavor", "Set Disassembly Flavor to {0}", "Intel").replace(/"/g, '\\"')}",
+        "description": "${localize("enable.intel.disassembly.flavor", "Set Disassembly Flavor to {0}", "Intel").replace(/"/g, '')}",
         "text": "-gdb-set disassembly-flavor intel",
         "ignoreFailures": true
     }

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -92,7 +92,7 @@ function createLaunchString(name: string, type: string, executable: string): str
     return `"name": "${name}",
 "type": "${type}",
 "request": "launch",
-"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '\\"')}",
+"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '')}",
 "args": [],
 "stopAtEntry": false,
 "cwd": "$\{fileDirname\}",
@@ -106,7 +106,7 @@ function createAttachString(name: string, type: string, executable: string): str
 "name": "${name}",
 "type": "${type}",
 "request": "attach",{0}
-`, [type === "cppdbg" ? `${os.EOL}"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '\\"')}",` : ""]);
+`, [type === "cppdbg" ? `${os.EOL}"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '')}",` : ""]);
 }
 
 function createRemoteAttachString(name: string, type: string, executable: string): string {
@@ -114,7 +114,7 @@ function createRemoteAttachString(name: string, type: string, executable: string
 "name": "${name}",
 "type": "${type}",
 "request": "attach",
-"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '\\"')}",
+"program": "${localize("enter.program.name", "enter program name, for example {0}", "$\{workspaceFolder\}" + "/" + executable).replace(/"/g, '')}",
 "processId": "$\{command:pickRemoteProcess\}"
 `;
 }
@@ -158,7 +158,7 @@ abstract class Configuration implements IConfiguration {
 export class MIConfigurations extends Configuration {
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("launch.string", "Launch").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("launch.string", "Launch").replace(/"/g, '')}`;
 
         const body: string = formatString(`{
 \t${indentJsonString(createLaunchString(name, this.miDebugger, this.executable))},
@@ -168,7 +168,7 @@ export class MIConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("launch.with", "Launch with {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("launch.with", "Launch with {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "isInitialConfiguration": true,
             "debuggerType": DebuggerType.cppdbg
@@ -176,7 +176,7 @@ export class MIConfigurations extends Configuration {
     }
 
     public GetAttachConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("attach.string", "Attach").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("attach.string", "Attach").replace(/"/g, '')}`;
 
         const body: string = formatString(`{
 \t${indentJsonString(createAttachString(name, this.miDebugger, this.executable))}
@@ -186,7 +186,7 @@ export class MIConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("attach.with", "Attach with {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("attach.with", "Attach with {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppdbg
         };
@@ -197,7 +197,7 @@ export class MIConfigurations extends Configuration {
 export class PipeTransportConfigurations extends Configuration {
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("pipe.launch", "Pipe Launch").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("pipe.launch", "Pipe Launch").replace(/"/g, '')}`;
 
         const body: string = formatString(`
 {
@@ -208,7 +208,7 @@ export class PipeTransportConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("pipe.launch.with", "Pipe Launch with {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("pipe.launch.with", "Pipe Launch with {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppdbg
         };
@@ -216,7 +216,7 @@ export class PipeTransportConfigurations extends Configuration {
     }
 
     public GetAttachConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("pipe.attach", "Pipe Attach").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("pipe.attach", "Pipe Attach").replace(/"/g, '')}`;
 
         const body: string = formatString(`
 {
@@ -226,7 +226,7 @@ export class PipeTransportConfigurations extends Configuration {
 }`, [this.additionalProperties ? `,${os.EOL}\t${indentJsonString(this.additionalProperties)}` : ""]);
         return {
             "label": configPrefix + name,
-            "description": localize("pipe.attach.with", "Pipe Attach with {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("pipe.attach.with", "Pipe Attach with {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppdbg
         };
@@ -237,7 +237,7 @@ export class PipeTransportConfigurations extends Configuration {
 export class WindowsConfigurations extends Configuration {
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
-        const name: string = `(Windows) ${localize("launch.string", "Launch").replace(/"/g, '\\"')}`;
+        const name: string = `(Windows) ${localize("launch.string", "Launch").replace(/"/g, '')}`;
 
         const body: string = `
 {
@@ -246,7 +246,7 @@ export class WindowsConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("launch.with.vs.debugger", "Launch with the Visual Studio C/C++ debugger.").replace(/"/g, '\\"'),
+            "description": localize("launch.with.vs.debugger", "Launch with the Visual Studio C/C++ debugger.").replace(/"/g, ''),
             "bodyText": body.trim(),
             "isInitialConfiguration": true,
             "debuggerType": DebuggerType.cppvsdbg
@@ -255,7 +255,7 @@ export class WindowsConfigurations extends Configuration {
     }
 
     public GetAttachConfiguration(): IConfigurationSnippet {
-        const name: string = `(Windows) ${localize("attach.string", "Attach").replace(/"/g, '\\"')}`;
+        const name: string = `(Windows) ${localize("attach.string", "Attach").replace(/"/g, '')}`;
 
         const body: string = `
 {
@@ -264,7 +264,7 @@ export class WindowsConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("attach.with.vs.debugger", "Attach to a process with the Visual Studio C/C++ debugger.").replace(/"/g, '\\"'),
+            "description": localize("attach.with.vs.debugger", "Attach to a process with the Visual Studio C/C++ debugger.").replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppvsdbg
         };
@@ -277,7 +277,7 @@ export class WSLConfigurations extends Configuration {
     public bashPipeProgram = process.arch === 'ia32' ? "${env:windir}\\\\sysnative\\\\bash.exe" : "${env:windir}\\\\system32\\\\bash.exe";
 
     public GetLaunchConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("bash.on.windows.launch", "Bash on Windows Launch").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("bash.on.windows.launch", "Bash on Windows Launch").replace(/"/g, '')}`;
 
         const body: string = formatString(`
 {
@@ -287,14 +287,14 @@ export class WSLConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("launch.bash.windows", "Launch in Bash on Windows using {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("launch.bash.windows", "Launch in Bash on Windows using {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppdbg
         };
     }
 
     public GetAttachConfiguration(): IConfigurationSnippet {
-        const name: string = `(${this.MIMode}) ${localize("bash.on.windows.attach", "Bash on Windows Attach").replace(/"/g, '\\"')}`;
+        const name: string = `(${this.MIMode}) ${localize("bash.on.windows.attach", "Bash on Windows Attach").replace(/"/g, '')}`;
 
         const body: string = formatString(`
 {
@@ -304,7 +304,7 @@ export class WSLConfigurations extends Configuration {
 
         return {
             "label": configPrefix + name,
-            "description": localize("remote.attach.bash.windows", "Attach to a remote process running in Bash on Windows using {0}.", this.MIMode).replace(/"/g, '\\"'),
+            "description": localize("remote.attach.bash.windows", "Attach to a remote process running in Bash on Windows using {0}.", this.MIMode).replace(/"/g, ''),
             "bodyText": body.trim(),
             "debuggerType": DebuggerType.cppdbg
         };

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -2006,6 +2006,7 @@ export class CppProperties {
             }
 
             // Escape the path string for literal use in a regular expression
+            // Need to escape any quotes to match the original text
             let escapedPath: string = curPath.replace(/"/g, '\\"');
             escapedPath = escapedPath.replace(/[-\"\/\\^$*+?.()|[\]{}]/g, '\\$&');
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1539,10 +1539,18 @@ export class CppProperties {
         }
 
         if (assumeRelative) {
+            let quoted = false;
+            if (result.startsWith('"') && result.endsWith('"')) {
+                quoted = true;
+                result = result.slice(1, -1);
+            }
             // Make sure all paths result to an absolute path.
             // Do not add the root path to an unresolved env variable.
             if (!result.includes("env:") && !path.isAbsolute(result) && this.rootUri) {
                 result = path.join(this.rootUri.fsPath, result);
+            }
+            if (quoted) {
+                result = `"${result}"`;
             }
         }
 
@@ -1998,7 +2006,6 @@ export class CppProperties {
             }
 
             // Escape the path string for literal use in a regular expression
-            // Need to escape any quotes to match the original text
             let escapedPath: string = curPath.replace(/"/g, '\\"');
             escapedPath = escapedPath.replace(/[-\"\/\\^$*+?.()|[\]{}]/g, '\\$&');
 


### PR DESCRIPTION
This should address a few CodeQL issues flagged in the repo. There was some code added to escape any double quotes that might be added from the generated debug configurations during the localization process. Since we don't really want those double quotes anyway, it should be acceptable to simply remove them.

While looking at some of the other issues flagged, I noticed that a helper function ends up thinking a quoted path is a relative path. Fixing that doesn't fix any other underlying assumptions we make about the include paths set by the user, but it does allow them to be squiggled when the true path is invalid.