### PR TITLE
Restore the functionality to filter out C++ headers outside current workspace

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -529,7 +529,7 @@ interface GetIncludesParams {
     maxDepth: number;
 }
 
-interface GetIncludesResult {
+export interface GetIncludesResult {
     includedFiles: string[];
 }
 


### PR DESCRIPTION
The filtering has been lost due to missing unit test for this specific case in the original repository where the functionality lived. Now the filtering has been moved here.