### PR TITLE
Add C++ configuration as a language model tool

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6464,9 +6464,9 @@
             {
                 "id": "cpptools-lmtool-configuration",
                 "name": "cpp",
-                "displayName": "C/C++ configuration",
+                "displayName": "%c_cpp.languageModelTools.configuration.displayName%",
                 "canBeInvokedManually": true,
-                "userDescription": "Configuration of the active C or C++ file, like language standard version and target platform.",
+                "userDescription": "%c_cpp.languageModelTools.configuration.userDescription%",
                 "modelDescription": "For the active C or C++ file, this tool provides: the language (C, C++, or CUDA), the language standard version (such as C++11, C++14, C++17, or C++20), the compiler (such as GCC, Clang, or MSVC), the target platform (such as x86, x64, or ARM), and the target architecture (such as 32-bit or 64-bit).",
                 "icon": "$(file-code)",
                 "parametersSchema": {}

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -38,7 +38,9 @@
         "Snippets"
     ],
     "enabledApiProposals": [
-        "terminalDataWriteEvent"
+        "terminalDataWriteEvent",
+        "chatParticipant",
+        "chatVariableResolver"
     ],
     "capabilities": {
         "untrustedWorkspaces": {

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -39,8 +39,7 @@
     ],
     "enabledApiProposals": [
         "terminalDataWriteEvent",
-        "chatParticipant",
-        "chatVariableResolver"
+        "lmTools"
     ],
     "capabilities": {
         "untrustedWorkspaces": {
@@ -6459,6 +6458,18 @@
                     "title": "%c_cpp.codeActions.refactor.extract.function.title%",
                     "description": "%c_cpp.codeActions.refactor.extract.function.description%"
                 }
+            }
+        ],
+        "languageModelTools": [
+            {
+                "id": "cpptools-lmtool-configuration",
+                "name": "cpp",
+                "displayName": "C/C++ configuration",
+                "canBeInvokedManually": true,
+                "userDescription": "Configuration of the active C or C++ file, like language standard version and target platform.",
+                "modelDescription": "For the active C or C++ file, this tool provides: the language (C, C++, or CUDA), the language standard version (such as C++11, C++14, C++17, or C++20), the compiler (such as GCC, Clang, or MSVC), the target platform (such as x86, x64, or ARM), and the target architecture (such as 32-bit or 64-bit).",
+                "icon": "$(file-code)",
+                "parametersSchema": {}
             }
         ]
     },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -1013,5 +1013,7 @@
     "c_cpp.configuration.refactoring.includeHeader.markdownDescription": "Controls whether to include the header file of a refactored function/symbol to its corresponding source file when doing a refactoring action, such as create declaration/definition.",
     "c_cpp.configuration.refactoring.includeHeader.always.description": "Always include the header file if it is not included explicitly in its source file.",
     "c_cpp.configuration.refactoring.includeHeader.ifNeeded.description": "Only include the header file if it is not included explicitly in its source file or through implicit inclusion.",
-    "c_cpp.configuration.refactoring.includeHeader.never.description": "Never include the header file."
+    "c_cpp.configuration.refactoring.includeHeader.never.description": "Never include the header file.",
+    "c_cpp.languageModelTools.configuration.displayName": "C/C++ configuration",
+    "c_cpp.languageModelTools.configuration.userDescription": "Configuration of the active C or C++ file, like language standard version and target platform."
 }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -541,6 +541,14 @@ interface GetIncludesResult {
     includedFiles: string[];
 }
 
+export interface ChatContextResult {
+    language: string;
+    standardVersion: string;
+    compiler: string;
+    targetPlatform: string;
+    targetArchitecture: string;
+}
+
 // Requests
 const PreInitializationRequest: RequestType<void, string, void> = new RequestType<void, string, void>('cpptools/preinitialize');
 const InitializationRequest: RequestType<CppInitializationParams, void, void> = new RequestType<CppInitializationParams, void, void>('cpptools/initialize');
@@ -560,6 +568,7 @@ const GoToDirectiveInGroupRequest: RequestType<GoToDirectiveInGroupParams, Posit
 const GenerateDoxygenCommentRequest: RequestType<GenerateDoxygenCommentParams, GenerateDoxygenCommentResult | undefined, void> = new RequestType<GenerateDoxygenCommentParams, GenerateDoxygenCommentResult, void>('cpptools/generateDoxygenComment');
 const ChangeCppPropertiesRequest: RequestType<CppPropertiesParams, void, void> = new RequestType<CppPropertiesParams, void, void>('cpptools/didChangeCppProperties');
 const IncludesRequest: RequestType<GetIncludesParams, GetIncludesResult, void> = new RequestType<GetIncludesParams, GetIncludesResult, void>('cpptools/getIncludes');
