### PR TITLE
The compiler path selection control is not in sync with the textbox

### DIFF
--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -109,8 +109,8 @@ class SettingsApp {
         document.getElementById(elementId.configName)?.addEventListener("change", this.onConfigNameChanged.bind(this));
         document.getElementById(elementId.configSelection)?.addEventListener("change", this.onConfigSelect.bind(this));
         document.getElementById(elementId.addConfigBtn)?.addEventListener("click", this.onAddConfigBtn.bind(this));
-        document.getElementById(elementId.addConfigOk)?.addEventListener("click", this.OnAddConfigConfirm.bind(this, true));
-        document.getElementById(elementId.addConfigCancel)?.addEventListener("click", this.OnAddConfigConfirm.bind(this, false));
+        document.getElementById(elementId.addConfigOk)?.addEventListener("click", this.onAddConfigConfirm.bind(this, true));
+        document.getElementById(elementId.addConfigCancel)?.addEventListener("click", this.onAddConfigConfirm.bind(this, false));
     }
 
     private onTabKeyDown(e: any): void {
@@ -148,7 +148,7 @@ class SettingsApp {
         this.showElement(elementId.addConfigInputDiv, true);
     }
 
-    private OnAddConfigConfirm(request: boolean): void {
+    private onAddConfigConfirm(request: boolean): void {
         this.showElement(elementId.addConfigInputDiv, false);
         this.showElement(elementId.addConfigDiv, true);
 
@@ -204,7 +204,7 @@ class SettingsApp {
         if (this.updating) {
             return;
         }
-        const el: HTMLInputElement = <HTMLInputElement>document.getElementById(elementId.knownCompilers);
+        const el: HTMLSelectElement = <HTMLSelectElement>document.getElementById(elementId.knownCompilers);
         (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = el.value;
         this.onChanged(elementId.compilerPath);
 
@@ -217,17 +217,15 @@ class SettingsApp {
     // To enable custom entries, the compiler path control is a text box on top of a select control.
     // This function ensures that the select control is updated when the text box is changed.
     private fixKnownCompilerSelection(): void {
-        const compilerPath = <HTMLInputElement>document.getElementById(elementId.compilerPath);
+        const compilerPath = (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value.toLowerCase();
         const knownCompilers = <HTMLSelectElement>document.getElementById(elementId.knownCompilers);
         for (let n = 0; n < knownCompilers.options.length; n++) {
-            if (compilerPath.value.toLowerCase() === knownCompilers.options[n].value.toLowerCase()) {
+            if (compilerPath === knownCompilers.options[n].value.toLowerCase()) {
                 knownCompilers.value = knownCompilers.options[n].value;
-                break;
-            }
-            if (n === knownCompilers.options.length - 1) {
-                knownCompilers.value = '';
+                return;
             }
         }
+        knownCompilers.value = '';
     }
 
     private onChangedCheckbox(id: string): void {

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -4,8 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import path = require("path");
-
 const elementId: { [key: string]: string } = {
     // Basic settings
     configName: "configName",
@@ -222,7 +220,7 @@ class SettingsApp {
         const compilerPath = <HTMLInputElement>document.getElementById(elementId.compilerPath);
         const knownCompilers = <HTMLSelectElement>document.getElementById(elementId.knownCompilers);
         for (let n = 0; n < knownCompilers.options.length; n++) {
-            if (path.normalize(compilerPath.value) === path.normalize(knownCompilers.options[n].value)) {
+            if (compilerPath.value.toLowerCase() === knownCompilers.options[n].value.toLowerCase()) {
                 knownCompilers.value = knownCompilers.options[n].value;
                 break;
             }

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -4,6 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
+import path = require("path");
+
 const elementId: { [key: string]: string } = {
     // Basic settings
     configName: "configName",
@@ -212,10 +214,24 @@ class SettingsApp {
         this.vsCodeApi.postMessage({
             command: "knownCompilerSelect"
         });
-
-        // Reset selection to none
-        el.value = "";
     }
+
+    // To enable custom entries, the compiler path control is a text box on top of a select control.
+    // This function ensures that the select control is updated when the text box is changed.
+    private fixKnownCompilerSelection(): void {
+        const compilerPath = <HTMLInputElement>document.getElementById(elementId.compilerPath);
+        const knownCompilers = <HTMLSelectElement>document.getElementById(elementId.knownCompilers);
+        for (let n = 0; n < knownCompilers.options.length; n++) {
+            if (path.normalize(compilerPath.value) === path.normalize(knownCompilers.options[n].value)) {
+                knownCompilers.value = knownCompilers.options[n].value;
+                break;
+            }
+            if (n === knownCompilers.options.length - 1) {
+                knownCompilers.value = '';
+            }
+        }
+    }
+
     private onChangedCheckbox(id: string): void {
         if (this.updating) {
             return;
@@ -235,6 +251,9 @@ class SettingsApp {
         }
 
         const el: HTMLInputElement = <HTMLInputElement>document.getElementById(id);
+        if (id === elementId.compilerPath) {
+            this.fixKnownCompilerSelection();
+        }
         this.vsCodeApi.postMessage({
             command: "change",
             key: id,
@@ -268,6 +287,7 @@ class SettingsApp {
             // Basic settings
             (<HTMLInputElement>document.getElementById(elementId.configName)).value = config.name;
             (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ? config.compilerPath : "";
+            this.fixKnownCompilerSelection();
             (<HTMLInputElement>document.getElementById(elementId.compilerArgs)).value = joinEntries(config.compilerArgs);
 
             (<HTMLInputElement>document.getElementById(elementId.intelliSenseMode)).value = config.intelliSenseMode ? config.intelliSenseMode : "${default}";


### PR DESCRIPTION
Fixes: #7427

The faux editable combobox we use to set the compilerPath property was not keeping the select control in sync with the contents of the textbox.  This change fixes it.