### PR TITLE
Fix issue with requests in protocolFilter.ts causing stalls

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -18,14 +18,8 @@ export const ServerCancelled: number = -32802;
 let anyFileOpened: boolean = false;
 
 export function createProtocolFilter(): Middleware {
-    // Disabling lint for invoke handlers
-    const invoke1 = (a: any, next: (a: any) => any): any => clients.ActiveClient.enqueue(() => next(a));
-    const invoke2 = (a: any, b: any, next: (a: any, b: any) => any): any => clients.ActiveClient.enqueue(() => next(a, b));
-    const invoke3 = (a: any, b: any, c: any, next: (a: any, b: any, c: any) => any): any => clients.ActiveClient.enqueue(() => next(a, b, c));
-    const invoke4 = (a: any, b: any, c: any, d: any, next: (a: any, b: any, c: any, d: any) => any): any => clients.ActiveClient.enqueue(() => next(a, b, c, d));
-
     return {
-        didOpen: async (document, sendMessage) => clients.ActiveClient.enqueue(async () => {
+        didOpen: async (document, sendMessage) => {
             if (!util.isCpp(document)) {
                 return;
             }
@@ -41,62 +35,41 @@ export function createProtocolFilter(): Middleware {
                         const mappingString: string = baseFileName + "@" + document.fileName;
                         client.addFileAssociations(mappingString, "cpp");
                         client.sendDidChangeSettings();
-                        document = await vscode.languages.setTextDocumentLanguage(document, "cpp");
+                        // This will cause the file to be closed and reopened.
+                        vscode.languages.setTextDocumentLanguage(document, "cpp");
+                        return;
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.onDidOpenTextDocument(document);
                     client.takeOwnership(document);
-                    await sendMessage(document);
-
-                    // For a file already open when we activate, sometimes we don't get any notifications about visible
-                    // or active text editors, visible ranges, or text selection. As a workaround, we trigger
-                    // onDidChangeVisibleTextEditors here, only for the first file opened.
-                    if (!anyFileOpened) {
-                        anyFileOpened = true;
-                        const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-                        await client.onDidChangeVisibleTextEditors(cppEditors);
-                    }
+                    sendMessage(document).then(() => {
+                        // For a file already open when we activate, sometimes we don't get any notifications about visible
+                        // or active text editors, visible ranges, or text selection. As a workaround, we trigger
+                        // onDidChangeVisibleTextEditors here, only for the first file opened.
+                        if (!anyFileOpened) {
+                            anyFileOpened = true;
+                            const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
+                            client.onDidChangeVisibleTextEditors(cppEditors);
+                        }
+                    });
                 }
             }
-        }),
-        didChange: invoke1,
-        willSave: invoke1,
+        },
         willSaveWaitUntil: async (event, sendMessage) => {
-            // await clients.ActiveClient.ready;
-            // Don't use awaitUntilLanguageClientReady.
-            // Otherwise, the message can be delayed too long.
             const me: Client = clients.getClientFor(event.document.uri);
             if (me.TrackedDocuments.has(event.document.uri.toString())) {
                 return sendMessage(event);
             }
             return [];
         },
-        didSave: invoke1,
-        didClose: async (document, sendMessage) => clients.ActiveClient.enqueue(async () => {
+        didClose: async (document, sendMessage) => {
             const me: Client = clients.getClientFor(document.uri);
             const uriString: string = document.uri.toString();
             if (me.TrackedDocuments.has(uriString)) {
                 me.onDidCloseTextDocument(document);
                 me.TrackedDocuments.delete(uriString);
-                await sendMessage(document);
+                sendMessage(document);
             }
-        }),
-        provideCompletionItem: invoke4,
-        resolveCompletionItem: invoke2,
-        provideHover: async (document, position, token, next: (document: any, position: any, token: any) => any) => clients.ActiveClient.enqueue(async () => {
-            const me: Client = clients.getClientFor(document.uri);
-            if (me.TrackedDocuments.has(document.uri.toString())) {
-                return next(document, position, token);
-            }
-            return null;
-        }),
-        provideSignatureHelp: invoke4,
-        provideDefinition: invoke3,
-        provideReferences: invoke4,
-        provideDocumentHighlights: invoke3,
-        provideDeclaration: invoke3,
-        workspace: {
-            didChangeConfiguration: invoke1
-        }
+        },
     };
 }


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-cpptools/issues/12905

I managed basically remove the need to do any awaiting in protocolFilter.ts, making it unnecessary to ensure the messages are otherwise kept in sequence.  It looks like not specifying a filter at all does not cause VS Code to await responses to requests before processing the next message.