+const CppContextRequest: RequestType<void, ChatContextResult, void> = new RequestType<void, ChatContextResult, void>('cpptools/getChatContext');
 
 // Notifications to the server
 const DidOpenNotification: NotificationType<DidOpenTextDocumentParams> = new NotificationType<DidOpenTextDocumentParams>('textDocument/didOpen');
@@ -790,6 +799,7 @@ export interface Client {
     setShowConfigureIntelliSenseButton(show: boolean): void;
     addTrustedCompiler(path: string): Promise<void>;
     getIncludes(maxDepth: number): Promise<GetIncludesResult>;
+    getChatContext(): Promise<ChatContextResult | undefined>;
 }
 
 export function createClient(workspaceFolder?: vscode.WorkspaceFolder): Client {
@@ -2202,6 +2212,11 @@ export class DefaultClient implements Client {
         const params: GetIncludesParams = { maxDepth: maxDepth };
         await this.ready;
         return this.languageClient.sendRequest(IncludesRequest, params);
+    }
+
+    public async getChatContext(): Promise<ChatContextResult | undefined> {
+        await this.ready;
+        return this.languageClient.sendRequest(CppContextRequest, null);
     }
 
     /**
@@ -4084,4 +4099,5 @@ class NullClient implements Client {
     setShowConfigureIntelliSenseButton(show: boolean): void { }
     addTrustedCompiler(path: string): Promise<void> { return Promise.resolve(); }
     getIncludes(): Promise<GetIncludesResult> { return Promise.resolve({} as GetIncludesResult); }
+    getChatContext(): Promise<ChatContextResult> { return Promise.resolve({} as ChatContextResult); }
 }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -61,7 +61,7 @@ import * as refs from './references';
 import { CppSettings, OtherSettings, SettingsParams, WorkspaceFolderSettingsParams, getEditorConfigSettings } from './settings';
 import { SettingsTracker } from './settingsTracker';
 import { ConfigurationType, LanguageStatusUI, getUI } from './ui';
-import { handleChangedFromCppToC, makeLspRange, makeVscodeLocation, makeVscodeRange } from './utils';
+import { handleChangedFromCppToC, makeLspRange, makeVscodeLocation, makeVscodeRange, withCancellation } from './utils';
 import minimatch = require("minimatch");
 
 function deepCopy(obj: any) {
@@ -799,7 +799,7 @@ export interface Client {
     setShowConfigureIntelliSenseButton(show: boolean): void;
     addTrustedCompiler(path: string): Promise<void>;
     getIncludes(maxDepth: number): Promise<GetIncludesResult>;
-    getChatContext(): Promise<ChatContextResult | undefined>;
+    getChatContext(token: vscode.CancellationToken): Promise<ChatContextResult | undefined>;
 }
 
 export function createClient(workspaceFolder?: vscode.WorkspaceFolder): Client {
@@ -2214,9 +2214,17 @@ export class DefaultClient implements Client {
         return this.languageClient.sendRequest(IncludesRequest, params);
     }
 
-    public async getChatContext(): Promise<ChatContextResult | undefined> {
-        await this.ready;
-        return this.languageClient.sendRequest(CppContextRequest, null);
+    public async getChatContext(token: vscode.CancellationToken): Promise<ChatContextResult | undefined> {
+        await withCancellation(this.ready, token);
+        const result = await this.languageClient.sendRequest(CppContextRequest, null, token);
+
+        // sendRequest() won't throw on cancellation, but will return an
+        // unexpected object with an error code and message.
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        return result;
     }
 
     /**
@@ -4099,5 +4107,5 @@ class NullClient implements Client {
     setShowConfigureIntelliSenseButton(show: boolean): void { }
     addTrustedCompiler(path: string): Promise<void> { return Promise.resolve(); }
     getIncludes(): Promise<GetIncludesResult> { return Promise.resolve({} as GetIncludesResult); }
-    getChatContext(): Promise<ChatContextResult> { return Promise.resolve({} as ChatContextResult); }
+    getChatContext(token: vscode.CancellationToken): Promise<ChatContextResult> { return Promise.resolve({} as ChatContextResult); }
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -20,7 +20,7 @@ import * as util from '../common';
 import { getCrashCallStacksChannel } from '../logger';
 import { PlatformInformation } from '../platform';
 import * as telemetry from '../telemetry';
-import { Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
+import { ChatContextResult, Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
 import { ClientCollection } from './clientCollection';
 import { CodeActionDiagnosticInfo, CodeAnalysisDiagnosticIdentifiersAndUri, codeAnalysisAllFixes, codeAnalysisCodeToFixes, codeAnalysisFileToCodeActions } from './codeAnalysis';
 import { CppBuildTaskProvider } from './cppBuildTaskProvider';
@@ -248,6 +248,78 @@ export async function activate(): Promise<void> {
         clients.timeTelemetryCollector.setFirstFile(activeEditor.document.uri);
         activeDocument = activeEditor.document;
     }
+
+    await setupCppChatVariable(util.extensionContext);
+}
+
+export async function setupCppChatVariable(context: vscode.ExtensionContext | undefined): Promise<void>
+{
+    if (!context) {
+        return;
+    }
+
+    vscode.chat.registerChatVariableResolver('cpp',
+        `Describes the the C++ language features that can be used according
+ to the following information: the C++ language standard version, the target architecture and target operating system.`, {
+            resolve: async (name, _context, _token) => {
+                function fixUpLanguage(languageId: string) {
+                    const languageIdToLanguage: { [id: string]: string } =
+                    { 'c': 'C', 'cpp': 'C++', 'cuda-cpp': 'CUDA C++' };
+                    return languageIdToLanguage[languageId] || languageId;
+                }
+
+                function fixUpCompiler(compilerId: string) {
+                    const compilerIdToCompiler: { [id: string]: string } =
+                    { 'msvc': 'MSVC', 'clang': 'Clang', 'gcc': 'GCC' };
+                    return compilerIdToCompiler[compilerId] || compilerId;
+                }
+
+                function fixUpStandardVersion(stdVerId: string) {
+                    const stdVerIdToStdVer: { [id: string]: string } =
+                    { 'c++98': 'C++98', 'c++03': 'C++03', 'c++11': 'C++11', 'c++14': 'C++14', 'c++17': 'C++17',
+                        'c++20': 'C++20', 'c++23': 'C++23', 'c90' : "C90", 'c99': "C99", 'c11': "C11", 'c17': "C17",
+                        'c23': "C23" };
+                    return stdVerIdToStdVer[stdVerId] || stdVerId;
+                }
+
+                function fixTargetPlatform(targetPlatformId: string) {
+                    const platformIdToPlatform: { [id: string]: string } = { 'windows': 'Windows', 'Linux': 'Linux', 'macos': 'macOS' };
+                    return platformIdToPlatform[targetPlatformId] || targetPlatformId;
+                }
+
+                if (name !== 'cpp') {
+                    return undefined;
+                }
+
+                // Return undefined if the active document is not a C++/C/CUDA/Header file.
+                const currentDoc = vscode.window.activeTextEditor?.document;
+                if (!currentDoc || (!util.isCpp(currentDoc) && !util.isHeaderFile(currentDoc.uri))) {
+                    return undefined;
+                }
+
+                const chatContext: ChatContextResult | undefined = await getChatContext();
+                if (!chatContext) {
+                    return undefined;
+                }
+
+                telemetry.logCppChatVariableEvent('cpp',
+                    { "language": chatContext.language, "compiler": chatContext.compiler, "standardVersion": chatContext.standardVersion,
+                        "targetPlatform": chatContext.targetPlatform, "targetArchitecture": chatContext.targetArchitecture });
+
+                const language = fixUpLanguage(chatContext.language);
+                const compiler = fixUpCompiler(chatContext.compiler);
+                const standardVersion = fixUpStandardVersion(chatContext.standardVersion);
+                const targetPlatform = fixTargetPlatform(chatContext.targetPlatform);
+                const value = `I am working on a project of the following nature:
+- Using ${language}. Prefer a solution written in ${language} to any other language. Call out which language you are using in the answer.
+- Using the ${language} standard language version ${standardVersion}. Prefer solutions using the new and more recent features introduced in ${standardVersion}. Call out which standard version you are using in the answer.
+- Using the ${compiler} compiler. Prefer solutions supported by the ${compiler} compiler.
+- Targeting the ${targetPlatform} platform. Prefer solutions and API that are supported on ${targetPlatform}.
+- Targeting the ${chatContext.targetArchitecture} architecture. Prefer solutions and techniques that are supported on the ${chatContext.targetArchitecture} architecture.
+`;
+                return [ { level: vscode.ChatVariableLevel.Full, value: value } ];
+            }
+        });
 }
 
 export function updateLanguageConfigurations(): void {
@@ -1378,4 +1450,8 @@ export async function preReleaseCheck(): Promise<void> {
 export async function getIncludes(maxDepth: number): Promise<any> {
     const includes = await clients.ActiveClient.getIncludes(maxDepth);
     return includes;
+}
+
+export async function getChatContext(): Promise<ChatContextResult | undefined> {
+    return clients?.ActiveClient?.getChatContext() ?? undefined;
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -20,12 +20,13 @@ import * as util from '../common';
 import { getCrashCallStacksChannel } from '../logger';
 import { PlatformInformation } from '../platform';
 import * as telemetry from '../telemetry';
-import { ChatContextResult, Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
+import { Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
 import { ClientCollection } from './clientCollection';
 import { CodeActionDiagnosticInfo, CodeAnalysisDiagnosticIdentifiersAndUri, codeAnalysisAllFixes, codeAnalysisCodeToFixes, codeAnalysisFileToCodeActions } from './codeAnalysis';
 import { CppBuildTaskProvider } from './cppBuildTaskProvider';
 import { getCustomConfigProviders } from './customProviders';
 import { getLanguageConfig } from './languageConfig';
+import { CppConfigurationLanguageModelTool } from './lmTool';
 import { PersistentState } from './persistentState';
 import { NodeType, TreeNode } from './referencesModel';
 import { CppSettings } from './settings';
@@ -249,77 +250,10 @@ export async function activate(): Promise<void> {
         activeDocument = activeEditor.document;
     }
 
-    await setupCppChatVariable(util.extensionContext);
-}
-
-export async function setupCppChatVariable(context: vscode.ExtensionContext | undefined): Promise<void>
-{
-    if (!context) {
-        return;
+    if (util.extensionContext) {
+        const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool(clients));
+        disposables.push(tool);
     }
-
-    vscode.chat.registerChatVariableResolver('cpp',
-        `Describes the the C++ language features that can be used according
- to the following information: the C++ language standard version, the target architecture and target operating system.`, {
-            resolve: async (name, _context, _token) => {
-                function fixUpLanguage(languageId: string) {
-                    const languageIdToLanguage: { [id: string]: string } =
-                    { 'c': 'C', 'cpp': 'C++', 'cuda-cpp': 'CUDA C++' };
-                    return languageIdToLanguage[languageId] || languageId;
-                }
-
-                function fixUpCompiler(compilerId: string) {
-                    const compilerIdToCompiler: { [id: string]: string } =
-                    { 'msvc': 'MSVC', 'clang': 'Clang', 'gcc': 'GCC' };
-                    return compilerIdToCompiler[compilerId] || compilerId;
-                }
-
-                function fixUpStandardVersion(stdVerId: string) {
-                    const stdVerIdToStdVer: { [id: string]: string } =
-                    { 'c++98': 'C++98', 'c++03': 'C++03', 'c++11': 'C++11', 'c++14': 'C++14', 'c++17': 'C++17',
-                        'c++20': 'C++20', 'c++23': 'C++23', 'c90' : "C90", 'c99': "C99", 'c11': "C11", 'c17': "C17",
-                        'c23': "C23" };
-                    return stdVerIdToStdVer[stdVerId] || stdVerId;
-                }
-
-                function fixTargetPlatform(targetPlatformId: string) {
-                    const platformIdToPlatform: { [id: string]: string } = { 'windows': 'Windows', 'Linux': 'Linux', 'macos': 'macOS' };
-                    return platformIdToPlatform[targetPlatformId] || targetPlatformId;
-                }
-
-                if (name !== 'cpp') {
-                    return undefined;
-                }
-
-                // Return undefined if the active document is not a C++/C/CUDA/Header file.
-                const currentDoc = vscode.window.activeTextEditor?.document;
-                if (!currentDoc || (!util.isCpp(currentDoc) && !util.isHeaderFile(currentDoc.uri))) {
-                    return undefined;
-                }
-
-                const chatContext: ChatContextResult | undefined = await getChatContext();
-                if (!chatContext) {
-                    return undefined;
-                }
-
-                telemetry.logCppChatVariableEvent('cpp',
-                    { "language": chatContext.language, "compiler": chatContext.compiler, "standardVersion": chatContext.standardVersion,
-                        "targetPlatform": chatContext.targetPlatform, "targetArchitecture": chatContext.targetArchitecture });
-
-                const language = fixUpLanguage(chatContext.language);
-                const compiler = fixUpCompiler(chatContext.compiler);
-                const standardVersion = fixUpStandardVersion(chatContext.standardVersion);
-                const targetPlatform = fixTargetPlatform(chatContext.targetPlatform);
-                const value = `I am working on a project of the following nature:
-- Using ${language}. Prefer a solution written in ${language} to any other language. Call out which language you are using in the answer.
-- Using the ${language} standard language version ${standardVersion}. Prefer solutions using the new and more recent features introduced in ${standardVersion}. Call out which standard version you are using in the answer.
-- Using the ${compiler} compiler. Prefer solutions supported by the ${compiler} compiler.
-- Targeting the ${targetPlatform} platform. Prefer solutions and API that are supported on ${targetPlatform}.
-- Targeting the ${chatContext.targetArchitecture} architecture. Prefer solutions and techniques that are supported on the ${chatContext.targetArchitecture} architecture.
-`;
-                return [ { level: vscode.ChatVariableLevel.Full, value: value } ];
-            }
-        });
 }
 
 export function updateLanguageConfigurations(): void {
@@ -1450,8 +1384,4 @@ export async function preReleaseCheck(): Promise<void> {
 export async function getIncludes(maxDepth: number): Promise<any> {
     const includes = await clients.ActiveClient.getIncludes(maxDepth);
     return includes;
-}
-
-export async function getChatContext(): Promise<ChatContextResult | undefined> {
-    return clients?.ActiveClient?.getChatContext() ?? undefined;
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -251,7 +251,7 @@ export async function activate(): Promise<void> {
     }
 
     if (util.extensionContext) {
-        const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool(clients));
+        const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool());
         disposables.push(tool);
     }
 }

--- a/Extension/src/LanguageServer/lmTool.ts
+++ b/Extension/src/LanguageServer/lmTool.ts
@@ -1,0 +1,90 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as util from '../common';
+import * as telemetry from '../telemetry';
+import { ChatContextResult } from './client';
+import { ClientCollection } from './clientCollection';
+
+const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: string } } = {
+    language: {
+        'c': 'C',
+        'cpp': 'C++',
+        'cuda-cpp': 'CUDA C++',
+    },
+    compiler: {
+        'msvc': 'MSVC',
+        'clang': 'Clang',
+        'gcc': 'GCC',
+    },
+    standardVersion: {
+        'c++98': 'C++98',
+        'c++03': 'C++03',
+        'c++11': 'C++11',
+        'c++14': 'C++14',
+        'c++17': 'C++17',
+        'c++20': 'C++20',
+        'c++23': 'C++23',
+        'c90': "C90",
+        'c99': "C99",
+        'c11': "C11",
+        'c17': "C17",
+        'c23': "C23",
+    },
+    targetPlatform: {
+        'windows': 'Windows',
+        'Linux': 'Linux',
+        'macos': 'macOS',
+    },
+};
+
+class StringLanguageModelToolResult implements vscode.LanguageModelToolResult
+{
+    public constructor(public readonly value: string) {}
+    public toString(): string { return this.value; }
+}
+
+export class CppConfigurationLanguageModelTool implements vscode.LanguageModelTool
+{
+    public constructor(private readonly clients: ClientCollection) {}
+
+    public async invoke(parameters: any, token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
+        return new StringLanguageModelToolResult(await this.getContext());
+    }
+
+    private async getContext(): Promise<string> {
+        const currentDoc = vscode.window.activeTextEditor?.document;
+        if (!currentDoc || (!util.isCpp(currentDoc) && !util.isHeaderFile(currentDoc.uri))) {
+            return 'The active document is not a C, C++, or CUDA file.';
+        }
+
+        const chatContext: ChatContextResult | undefined = await (this.clients?.ActiveClient?.getChatContext() ?? undefined);
+        if (!chatContext) {
+            return 'No configuration information is available for the active document.';
+        }
+
+        telemetry.logLanguageModelToolEvent(
+            'cpp',
+            {
+                "language": chatContext.language,
+                "compiler": chatContext.compiler,
+                "standardVersion": chatContext.standardVersion,
+                "targetPlatform": chatContext.targetPlatform,
+                "targetArchitecture": chatContext.targetArchitecture
+            });
+
+        for (const key in knownValues) {
+            const knownKey = key as keyof ChatContextResult;
+            if (knownValues[knownKey] && chatContext[knownKey])
+            {
+                chatContext[knownKey] = knownValues[knownKey][chatContext[knownKey]] || chatContext[knownKey];
+            }
+        }
+
+        return `The user is working on a ${chatContext.language} project. The project uses language version ${chatContext.standardVersion}, compiles using the ${chatContext.compiler} compiler, targets the ${chatContext.targetPlatform} platform, and targets the ${chatContext.targetArchitecture} architecture.`;
+    }
+}

--- a/Extension/src/LanguageServer/lmTool.ts
+++ b/Extension/src/LanguageServer/lmTool.ts
@@ -14,12 +14,12 @@ const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: str
     language: {
         'c': 'C',
         'cpp': 'C++',
-        'cuda-cpp': 'CUDA C++',
+        'cuda-cpp': 'CUDA C++'
     },
     compiler: {
         'msvc': 'MSVC',
         'clang': 'Clang',
-        'gcc': 'GCC',
+        'gcc': 'GCC'
     },
     standardVersion: {
         'c++98': 'C++98',
@@ -33,13 +33,13 @@ const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: str
         'c99': "C99",
         'c11': "C11",
         'c17': "C17",
-        'c23': "C23",
+        'c23': "C23"
     },
     targetPlatform: {
         'windows': 'Windows',
         'Linux': 'Linux',
-        'macos': 'macOS',
-    },
+        'macos': 'macOS'
+    }
 };
 
 class StringLanguageModelToolResult implements vscode.LanguageModelToolResult
@@ -52,7 +52,7 @@ export class CppConfigurationLanguageModelTool implements vscode.LanguageModelTo
 {
     public constructor(private readonly clients: ClientCollection) {}
 
-    public async invoke(parameters: any, token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
+    public async invoke(_parameters: any, _token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
         return new StringLanguageModelToolResult(await this.getContext());
     }
 

--- a/Extension/src/LanguageServer/utils.ts
+++ b/Extension/src/LanguageServer/utils.ts
@@ -99,3 +99,10 @@ export function showInstallCompilerWalkthrough(): void {
 }
 
 const docsChangedFromCppToC: Set<string> = new Set<string>();
+
+export async function withCancellation<T>(promise: Promise<T>, token: vscode.CancellationToken): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        token.onCancellationRequested(() => reject(new vscode.CancellationError()));
+        promise.then((value) => resolve(value), (reason) => reject(reason));
+    });
+}

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -123,10 +123,10 @@ export function logLanguageServerEvent(eventName: string, properties?: Record<st
     sendTelemetry();
 }
 
-export function logCppChatVariableEvent(eventName: string, properties?: Record<string, string>, metrics?: Record<string, number>): void {
+export function logLanguageModelToolEvent(eventName: string, properties?: Record<string, string>, metrics?: Record<string, number>): void {
     const sendTelemetry = () => {
         if (experimentationTelemetry) {
-            const eventNamePrefix: string = "C_Cpp/Copilot/Chat/Variable/";
+            const eventNamePrefix: string = "C_Cpp/Copilot/Chat/Tool/";
             experimentationTelemetry.sendTelemetryEvent(eventNamePrefix + eventName, properties, metrics);
         }
     };

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -123,6 +123,20 @@ export function logLanguageServerEvent(eventName: string, properties?: Record<st
     sendTelemetry();
 }
 
+export function logCppChatVariableEvent(eventName: string, properties?: Record<string, string>, metrics?: Record<string, number>): void {
+    const sendTelemetry = () => {
+        if (experimentationTelemetry) {
+            const eventNamePrefix: string = "C_Cpp/Copilot/Chat/Variable/";
+            experimentationTelemetry.sendTelemetryEvent(eventNamePrefix + eventName, properties, metrics);
+        }
+    };
+
+    if (is.promise(initializationPromise)) {
+        return void initializationPromise.catch(logAndReturn.undefined).then(sendTelemetry).catch(logAndReturn.undefined);
+    }
+    sendTelemetry();
+}
+
 function getPackageInfo(): IPackageInfo {
     return {
         name: util.packageJson.publisher + "." + util.packageJson.name,


### PR DESCRIPTION
This is essentially the same as #12044, but adapted to use the new proposed language model tools API instead of the chat variables API. I'm leaving it in a draft statue until the API is on a path to stabilization and we've resolved issues like https://github.com/microsoft/vscode/issues/225737. I'm also guessing we'll want to add the ability to A/B experiment.

cc @lukka @sinemakinci1