### PR TITLE
Remove parametersSchema for #cpp

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6451,7 +6451,6 @@
                 "userDescription": "%c_cpp.languageModelTools.configuration.userDescription%",
                 "modelDescription": "For the active C or C++ file, this tool provides: the language (C, C++, or CUDA), the language standard version (such as C++11, C++14, C++17, or C++20), the compiler (such as GCC, Clang, or MSVC), the target platform (such as x86, x64, or ARM), and the target architecture (such as 32-bit or 64-bit).",
                 "icon": "$(file-code)",
-                "parametersSchema": {},
                 "when": "(config.C_Cpp.experimentalFeatures =~ /^[eE]nabled$/)",
                 "supportedContentTypes": [
                     "text/plain"


### PR DESCRIPTION
I haven't gotten a repro, but this hopefully resolves https://github.com/microsoft/vscode-copilot-release/issues/1634. The #cpp tool doesn't actually expect any parameters to be passed.