### PR TITLE
Ensure updates to `openFileVersion` data is not delayed

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -170,6 +170,7 @@ export async function activate(): Promise<void> {
     });
 
     disposables.push(vscode.workspace.onDidChangeConfiguration(onDidChangeSettings));
+    disposables.push(vscode.workspace.onDidChangeTextDocument(onDidChangeTextDocument));
     disposables.push(vscode.window.onDidChangeTextEditorVisibleRanges((e) => clients.ActiveClient.enqueue(async () => onDidChangeTextEditorVisibleRanges(e))));
     disposables.push(vscode.window.onDidChangeActiveTextEditor((e) => clients.ActiveClient.enqueue(async () => onDidChangeActiveTextEditor(e))));
     ui.didChangeActiveEditor(); // Handle already active documents (for non-cpp files that we don't register didOpen).
@@ -286,6 +287,11 @@ async function onDidChangeSettings(event: vscode.ConfigurationChangeEvent): Prom
             UpdateInsidersAccess();
         }
     }
+}
+
+async function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): Promise<void> {
+    const me: Client = clients.getClientFor(event.document.uri);
+    me.onDidChangeTextDocument(event);
 }
 
 let noActiveEditorTimeout: NodeJS.Timeout | undefined;

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -59,11 +59,7 @@ export function createProtocolFilter(): Middleware {
                 }
             }
         }),
-        didChange: async (textDocumentChangeEvent, sendMessage) => clients.ActiveClient.enqueue(async () => {
-            const me: Client = clients.getClientFor(textDocumentChangeEvent.document.uri);
-            me.onDidChangeTextDocument(textDocumentChangeEvent);
-            await sendMessage(textDocumentChangeEvent);
-        }),
+        didChange: invoke1,
         willSave: invoke1,
         willSaveWaitUntil: async (event, sendMessage) => {
             // await clients.ActiveClient.ready;


### PR DESCRIPTION
I have been occasionally seeing stale colorization get applied, immediately after making an edit.  I've repro'ed it with a complex TU, which takes some time to update, and noticed that it occurs quickly, as if stale results are being applied after an edit.  I haven't been able to find any issues with document version tracking in the native code.  I thought perhaps I could be seeing the result of: https://github.com/microsoft/vscode/issues/74094

What I think is going on here is that due to `onDidChangeTextDocument` being delivered from the protocolFilter, it's being delayed until any other messages in queue have been processed. Since we're considering the `openFileVersion` to be the authority on the 'current' state of open files, this delay seems like a bad thing.

This change moves delivery of `onDidChangeTextDocument` into an event handler, which should avoid the delay.