### PR TITLE
Fix an issue preventing use of a full command line in compilerPath

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1877,8 +1877,7 @@ export class CppProperties {
         // Check for path-related squiggles.
         const paths: string[] = [];
         let compilerPath: string | undefined;
-        for (const pathArray of [currentConfiguration.browse ? currentConfiguration.browse.path : undefined,
-        currentConfiguration.includePath, currentConfiguration.macFrameworkPath]) {
+        for (const pathArray of [currentConfiguration.browse ? currentConfiguration.browse.path : undefined, currentConfiguration.includePath, currentConfiguration.macFrameworkPath]) {
             if (pathArray) {
                 for (const curPath of pathArray) {
                     paths.push(`${curPath}`);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -594,7 +594,7 @@ export class CppProperties {
             configuration.intelliSenseMode === "${default}") {
             return "";
         }
-        const resolvedCompilerPath: string = this.resolvePath(configuration.compilerPath);
+        const resolvedCompilerPath: string = this.resolvePath(configuration.compilerPath, false, false);
         const settings: CppSettings = new CppSettings(this.rootUri);
         const compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(!!settings.legacyCompilerArgsBehavior, resolvedCompilerPath);
 
@@ -1878,7 +1878,7 @@ export class CppProperties {
         const paths: string[] = [];
         let compilerPath: string | undefined;
         for (const pathArray of [currentConfiguration.browse ? currentConfiguration.browse.path : undefined,
-            currentConfiguration.includePath, currentConfiguration.macFrameworkPath]) {
+        currentConfiguration.includePath, currentConfiguration.macFrameworkPath]) {
             if (pathArray) {
                 for (const curPath of pathArray) {
                     paths.push(`${curPath}`);


### PR DESCRIPTION
We have a (undocumented) feature that allows a full command line to be provided in the `compilerPath` field of `c_cpp_properties.json`.  This feature is useful for providing a command line that contains shell escaping (as shell escaping is not supported in the `compilerArgs` field.  The concept of shell escaping is implicitly linked to the concept of a 'command line', and not necessarily linked to 'args').  It looks like this support has been broken for a while.

This is fixed by specifying `false` to `resolvePath` for both `replaceAsterisks` and `assumeRelative`.

The other change is a result of formatting the document.