### PR TITLE
Fix show a list local processes, if remote connection failed (useExtendedRemote)

### DIFF
--- a/Extension/src/SSH/sshCommandRunner.ts
+++ b/Extension/src/SSH/sshCommandRunner.ts
@@ -304,7 +304,7 @@ export function runInteractiveSshTerminalCommand(args: ITerminalCommandArgs): Pr
 
         // When using showLoginTerminal, stdout include the passphrase prompt, etc. Try to get just the command output on the last line.
         const actualOutput: string | undefined = cancel ? '' : lastNonemptyLine(stdout);
-        result.resolve({ succeeded: !exitCode, exitCode, output: actualOutput || '' });
+        result.resolve({ succeeded: !exitCode, exitCode, outputError: '', output: actualOutput || '' });
     };
 
     const failed = (error?: any) => {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -753,7 +753,7 @@ export interface ProcessReturnType {
     succeeded: boolean;
     exitCode?: number | NodeJS.Signals;
     output: string;
-    outputError : string;
+    outputError: string;
 }
 
 export async function spawnChildProcess(program: string, args: string[] = [], continueOn?: string, skipLogging?: boolean, cancellationToken?: vscode.CancellationToken): Promise<ProcessReturnType> {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -753,6 +753,7 @@ export interface ProcessReturnType {
     succeeded: boolean;
     exitCode?: number | NodeJS.Signals;
     output: string;
+    outputError : string;
 }
 
 export async function spawnChildProcess(program: string, args: string[] = [], continueOn?: string, skipLogging?: boolean, cancellationToken?: vscode.CancellationToken): Promise<ProcessReturnType> {
@@ -766,7 +767,7 @@ export async function spawnChildProcess(program: string, args: string[] = [], co
     const programOutput: ProcessOutput = await spawnChildProcessImpl(program, args, continueOn, skipLogging, cancellationToken);
     const exitCode: number | NodeJS.Signals | undefined = programOutput.exitCode;
     if (programOutput.exitCode) {
-        return { succeeded: false, exitCode, output: programOutput.stderr || programOutput.stdout || localize('process.exited', 'Process exited with code {0}', exitCode) };
+        return { succeeded: false, exitCode, outputError: programOutput.stderr, output: programOutput.stderr || programOutput.stdout || localize('process.exited', 'Process exited with code {0}', exitCode) };
     } else {
         let stdout: string;
         if (programOutput.stdout.length) {
@@ -775,7 +776,7 @@ export async function spawnChildProcess(program: string, args: string[] = [], co
         } else {
             stdout = localize('process.succeeded', 'Process executed successfully.');
         }
-        return { succeeded: true, exitCode, output: stdout };
+        return { succeeded: true, exitCode, outputError: programOutput.stderr, output: stdout };
     }
 }
 


### PR DESCRIPTION
Hello, I fixed https://github.com/microsoft/vscode-cpptools/issues/12547 

The problem was that there was a connection error (`-ex "target extended-remote 192.168.1.1:8888"`) and the command to list the processes was executed (` -ex "info os processes"`)
Command run gdb: `gdb -ex "target extended-remote 192.168.1.1:8888" -ex "info os processes" -batch`
 
If the connection failed, an error message will be displayed.