### PR TITLE
Enable #cpp for all users

### DIFF
--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -331,7 +331,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
         // Run deploy steps
         if (config.deploySteps && config.deploySteps.length !== 0) {
-            const codeVersion: number[] = vscode.version.split('.').map(num => parseInt(num, undefined));
+            const codeVersion: number[] = util.getVsCodeVersion();
             if ((util.isNumber(codeVersion[0]) && codeVersion[0] < 1) || (util.isNumber(codeVersion[0]) && codeVersion[0] === 1 && util.isNumber(codeVersion[1]) && codeVersion[1] < 69)) {
                 void logger.getOutputChannelLogger().showErrorMessage(localize("vs.code.1.69+.required", "'deploySteps' require VS Code 1.69+."));
                 return undefined;

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -252,9 +252,14 @@ export async function activate(): Promise<void> {
         activeDocument = activeEditor.document;
     }
 
-    if (util.extensionContext && new CppSettings().experimentalFeatures) {
-        const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool());
-        disposables.push(tool);
+    if (util.extensionContext) {
+        // lmTools wasn't stabilized until 1.95, but (as of October 2024)
+        // cpptools can be installed on versions of VS Code as old as 1.67.
+        const version = util.getVsCodeVersion();
+        if (version[0] > 1 || (version[0] === 1 && version[1] >= 95)) {
+            const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool());
+            disposables.push(tool);
+        }
     }
 
     await registerRelatedFilesProvider();

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -254,7 +254,8 @@ export async function activate(): Promise<void> {
 
     if (util.extensionContext) {
         // lmTools wasn't stabilized until 1.95, but (as of October 2024)
-        // cpptools can be installed on versions of VS Code as old as 1.67.
+        // cpptools can be installed on older versions of VS Code. See
+        // https://github.com/microsoft/vscode-cpptools/blob/main/Extension/package.json#L14
         const version = util.getVsCodeVersion();
         if (version[0] > 1 || (version[0] === 1 && version[1] >= 95)) {
             const tool = vscode.lm.registerTool('cpptools-lmtool-configuration', new CppConfigurationLanguageModelTool());

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1814,3 +1814,7 @@ export function findExePathInArgs(args: CommandString[]): string | undefined {
 
     return undefined;
 }
+
+export function getVsCodeVersion(): number[] {
+    return vscode.version.split('.').map(num => parseInt(num, undefined));
+}


### PR DESCRIPTION
VS Code 1.95 has now shipped, and it includes the stabilization of the lmTools API. https://code.visualstudio.com/updates/v1_95#_tools-for-language-models

cc @microsoft/cpp-copilot 