### PR TITLE
Check related files API flag when IntelliSense is disabled

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -375,7 +375,7 @@ function onInterval(): void {
 /**
  * registered commands
  */
-export function registerCommands(enabled: boolean, isRelatedFilesApiEnabled: boolean = false): void {
+export function registerCommands(enabled: boolean, isRelatedFilesApiEnabled: boolean): void {
     commandDisposables.forEach(d => d.dispose());
     commandDisposables.length = 0;
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.SwitchHeaderSource', enabled ? onSwitchHeaderSource : onDisabledCommand));

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -146,7 +146,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     if (shouldActivateLanguageServer) {
         await LanguageServer.activate();
     } else if (isIntelliSenseEngineDisabled) {
-        LanguageServer.registerCommands(false);
+        const isRelatedFilesApiEnabled = await Telemetry.isExperimentEnabled("CppToolsRelatedFilesApi");
+        LanguageServer.registerCommands(false, isRelatedFilesApiEnabled);
         // The check here for isIntelliSenseEngineDisabled avoids logging
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));


### PR DESCRIPTION
Follow up to a small issue Bob identified in #12735. When IntelliSense is disabled, the existing behavior is to fall back to also disabling the related files API and registering the `getIncludes` command as a no-op. However, that wouldn't correctly test the eventual migration we want where the `getIncludes` command goes away entirely. I changed this to explicitly check the experiment state on the IntelliSense disabled path too.

No need to re-spin any insiders builds for this -- it can go into the next release.