### PR TITLE
Switch from LSP hover to HoverProvider

### DIFF
--- a/Extension/src/LanguageServer/Providers/HoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/HoverProvider.ts
@@ -38,10 +38,13 @@ export class HoverProvider implements vscode.HoverProvider {
         }
         // VS Code doesn't like the raw objects returned via RPC, so we need to create proper VS Code objects here.
         const strings: vscode.MarkdownString[] = [];
-        let markdownString: vscode.MarkdownString;
         for (const element of hoverResult.contents) {
-            markdownString = element as vscode.MarkdownString;
-            strings.push(markdownString);
+            const oldMarkdownString: vscode.MarkdownString = element as vscode.MarkdownString;
+            const newMarkdownString: vscode.MarkdownString = new vscode.MarkdownString(oldMarkdownString.value, oldMarkdownString.supportThemeIcons);
+            newMarkdownString.isTrusted = oldMarkdownString.isTrusted;
+            newMarkdownString.supportHtml = oldMarkdownString.supportHtml;
+            newMarkdownString.baseUri = oldMarkdownString.baseUri;
+            strings.push(newMarkdownString);
         }
         let range: vscode.Range | undefined;
         if (hoverResult.range) {

--- a/Extension/src/LanguageServer/Providers/HoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/HoverProvider.ts
@@ -1,0 +1,54 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as vscode from 'vscode';
+import { Position, ResponseError, TextDocumentPositionParams } from 'vscode-languageclient';
+import { DefaultClient, HoverRequest } from '../client';
+import { RequestCancelled, ServerCancelled } from '../protocolFilter';
+import { CppSettings } from '../settings';
+
+export class HoverProvider implements vscode.HoverProvider {
+    private client: DefaultClient;
+    constructor(client: DefaultClient) {
+        this.client = client;
+    }
+
+    public async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | undefined> {
+        const settings: CppSettings = new CppSettings(vscode.workspace.getWorkspaceFolder(document.uri)?.uri);
+        if (settings.hover === "disabled") {
+            return undefined;
+        }
+        const params: TextDocumentPositionParams = {
+            textDocument: { uri: document.uri.toString() },
+            position: Position.create(position.line, position.character)
+        };
+        await this.client.ready;
+        let hoverResult: vscode.Hover;
+        try {
+            hoverResult = await this.client.languageClient.sendRequest(HoverRequest, params, token);
+        } catch (e: any) {
+            if (e instanceof ResponseError && (e.code === RequestCancelled || e.code === ServerCancelled)) {
+                throw new vscode.CancellationError();
+            }
+            throw e;
+        }
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        // VS Code doesn't like the raw objects returned via RPC, so we need to create proper VS Code objects here.
+        const strings: (vscode.MarkdownString | vscode.MarkedString)[] = new Array<vscode.MarkdownString | vscode.MarkedString>();
+        let markdownString: vscode.MarkdownString;
+        for (const element of hoverResult.contents) {
+            markdownString = element as vscode.MarkdownString;
+            strings.push(markdownString.value);
+        }
+        let range: vscode.Range | undefined;
+        if (hoverResult.range) {
+            range = new vscode.Range(hoverResult.range.start.line, hoverResult.range.start.character,
+                hoverResult.range.end.line, hoverResult.range.end.character);
+        }
+
+        return new vscode.Hover(strings, range);
+    }
+}

--- a/Extension/src/LanguageServer/Providers/HoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/HoverProvider.ts
@@ -37,11 +37,11 @@ export class HoverProvider implements vscode.HoverProvider {
             throw new vscode.CancellationError();
         }
         // VS Code doesn't like the raw objects returned via RPC, so we need to create proper VS Code objects here.
-        const strings: (vscode.MarkdownString | vscode.MarkedString)[] = new Array<vscode.MarkdownString | vscode.MarkedString>();
+        const strings: vscode.MarkdownString[] = [];
         let markdownString: vscode.MarkdownString;
         for (const element of hoverResult.contents) {
             markdownString = element as vscode.MarkdownString;
-            strings.push(markdownString.value);
+            strings.push(markdownString);
         }
         let range: vscode.Range | undefined;
         if (hoverResult.range) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -27,7 +27,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { SourceFileConfiguration, SourceFileConfigurationItem, Version, WorkspaceBrowseConfiguration } from 'vscode-cpptools';
 import { IntelliSenseStatus, Status } from 'vscode-cpptools/out/testApi';
-import { CloseAction, DidOpenTextDocumentParams, ErrorAction, LanguageClientOptions, NotificationType, Position, Range, RequestType, TextDocumentIdentifier } from 'vscode-languageclient';
+import { CloseAction, DidOpenTextDocumentParams, ErrorAction, LanguageClientOptions, NotificationType, Position, Range, RequestType, TextDocumentIdentifier, TextDocumentPositionParams } from 'vscode-languageclient';
 import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
 import * as nls from 'vscode-nls';
 import { DebugConfigurationProvider } from '../Debugger/configurationProvider';
@@ -43,6 +43,7 @@ import { localizedStringCount, lookupString } from '../nativeStrings';
 import { SessionState } from '../sessionState';
 import * as telemetry from '../telemetry';
 import { TestHook, getTestHook } from '../testHook';
+import { HoverProvider } from './Providers/HoverProvider';
 import {
     CodeAnalysisDiagnosticIdentifiersAndUri,
     RegisterCodeAnalysisNotifications,
@@ -554,6 +555,7 @@ export const GetFoldingRangesRequest: RequestType<GetFoldingRangesParams, GetFol
 export const FormatDocumentRequest: RequestType<FormatParams, FormatResult, void> = new RequestType<FormatParams, FormatResult, void>('cpptools/formatDocument');
 export const FormatRangeRequest: RequestType<FormatParams, FormatResult, void> = new RequestType<FormatParams, FormatResult, void>('cpptools/formatRange');
 export const FormatOnTypeRequest: RequestType<FormatParams, FormatResult, void> = new RequestType<FormatParams, FormatResult, void>('cpptools/formatOnType');
+export const HoverRequest: RequestType<TextDocumentPositionParams, vscode.Hover, void> = new RequestType<TextDocumentPositionParams, vscode.Hover, void>('cpptools/hover');
 const CreateDeclarationOrDefinitionRequest: RequestType<CreateDeclarationOrDefinitionParams, CreateDeclarationOrDefinitionResult, void> = new RequestType<CreateDeclarationOrDefinitionParams, CreateDeclarationOrDefinitionResult, void>('cpptools/createDeclDef');
 const ExtractToFunctionRequest: RequestType<ExtractToFunctionParams, WorkspaceEditResult, void> = new RequestType<ExtractToFunctionParams, WorkspaceEditResult, void>('cpptools/extractToFunction');
 const GoToDirectiveInGroupRequest: RequestType<GoToDirectiveInGroupParams, Position | undefined, void> = new RequestType<GoToDirectiveInGroupParams, Position | undefined, void>('cpptools/goToDirectiveInGroup');
@@ -1255,6 +1257,7 @@ export class DefaultClient implements Client {
                 initializedClientCount = 0;
                 this.inlayHintsProvider = new InlayHintsProvider();
 
+                this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, new HoverProvider(this)));
                 this.disposables.push(vscode.languages.registerInlayHintsProvider(util.documentSelector, this.inlayHintsProvider));
                 this.disposables.push(vscode.languages.registerRenameProvider(util.documentSelector, new RenameProvider(this)));
                 this.disposables.push(vscode.languages.registerReferenceProvider(util.documentSelector, new FindAllReferencesProvider(this)));


### PR DESCRIPTION
This is mainly to support Spencer's work on AI hover resultd.  Moving hover processing out of LSP and into a `HoverProvider` provides some additional flexibility.

There is a native-side PR as well.
