### PR TITLE
Refactor compilerPath logic to reflect settings validation changes

### DIFF
--- a/Extension/c_cpp_properties.schema.json
+++ b/Extension/c_cpp_properties.schema.json
@@ -18,7 +18,10 @@
                     "compilerPath": {
                         "markdownDescription": "Full path of the compiler being used, e.g. `/usr/bin/gcc`, to enable more accurate IntelliSense.",
                         "descriptionHint": "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered.",
-                        "type": "string"
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
                     "compilerArgs": {
                         "markdownDescription": "Compiler arguments to modify the includes or defines used, e.g. `-nostdinc++`, `-m32`, etc. Arguments that take additional space-delimited arguments should be entered as separate arguments in the array, e.g. for `--sysroot <arg>` use `\"--sysroot\", \"<arg>\"`.",

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3052,7 +3052,7 @@ export class DefaultClient implements Client {
                         providerVersion < Version.v6,
                         itemConfig.compilerPath,
                         util.isArrayOfString(itemConfig.compilerArgs) ? itemConfig.compilerArgs : undefined);
-                    itemConfig.compilerPath = compilerPathAndArgs.compilerPath;
+                    itemConfig.compilerPath = compilerPathAndArgs.compilerPath ?? undefined;
                     if (itemConfig.compilerPath !== undefined) {
                         void this.addTrustedCompiler(itemConfig.compilerPath).catch(logAndReturn.undefined);
                     }
@@ -3156,7 +3156,7 @@ export class DefaultClient implements Client {
                     providerVersion < Version.v6,
                     sanitized.compilerPath,
                     util.isArrayOfString(sanitized.compilerArgs) ? sanitized.compilerArgs : undefined);
-                sanitized.compilerPath = compilerPathAndArgs.compilerPath;
+                sanitized.compilerPath = compilerPathAndArgs.compilerPath ?? undefined;
                 if (sanitized.compilerPath !== undefined) {
                     void this.addTrustedCompiler(sanitized.compilerPath).catch(logAndReturn.undefined);
                 }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -995,8 +995,6 @@ export class CppProperties {
                 if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
-                } else {
-                    configuration.compilerPathIsExplicit = false;
                 }
             }
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -992,7 +992,7 @@ export class CppProperties {
                 }
                 if (configuration.compilerPath === null) {
                     configuration.compilerPathIsExplicit = true;
-                } else if (configuration.compilerPath !== undefined ) {
+                } else if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
                 } else {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -989,12 +989,15 @@ export class CppProperties {
                 // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
                 if (configuration.compilerPath === "${default}") {
                     configuration.compilerPath = settings.defaultCompilerPath ?? undefined;
-                    configuration.compilerPathIsExplicit = settings.defaultCompilerPath === null && configuration.compilerPath === undefined;
                 }
 
                 if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
+                } else if (settings.defaultCompilerPath === null) {
+                    configuration.compilerPathIsExplicit = true;
+                } else {
+                    configuration.compilerPathIsExplicit = false;
                 }
             }
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1566,10 +1566,10 @@ export class CppProperties {
 
         // Check if config name is unique.
         errors.name = this.isConfigNameUnique(config.name);
-        let resolvedCompilerPath: string | undefined;
+        let resolvedCompilerPath: string | undefined | null;
         // Validate compilerPath
         if (config.compilerPath) {
-            resolvedCompilerPath = which.sync(config.compilerPath, { nothrow: true }) ?? undefined;
+            resolvedCompilerPath = which.sync(config.compilerPath, { nothrow: true });
         }
 
         if (resolvedCompilerPath === undefined) {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -988,12 +988,11 @@ export class CppProperties {
             } else {
                 // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
                 if (configuration.compilerPath === "${default}") {
-                    configuration.compilerPath = settings.defaultCompilerPath ?? undefined;
+                    configuration.compilerPath = settings.defaultCompilerPath;
                 }
                 if (configuration.compilerPath === null) {
-                    configuration.compilerPath = undefined;
                     configuration.compilerPathIsExplicit = true;
-                } else if (configuration.compilerPath !== undefined) {
+                } else if (configuration.compilerPath !== undefined ) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
                 } else {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -989,11 +989,10 @@ export class CppProperties {
                 // However, if compileCommands are used and compilerPath is explicitly set, it's still necessary to resolve variables in it.
                 if (configuration.compilerPath === "${default}") {
                     configuration.compilerPath = settings.defaultCompilerPath ?? undefined;
+                    configuration.compilerPathIsExplicit = settings.defaultCompilerPath === null && configuration.compilerPath === undefined;
                 }
-                if (configuration.compilerPath === null) {
-                    configuration.compilerPath = undefined;
-                    configuration.compilerPathIsExplicit = true;
-                } else if (configuration.compilerPath !== undefined) {
+
+                if (configuration.compilerPath !== undefined) {
                     configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
                 } else {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -62,8 +62,8 @@ export interface ConfigurationJson {
 
 export interface Configuration {
     name: string;
-    compilerPathInCppPropertiesJson?: string;
-    compilerPath?: string;
+    compilerPathInCppPropertiesJson?: string | null;
+    compilerPath?: string | null;
     compilerPathIsExplicit?: boolean;
     compilerArgs?: string[];
     compilerArgsLegacy?: string[];
@@ -990,11 +990,11 @@ export class CppProperties {
                 if (configuration.compilerPath === "${default}") {
                     configuration.compilerPath = settings.defaultCompilerPath ?? undefined;
                 }
-
-                if (configuration.compilerPath !== undefined) {
-                    configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
+                if (configuration.compilerPath === null) {
+                    configuration.compilerPath = undefined;
                     configuration.compilerPathIsExplicit = true;
-                } else if (settings.defaultCompilerPath === null) {
+                } else if (configuration.compilerPath !== undefined) {
+                    configuration.compilerPath = util.resolveVariables(configuration.compilerPath, env);
                     configuration.compilerPathIsExplicit = true;
                 } else {
                     configuration.compilerPathIsExplicit = false;
@@ -1516,7 +1516,7 @@ export class CppProperties {
         return success;
     }
 
-    private resolvePath(input_path: string | undefined, replaceAsterisks: boolean = true, assumeRelative: boolean = true): string {
+    private resolvePath(input_path: string | undefined | null, replaceAsterisks: boolean = true, assumeRelative: boolean = true): string {
         if (!input_path || input_path === "${default}") {
             return "";
         }
@@ -1590,6 +1590,7 @@ export class CppProperties {
                 (compilerPathAndArgs.compilerArgsFromCommandLineInPath && compilerPathAndArgs.compilerArgsFromCommandLineInPath.length > 0) &&
                 !resolvedCompilerPath.startsWith('"') &&
                 compilerPathAndArgs.compilerPath !== undefined &&
+                compilerPathAndArgs.compilerPath !== null &&
                 compilerPathAndArgs.compilerPath.includes(" ");
 
             const compilerPathErrors: string[] = [];
@@ -1598,7 +1599,7 @@ export class CppProperties {
             }
 
             // Get compiler path without arguments before checking if it exists
-            resolvedCompilerPath = compilerPathAndArgs.compilerPath;
+            resolvedCompilerPath = compilerPathAndArgs.compilerPath ?? undefined;
             if (resolvedCompilerPath) {
                 let pathExists: boolean = true;
                 const existsWithExeAdded: (path: string) => boolean = (path: string) => isWindows && !path.startsWith("/") && fs.existsSync(path + ".exe");

--- a/Extension/src/LanguageServer/cppBuildTaskProvider.ts
+++ b/Extension/src/LanguageServer/cppBuildTaskProvider.ts
@@ -98,7 +98,7 @@ export class CppBuildTaskProvider implements TaskProvider {
 
         // Get user compiler path.
         const userCompilerPathAndArgs: util.CompilerPathAndArgs | undefined = await activeClient.getCurrentCompilerPathAndArgs();
-        let userCompilerPath: string | undefined;
+        let userCompilerPath: string | undefined | null;
         if (userCompilerPathAndArgs) {
             userCompilerPath = userCompilerPathAndArgs.compilerPath;
             if (userCompilerPath && userCompilerPathAndArgs.compilerName) {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1095,15 +1095,15 @@ export function isCl(compilerPath: string): boolean {
 
 /** CompilerPathAndArgs retains original casing of text input for compiler path and args */
 export interface CompilerPathAndArgs {
-    compilerPath?: string;
+    compilerPath?: string | null;
     compilerName: string;
     compilerArgs?: string[];
     compilerArgsFromCommandLineInPath: string[];
     allCompilerArgs: string[];
 }
 
-export function extractCompilerPathAndArgs(useLegacyBehavior: boolean, inputCompilerPath?: string, compilerArgs?: string[]): CompilerPathAndArgs {
-    let compilerPath: string | undefined = inputCompilerPath;
+export function extractCompilerPathAndArgs(useLegacyBehavior: boolean, inputCompilerPath?: string | null, compilerArgs?: string[]): CompilerPathAndArgs {
+    let compilerPath: string | undefined | null = inputCompilerPath;
     let compilerName: string = "";
     let compilerArgsFromCommandLineInPath: string[] = [];
     if (compilerPath) {


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12555

Previously, default.compilerPath returned string | undefined when it was possible to return a null value in package.json. Now that it is returning null, the compilerPath logic needs to be updated to reflect this. 
