### PR TITLE
Update link to glob info

### DIFF
--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -120,7 +120,7 @@
         ]
     },
     "c_cpp.configuration.codeAnalysis.exclude.markdownDescription": {
-        "message": "Configure glob patterns for excluding folders and files for code analysis. Files not under the workspace folder are always excluded. Inherits values from `#files.exclude#` and `#C_Cpp.files.exclude#`. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+        "message": "Configure glob patterns for excluding folders and files for code analysis. Files not under the workspace folder are always excluded. Inherits values from `#files.exclude#` and `#C_Cpp.files.exclude#`. Learn more about [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
@@ -781,7 +781,7 @@
         ]
     },
     "c_cpp.configuration.filesExclude.markdownDescription": {
-        "message": "Configure glob patterns for excluding folders (and files if `#C_Cpp.exclusionPolicy#` is changed). These are specific to the C/C++ extension and are in addition to `#files.exclude#`, but unlike `#files.exclude#` they also apply to paths outside the current workspace folder and are not removed from the Explorer view. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
+        "message": "Configure glob patterns for excluding folders (and files if `#C_Cpp.exclusionPolicy#` is changed). These are specific to the C/C++ extension and are in addition to `#files.exclude#`, but unlike `#files.exclude#` they also apply to paths outside the current workspace folder and are not removed from the Explorer view. Learn more about [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options).",
         "comment": [
             "Markdown text between `` and [) should not be translated and the capitalization, spacing, and punctuation (including the ``) should not be altered: https://en.wikipedia.org/wiki/Markdown"
         ]


### PR DESCRIPTION
Fixes: #7824

There is a localization issue for these glob links where the localizers left out the description and kept only the "here" text.

Most hyperlink text guidelines recommend not using "click here" or other non-descriptive phrases as the target of the actual link anyway, so I'm changing the links to conform to the guidance and prompt an update to the translation in the process. 