### PR TITLE
Reduce amount of (un-needed) changed compile_commands.json events

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2022,9 +2022,13 @@ export class DefaultClient implements Client {
             }
             const provider: CustomConfigurationProvider1 | undefined = getCustomConfigProviders().get(providerId);
             if (!provider || !provider.isReady) {
+                this.configuration.configurationProviderFailed();
                 return;
             }
             const resultCode = await this.provideCustomConfigurationAsync(docUri, provider);
+            if (resultCode !== "success") {
+                this.configuration.configurationProviderFailed();
+            }
             telemetry.logLanguageServerEvent('provideCustomConfiguration', { providerId, resultCode });
         } finally {
             onFinished();
@@ -2039,9 +2043,6 @@ export class DefaultClient implements Client {
         const provideConfigurationAsync: () => Thenable<SourceFileConfigurationItem[] | undefined> = async () => {
             try {
                 if (!await provider.canProvideConfiguration(docUri, tokenSource.token)) {
-                    // some file cannot be provided by this provider
-                    // e.g file not included in a CMake project
-                    this.configuration.configurationProviderFailed();
                     return [];
                 }
             } catch (err) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2039,9 +2039,9 @@ export class DefaultClient implements Client {
         const provideConfigurationAsync: () => Thenable<SourceFileConfigurationItem[] | undefined> = async () => {
             try {
                 if (!await provider.canProvideConfiguration(docUri, tokenSource.token)) {
-                    const forceCheck: boolean = true;
-                    this.configuration.checkCompileCommands(forceCheck);
-                    console.log("provideCustomConfigurationAsync(): Provider cannot provide configuration for: ", docUri.path);
+                    // some file cannot be provided by this provider
+                    // e.g file not included in a CMake project
+                    this.configuration.configurationProviderFailed();
                     return [];
                 }
             } catch (err) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2039,6 +2039,9 @@ export class DefaultClient implements Client {
         const provideConfigurationAsync: () => Thenable<SourceFileConfigurationItem[] | undefined> = async () => {
             try {
                 if (!await provider.canProvideConfiguration(docUri, tokenSource.token)) {
+                    const forceCheck: boolean = true;
+                    this.configuration.checkCompileCommands(forceCheck);
+                    console.log("provideCustomConfigurationAsync(): Provider cannot provide configuration for: ", docUri.path);
                     return [];
                 }
             } catch (err) {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1119,9 +1119,9 @@ export class CppProperties {
         this.compileCommandsFileWatcher?.close();
         this.compileCommandsFileWatcher = undefined;
 
-        // check if the current configuration is using a configuration provider (e.g `CMake Tools`)
-        // if so, avoid setting up a `compile_commands.json` file watcher to avoid unnessary parsing
-        // by the language server
+        // Check if the current configuration is using a configuration provider. (e.g `CMake Tools`)
+        // If so, avoid setting up a `compile_commands.json` file watcher to avoid unnessary parsing
+        // by the language server.
         if (this.CurrentConfiguration?.configurationProvider && !this.configurationProviderFailedToProvide) {
             return;
         }
@@ -1136,9 +1136,9 @@ export class CppProperties {
                     clearInterval(this.compileCommandsFileWatcherTimer);
                     this.compileCommandsFileWatcherTimer = undefined;
 
-                    // if the file was deleted/renamed,
-                    // linux based systems lose track of the file (inode deleted)
-                    // we need to close the watcher and wait until file is created again
+                    // If the file was deleted/renamed,
+                    // Linux based systems lose track of the file. (inode deleted)
+                    // We need to close the watcher and wait until file is created again.
                     if (eventType === "rename") {
                         this.compileCommandsFileWatcher?.close();
                         this.compileCommandsFileWatcher = undefined;
@@ -1148,9 +1148,9 @@ export class CppProperties {
             });
         }
         catch (e: any) {
-            // either file not created or too many watchers
-            // rely on polling until the file is created
-            // then, file watching will be attempted again
+            // Either file not created or too many active watchers.
+            // Rely on polling until the file is created.
+            // Then, file watching will be attempted again.
             this.compileCommandsFileWatcher?.close();
             this.compileCommandsFileWatcher = undefined;
         }
@@ -2302,8 +2302,10 @@ export class CppProperties {
     }
 
     /**
-     * if `configurationProvider` is set, we don't watch for changes in the `compileCommands` file.
-     * calling this function means we need to start checking it.
+     * Configuration provider failed to provide for some file.
+     * This is used to determine if we should start watching for changes in the `compileCommands` file.
+     *
+     * NOTE: This is only used when `configurationProvider` is set.
      */
     public configurationProviderFailed(): void {
         this.configurationProviderFailedToProvide = true;
@@ -2313,9 +2315,9 @@ export class CppProperties {
      * Manually check for changes in the compileCommands file.
      *
      * NOTE: The check is skipped on any of the following terms:
-     * - There is an active `compile_commands.json` file watcher
-     * - The `configurationProvider` property is set and `configurationProviderFailed()` was not called
-     * - The `compileCommands` property is not set
+     * - There is an active `compile_commands.json` file watcher.
+     * - The `configurationProvider` property is set and `configurationProviderFailed()` was not called.
+     * - The `compileCommands` property is not set.
      */
     public checkCompileCommands(): void {
         if (this.compileCommandsFileWatcher !== undefined) {
@@ -2341,7 +2343,7 @@ export class CppProperties {
         catch (err: any) {
             if (err.code === "ENOENT" && this.compileCommandsFile) {
                 this.onCompileCommandsChanged(compileCommandsFile);
-                this.compileCommandsFile = undefined; // File deleted
+                this.compileCommandsFile = undefined; // File deleted.
             }
         }
 

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1128,7 +1128,7 @@ export class CppProperties {
 
         const path: string = this.resolvePath(this.CurrentConfiguration?.compileCommands);
         try {
-            this.compileCommandsFileWatcher = fs.watch(path, (eventType: fs.WatchEventType, filename: string | null) => {
+            this.compileCommandsFileWatcher = fs.watch(path, (eventType: fs.WatchEventType, _: string | null) => {
                 // Wait 1 second after a change to allow time for the write to finish.
                 clearInterval(this.compileCommandsFileWatcherTimer);
                 this.compileCommandsFileWatcherTimer = setTimeout(() => {
@@ -1136,7 +1136,7 @@ export class CppProperties {
                     clearInterval(this.compileCommandsFileWatcherTimer);
                     this.compileCommandsFileWatcherTimer = undefined;
 
-                    // if the file was deleted/renamed, 
+                    // if the file was deleted/renamed,
                     // linux based systems lose track of the file (inode deleted)
                     // we need to close the watcher and wait until file is created again
                     if (eventType === "rename") {
@@ -1145,7 +1145,7 @@ export class CppProperties {
                         this.compileCommandsFile = undefined;
                     }
                 }, 1000);
-            })
+            });
         }
         catch (e: any) {
             // either file not created or too many watchers
@@ -2301,9 +2301,8 @@ export class CppProperties {
         });
     }
 
-
     /**
-     * if `configurationProvider` is set, we don't watch for changes in the `compileCommands` file.  
+     * if `configurationProvider` is set, we don't watch for changes in the `compileCommands` file.
      * calling this function means we need to start checking it.
      */
     public configurationProviderFailed(): void {
@@ -2311,8 +2310,8 @@ export class CppProperties {
     }
 
     /**
-     * Manually check for changes in the compileCommands file.  
-     * 
+     * Manually check for changes in the compileCommands file.
+     *
      * NOTE: The check is skipped on any of the following terms:
      * - There is an active `compile_commands.json` file watcher
      * - The `configurationProvider` property is set and `configurationProviderFailed()` was not called


### PR DESCRIPTION
closes #12889  
Continuing on the discussion in #12911   
- only monitor the `compile_commands.json` file pointed by the current configuration.
  - a timestamp is saved for each `compile_commands.json` path to keep track when we last notified on it's change.
  - on configuration selection change, we stat the file and compare to the saved timestamp to check if it changed while we were using a different configuration index.
- avoid checking the `compile_commands.json` file (both by `fs.watcher` and periodically) if a Configuration Provider is set, until we are notified that some file cannot be provided by that provider.
  - for example, some source file is not part of a `CMakeLists.txt` and we use the `CMake Tools` as the provider.
- periodic checking is done only if the `compile_commands.json` file watcher is inactive.
  - the configured path to `compile_commands.json` doesn't exist.
  - exceeded allowed amount of watchers on linux.
- for having an expected behavior on linux systems, the file watcher is closed on 'rename' events.
- successful manual checking retries to set up the file watcher.

### Fixes that are byproducts of this PR:
1. `checkCompileCommands()` leaks open file watchers if the `compileCommands` file is deleted.
```ts
const compileCommandsFile: string | undefined = this.resolvePath(compileCommands);
fs.stat(compileCommandsFile, (err, stats) => {
    if (err) {
        if (err.code === "ENOENT" && this.compileCommandsFile) {
            this.compileCommandsFileWatchers = []; // reset file watchers <- leak here
            this.onCompileCommandsChanged(compileCommandsFile);
            this.compileCommandsFile = null; // File deleted
        }
```
2. due to the nature of the fallback function `checkCompileCommands()` only monitoring the current configuration's `compile_commands.json` with a single timestamp, we will not detect changes to a `compile_commands.json` on the following scenario:
   - we have more than 1 configuration, each one with a different path to a `compile_commands.json`.
   - the file watcher for the path in configuration `y` throwed an error. (for example if hit the `inotify` limit on Linux).
   - the file pointed by configuration `y` has changed while we were using configuration `x`. 
```ts
{
    "configurations": [
        {
            "name": "x",
            "compileCommands": "${workspaceFolder}/compile_commands_x.json"
        },
        {
            "name": "y",
            "compileCommands": "${workspaceFolder}/compile_commands_y.json"
        }
    ]
}
```