### PR TITLE
Switch to @vscode/dts.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6511,7 +6511,7 @@
         "translations-generate": "set NODE_OPTIONS=--no-experimental-fetch && gulp translations-generate",
         "translations-import": "gulp translations-import",
         "import-edge-strings": "ts-node -T ./.scripts/import_edge_strings.ts",
-        "prep:dts": "yarn verify dts --quiet || (npx vscode-dts dev && npx vscode-dts main)",
+        "prep:dts": "yarn verify dts --quiet || (npx @vscode/dts dev && npx @vscode/dts main)",
         "build": "yarn prep:dts && echo [Building TypeScript code] && tsc --build tsconfig.json"
     },
     "devDependencies": {


### PR DESCRIPTION
Fixes warning `npm warn deprecated vscode-dts@0.3.3: vscode-dts has been renamed to @vscode/dts. Install using @vscode/dts instead.`

I queued a dogfood vsix and verified the warning is fixed.