### PR TITLE
Migrate to Copilot related files API

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -266,12 +266,16 @@ export async function activate(): Promise<void> {
     if (isRelatedFilesApiEnabled) {
         const api = await getCopilotApi();
         if (util.extensionContext && api) {
-            for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
-                api.registerRelatedFilesProvider(
-                    { extensionId: util.extensionContext.extension.id, languageId },
-                    async (_uri: vscode.Uri) =>
-                        ({ entries: (await clients.ActiveClient.getIncludes(1))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [] })
-                );
+            try {
+                for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
+                    api.registerRelatedFilesProvider(
+                        { extensionId: util.extensionContext.extension.id, languageId },
+                        async (_uri: vscode.Uri) =>
+                            ({ entries: (await clients.ActiveClient.getIncludes(1))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [] })
+                    );
+                }
+            } catch {
+                console.log("Failed to register Copilot related files provider.");
             }
         }
     }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -33,6 +33,13 @@ import { CppSettings } from './settings';
 import { LanguageStatusUI, getUI } from './ui';
 import { makeLspRange, rangeEquals, showInstallCompilerWalkthrough } from './utils';
 
+interface CopilotApi {
+    registerRelatedFilesProvider(
+        providerId: { extensionId: string; languageId: string },
+        callback: (uri: vscode.Uri) => Promise<{ entries: vscode.Uri[]; traits?: { name: string; value: string }[] }>
+    ): void;
+}
+
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 export const CppSourceStr: string = "C/C++";
@@ -183,7 +190,7 @@ export async function activate(): Promise<void> {
 
     void clients.ActiveClient.ready.then(() => intervalTimer = global.setInterval(onInterval, 2500));
 
-    registerCommands(true);
+    await registerCommands(true);
 
     vscode.tasks.onDidStartTask(() => getActiveClient().PauseCodeAnalysis());
 
@@ -253,6 +260,20 @@ export async function activate(): Promise<void> {
     if (util.extensionContext && new CppSettings().experimentalFeatures) {
         const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool());
         disposables.push(tool);
+    }
+
+    if (await telemetry.isExperimentEnabled("CppToolsRelatedFilesApi")) {
+        const copilotExtension = vscode.extensions.getExtension<CopilotApi>('github.copilot');
+        if (util.extensionContext && copilotExtension) {
+            const api: CopilotApi = copilotExtension.isActive ? copilotExtension.exports : await copilotExtension.activate();
+            for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
+                api.registerRelatedFilesProvider(
+                    { extensionId: util.extensionContext.extension.id, languageId },
+                    async (_uri: vscode.Uri) =>
+                        ({ entries: (await clients.ActiveClient.getIncludes(1))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [] })
+                );
+            }
+        }
     }
 }
 
@@ -350,7 +371,7 @@ function onInterval(): void {
 /**
  * registered commands
  */
-export function registerCommands(enabled: boolean): void {
+export async function registerCommands(enabled: boolean): Promise<void> {
     commandDisposables.forEach(d => d.dispose());
     commandDisposables.length = 0;
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.SwitchHeaderSource', enabled ? onSwitchHeaderSource : onDisabledCommand));
@@ -408,7 +429,10 @@ export function registerCommands(enabled: boolean): void {
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ExtractToFreeFunction', enabled ? () => onExtractToFunction(true, false) : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ExtractToMemberFunction', enabled ? () => onExtractToFunction(false, true) : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ExpandSelection', enabled ? (r: Range) => onExpandSelection(r) : onDisabledCommand));
-    commandDisposables.push(vscode.commands.registerCommand('C_Cpp.getIncludes', enabled ? (maxDepth: number) => getIncludes(maxDepth) : () => Promise.resolve()));
+
+    if (!await telemetry.isExperimentEnabled("CppToolsRelatedFilesApi")) {
+        commandDisposables.push(vscode.commands.registerCommand('C_Cpp.getIncludes', enabled ? (maxDepth: number) => getIncludes(maxDepth) : () => Promise.resolve()));
+    }
 }
 
 function onDisabledCommand() {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -190,7 +190,8 @@ export async function activate(): Promise<void> {
 
     void clients.ActiveClient.ready.then(() => intervalTimer = global.setInterval(onInterval, 2500));
 
-    await registerCommands(true);
+    const isRelatedFilesApiEnabled = await telemetry.isExperimentEnabled("CppToolsRelatedFilesApi");
+    registerCommands(true, isRelatedFilesApiEnabled);
 
     vscode.tasks.onDidStartTask(() => getActiveClient().PauseCodeAnalysis());
 
@@ -262,7 +263,7 @@ export async function activate(): Promise<void> {
         disposables.push(tool);
     }
 
-    if (await telemetry.isExperimentEnabled("CppToolsRelatedFilesApi")) {
+    if (isRelatedFilesApiEnabled) {
         const copilotExtension = vscode.extensions.getExtension<CopilotApi>('github.copilot');
         if (util.extensionContext && copilotExtension) {
             const api: CopilotApi = copilotExtension.isActive ? copilotExtension.exports : await copilotExtension.activate();
@@ -371,7 +372,7 @@ function onInterval(): void {
 /**
  * registered commands
  */
-export async function registerCommands(enabled: boolean): Promise<void> {
+export function registerCommands(enabled: boolean, isRelatedFilesApiEnabled: boolean): void {
     commandDisposables.forEach(d => d.dispose());
     commandDisposables.length = 0;
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.SwitchHeaderSource', enabled ? onSwitchHeaderSource : onDisabledCommand));
@@ -430,7 +431,7 @@ export async function registerCommands(enabled: boolean): Promise<void> {
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ExtractToMemberFunction', enabled ? () => onExtractToFunction(false, true) : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ExpandSelection', enabled ? (r: Range) => onExpandSelection(r) : onDisabledCommand));
 
-    if (!await telemetry.isExperimentEnabled("CppToolsRelatedFilesApi")) {
+    if (!isRelatedFilesApiEnabled) {
         commandDisposables.push(vscode.commands.registerCommand('C_Cpp.getIncludes', enabled ? (maxDepth: number) => getIncludes(maxDepth) : () => Promise.resolve()));
     }
 }

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (shouldActivateLanguageServer) {
         await LanguageServer.activate();
     } else if (isIntelliSenseEngineDisabled) {
-        LanguageServer.registerCommands(false, /* isRelatedFilesApiEnabled */ false);
+        LanguageServer.registerCommands(false);
         // The check here for isIntelliSenseEngineDisabled avoids logging
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (shouldActivateLanguageServer) {
         await LanguageServer.activate();
     } else if (isIntelliSenseEngineDisabled) {
-        await LanguageServer.registerCommands(false);
+        LanguageServer.registerCommands(false, /* isRelatedFilesApiEnabled */ false);
         // The check here for isIntelliSenseEngineDisabled avoids logging
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -146,7 +146,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (shouldActivateLanguageServer) {
         await LanguageServer.activate();
     } else if (isIntelliSenseEngineDisabled) {
-        LanguageServer.registerCommands(false);
+        await LanguageServer.registerCommands(false);
         // The check here for isIntelliSenseEngineDisabled avoids logging
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));


### PR DESCRIPTION
This change migrates to the new API so that C++ is no longer a special case for related files. I set this up to support A/B experimentation so that we can verify that there are no regressions during the migration.

FYI @lukka @genlu @sandersn