### PR TITLE
Log the values of editor settings that we track

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1960,6 +1960,23 @@ export class DefaultClient implements Client {
             configJson += `Modified Settings:\n${JSON.stringify(settings, null, 4)}\n`;
         }
 
+        {
+            const editorSettings = new OtherSettings(this.RootUri);
+            const settings: Record<string, any> = {};
+            settings.editorTabSize = editorSettings.editorTabSize;
+            settings.editorInsertSpaces = editorSettings.editorInsertSpaces;
+            settings.editorAutoClosingBrackets = editorSettings.editorAutoClosingBrackets;
+            settings.filesEncoding = editorSettings.filesEncoding;
+            settings.filesAssociations = editorSettings.filesAssociations;
+            settings.filesExclude = editorSettings.filesExclude;
+            settings.filesAutoSaveAfterDelay = editorSettings.filesAutoSaveAfterDelay;
+            settings.editorInlayHintsEnabled = editorSettings.editorInlayHintsEnabled;
+            settings.editorParameterHintsEnabled = editorSettings.editorParameterHintsEnabled;
+            settings.searchExclude = editorSettings.searchExclude;
+            settings.workbenchSettingsEditor = editorSettings.workbenchSettingsEditor;
+            configJson += `Tracked Editor Settings:\n${JSON.stringify(settings, null, 4)}\n`;
+        }
+
         // Get diagnostics for configuration provider info.
         let configurationLoggingStr: string = "";
         const tuSearchStart: number = response.diagnostics.indexOf("Translation Unit Mappings:");

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1974,7 +1974,7 @@ export class DefaultClient implements Client {
             settings.editorParameterHintsEnabled = editorSettings.editorParameterHintsEnabled;
             settings.searchExclude = editorSettings.searchExclude;
             settings.workbenchSettingsEditor = editorSettings.workbenchSettingsEditor;
-            configJson += `Tracked Editor Settings:\n${JSON.stringify(settings, null, 4)}\n`;
+            configJson += `Additional Tracked Settings:\n${JSON.stringify(settings, null, 4)}\n`;
         }
 
         // Get diagnostics for configuration provider info.


### PR DESCRIPTION
A follow up to the previous logging change. Let me know if this is overkill.  We don't have code that tracks changes for editor settings, so this initial proposal will always log the values.

This may or may not be desirable so I'm soliciting feedback about the path forward. Should we:
1. Always log these values?
2. Always log a subset of these values? (e.g. if we don't think we care about some of them)
3. Write code to check if the values are not the default before logging them? The right solution here might involve some refactoring in the settings tracker class or moving the code to settings.ts (more work).