### PR TITLE
Prevent AddComment action from adding redundant comments

### DIFF
--- a/.github/actions/AddComment/AddComment.js
+++ b/.github/actions/AddComment/AddComment.js
@@ -35,9 +35,7 @@ class AddComment extends ActionBase_1.ActionBase {
                     let foundActionComment = false;
                     for await (const commentBatch of issue.getComments()) {
                         for (const comment of commentBatch) {
-                            (0, utils_1.safeLog)(`TEMP log comment author: ${comment.author}`);
                             if (comment.author.isGitHubApp) {
-                                (0, utils_1.safeLog)('Found a comment by github-actions');
                                 foundActionComment = true;
                                 break;
                             }
@@ -46,7 +44,7 @@ class AddComment extends ActionBase_1.ActionBase {
                             break;
                     }
                     if (foundActionComment) {
-                        (0, utils_1.safeLog)(`Issue ${hydrated.number} already commented on by an action. Ignoring`);
+                        (0, utils_1.safeLog)(`Issue ${hydrated.number} already commented on by an action. Ignoring.`);
                         continue;
                     }
                     if (this.addComment) {

--- a/.github/actions/AddComment/AddComment.js
+++ b/.github/actions/AddComment/AddComment.js
@@ -31,6 +31,24 @@ class AddComment extends ActionBase_1.ActionBase {
                 if (hydrated.open && this.validateIssue(hydrated)
                 // TODO: Verify updated timestamp
                 ) {
+                    // Don't add a comment if already commented on by an action.
+                    let foundActionComment = false;
+                    for await (const commentBatch of issue.getComments()) {
+                        for (const comment of commentBatch) {
+                            (0, utils_1.safeLog)(`TEMP log comment author: ${comment.author}`);
+                            if (comment.author.isGitHubApp) {
+                                (0, utils_1.safeLog)('Found a comment by github-actions');
+                                foundActionComment = true;
+                                break;
+                            }
+                        }
+                        if (foundActionComment)
+                            break;
+                    }
+                    if (foundActionComment) {
+                        (0, utils_1.safeLog)(`Issue ${hydrated.number} already commented on by an action. Ignoring`);
+                        continue;
+                    }
                     if (this.addComment) {
                         (0, utils_1.safeLog)(`Posting comment on issue ${hydrated.number}`);
                         await issue.postComment(this.addComment);

--- a/.github/actions/AddComment/AddComment.ts
+++ b/.github/actions/AddComment/AddComment.ts
@@ -45,25 +45,20 @@ export class AddComment extends ActionBase {
 				if (hydrated.open && this.validateIssue(hydrated)
 					// TODO: Verify updated timestamp
 				) {
-
 					// Don't add a comment if already commented on by an action.
 					let foundActionComment = false;
 					for await (const commentBatch of issue.getComments()) {
 						for (const comment of commentBatch) {
-
-							safeLog(`TEMP log comment author: ${comment.author}`);
-
-						  if (comment.author.isGitHubApp) {
-							safeLog('Found a comment by github-actions');
-							foundActionComment = true;
-							break;
-						  }
+							if (comment.author.isGitHubApp) {
+								foundActionComment = true;
+								break;
+							}
 						}
 						if (foundActionComment)
 							break;
 					}
 					if (foundActionComment) {
-						safeLog(`Issue ${hydrated.number} already commented on by an action. Ignoring`);
+						safeLog(`Issue ${hydrated.number} already commented on by an action. Ignoring.`);
 						continue;
 					}
 


### PR DESCRIPTION
AddComment doesn't check the issue has already been commented on.

This change adds a check to avoid commenting on an issue that has been commented on by an action previously.

Alternatively, we could use a new label to label things as already commented on by the bot.