### PR TITLE
Work around issue with clang 18 and size_t

### DIFF
--- a/Extension/bin/linux.clang.arm.json
+++ b/Extension/bin/linux.clang.arm.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-Dunix=1",
@@ -11,5 +12,5 @@
     "-D__SIZE_TYPE__=unsigned int",
     "-D__WCHAR_TYPE__=long int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/linux.clang.arm64.json
+++ b/Extension/bin/linux.clang.arm64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-Dunix=1",
@@ -11,5 +12,5 @@
     "-D__SIZE_TYPE__=long unsigned int",
     "-D__WCHAR_TYPE__=int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/linux.clang.x64.json
+++ b/Extension/bin/linux.clang.x64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-Dunix=1",
@@ -11,5 +12,5 @@
     "-D__SIZE_TYPE__=long unsigned int",
     "-D__WCHAR_TYPE__=int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/linux.clang.x86.json
+++ b/Extension/bin/linux.clang.x86.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-Dunix=1",
@@ -11,5 +12,5 @@
     "-D__SIZE_TYPE__=unsigned int",
     "-D__WCHAR_TYPE__=long int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/macos.clang.arm.json
+++ b/Extension/bin/macos.clang.arm.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-D__APPLE__=1",
@@ -10,5 +11,5 @@
     "-D__SIZE_TYPE__=unsigned int",
     "-D__WCHAR_TYPE__=long int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/macos.clang.arm64.json
+++ b/Extension/bin/macos.clang.arm64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-D__APPLE__=1",
@@ -10,5 +11,5 @@
     "-D__SIZE_TYPE__=long unsigned int",
     "-D__WCHAR_TYPE__=int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/macos.clang.x64.json
+++ b/Extension/bin/macos.clang.x64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-D__APPLE__=1",
@@ -10,5 +11,5 @@
     "-D__SIZE_TYPE__=long unsigned int",
     "-D__WCHAR_TYPE__=int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/macos.clang.x86.json
+++ b/Extension/bin/macos.clang.x86.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8",
     "-D__APPLE__=1",
@@ -10,5 +11,5 @@
     "-D__SIZE_TYPE__=unsigned int",
     "-D__WCHAR_TYPE__=long int"
   ],
-  "defaults_op" :  "merge"
+  "defaults_op": "merge"
 }

--- a/Extension/bin/windows.clang.arm.json
+++ b/Extension/bin/windows.clang.arm.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8"
   ],

--- a/Extension/bin/windows.clang.arm64.json
+++ b/Extension/bin/windows.clang.arm64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8"
   ],

--- a/Extension/bin/windows.clang.x64.json
+++ b/Extension/bin/windows.clang.x64.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8"
   ],

--- a/Extension/bin/windows.clang.x86.json
+++ b/Extension/bin/windows.clang.x86.json
@@ -1,5 +1,6 @@
 {
   "defaults": [
+    "-D__building_module(x)=0",
     "--pack_alignment",
     "8"
   ],


### PR DESCRIPTION
Applying the work-around from: https://github.com/microsoft/vscode-cpptools/issues/12618

Since we don't yet have IntelliSense support for modules, this seems a viable temporary solution.