### PR TITLE
Enable log diagnostics without a C/C++ file active.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -5864,7 +5864,7 @@
                 },
                 {
                     "command": "C_Cpp.LogDiagnostics",
-                    "when": "editorLangId =~ /^(c|(cuda-)?cpp)$/ && !(config.C_Cpp.intelliSenseEngine =~ /^[dD]isabled$/)"
+                    "when": "!(config.C_Cpp.intelliSenseEngine =~ /^[dD]isabled$/)"
                 },
                 {
                     "command": "C_Cpp.RescanWorkspace",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/12634