### PR TITLE
Fix issue with Rename UI lingering after cancellation

### DIFF
--- a/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
+++ b/Extension/src/LanguageServer/Providers/callHierarchyProvider.ts
@@ -147,8 +147,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         return this.makeVscodeCallHierarchyItem(response.item);
     }
 
-    public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
-        Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
+    public async provideCallHierarchyIncomingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Promise<vscode.CallHierarchyIncomingCall[] | undefined> {
         await this.client.ready;
         workspaceReferences.cancelCurrentReferenceRequest(CancellationSender.NewRequest);
 
@@ -208,8 +207,7 @@ export class CallHierarchyProvider implements vscode.CallHierarchyProvider {
         return result;
     }
 
-    public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken):
-        Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
+    public async provideCallHierarchyOutgoingCalls(item: vscode.CallHierarchyItem, token: vscode.CancellationToken): Promise<vscode.CallHierarchyOutgoingCall[] | undefined> {
         const CallHierarchyCallsFromEvent: string = "CallHierarchyCallsFrom";
         if (item === undefined) {
             this.logTelemetry(CallHierarchyCallsFromEvent, CallHierarchyRequestStatus.Failed);

--- a/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
+++ b/Extension/src/LanguageServer/Providers/findAllReferencesProvider.ts
@@ -45,11 +45,12 @@ export class FindAllReferencesProvider implements vscode.ReferenceProvider {
                 throw e;
             }
         }
-
-        // Reset anything that can be cleared before processing the result.
-        workspaceReferences.resetProgressBar();
-        cancellationTokenListener.dispose();
-        requestCanceledListener.dispose();
+        finally {
+            // Reset anything that can be cleared before processing the result.
+            workspaceReferences.resetProgressBar();
+            cancellationTokenListener.dispose();
+            requestCanceledListener.dispose();
+        }
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || cancelled || (response && response.isCanceled)) {

--- a/Extension/src/LanguageServer/Providers/renameProvider.ts
+++ b/Extension/src/LanguageServer/Providers/renameProvider.ts
@@ -57,11 +57,12 @@ export class RenameProvider implements vscode.RenameProvider {
             }
             throw e;
         }
-
-        // Reset anything that can be cleared before processing the result.
-        workspaceReferences.resetProgressBar();
-        workspaceReferences.resetReferences();
-        requestCanceledListener.dispose();
+        finally {
+            // Reset anything that can be cleared before processing the result.
+            workspaceReferences.resetProgressBar();
+            workspaceReferences.resetReferences();
+            requestCanceledListener.dispose();
+        }
 
         // Process the result.
         if (cancelSource.token.isCancellationRequested || response.isCanceled) {


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12729

When I changed how cancellation is handled, to properly use LSP cancellation ( https://github.com/microsoft/vscode-cpptools/pull/12592 ) I overlooked some cleanup that needs to be run before the exception is thrown.
