### PR TITLE
Fixes to compile commands file watchers fallback logic

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -138,7 +138,7 @@ export class CppProperties {
     private configFileWatcherFallbackTime: Date = new Date(); // Used when file watching fails.
     private compileCommandsFile: vscode.Uri | undefined | null = undefined;
     private compileCommandsFileWatchers: fs.FSWatcher[] = [];
-    private compileCommandsFileWatcherFallbackTime: Date = new Date(); // Used when file watching fails.
+    private compileCommandsFileWatcherFallbackTime: Map<string, Date> = new Map<string, Date>(); // Used when file watching fails.
     private defaultCompilerPath: string | null = null;
     private knownCompilers?: KnownCompiler[];
     private defaultCStandard: string | null = null;
@@ -1093,6 +1093,10 @@ export class CppProperties {
 
             if (configuration.compileCommands) {
                 configuration.compileCommands = this.resolvePath(configuration.compileCommands);
+                if (!this.compileCommandsFileWatcherFallbackTime.has(configuration.compileCommands)) {
+                    // Start tracking the fallback time for a new path.
+                    this.compileCommandsFileWatcherFallbackTime.set(configuration.compileCommands, new Date());
+                }
             }
 
             if (configuration.forcedInclude) {
@@ -1104,9 +1108,26 @@ export class CppProperties {
             }
         }
 
+        this.clearStaleCompileCommandsFileWatcherFallbackTimes();
         this.updateCompileCommandsFileWatchers();
         if (!this.configurationIncomplete) {
             this.onConfigurationsChanged();
+        }
+    }
+
+    private clearStaleCompileCommandsFileWatcherFallbackTimes(): void {
+        const trackedCompileCommandsPaths: Set<string> = new Set();
+        this.configurationJson?.configurations.forEach((config: Configuration) => {
+            const path = this.resolvePath(config.compileCommands);
+            if (path.length > 0) {
+                trackedCompileCommandsPaths.add(path);
+            }
+        });
+
+        for (const path of this.compileCommandsFileWatcherFallbackTime.keys()) {
+            if (!trackedCompileCommandsPaths.has(path)) {
+                this.compileCommandsFileWatcherFallbackTime.delete(path);
+            }
         }
     }
 
@@ -2308,6 +2329,7 @@ export class CppProperties {
             return;
         }
         const compileCommandsFile: string | undefined = this.resolvePath(compileCommands);
+        const compileCommandsLastChanged: Date | undefined = this.compileCommandsFileWatcherFallbackTime.get(compileCommandsFile);
         fs.stat(compileCommandsFile, (err, stats) => {
             if (err) {
                 if (err.code === "ENOENT" && this.compileCommandsFile) {
@@ -2316,8 +2338,8 @@ export class CppProperties {
                     this.onCompileCommandsChanged(compileCommandsFile);
                     this.compileCommandsFile = null; // File deleted
                 }
-            } else if (stats.mtime > this.compileCommandsFileWatcherFallbackTime) {
-                this.compileCommandsFileWatcherFallbackTime = new Date();
+            } else if (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged) {
+                this.compileCommandsFileWatcherFallbackTime.set(compileCommandsFile, new Date());
                 this.onCompileCommandsChanged(compileCommandsFile);
                 this.compileCommandsFile = vscode.Uri.file(compileCommandsFile); // File created.
             }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -2330,7 +2330,6 @@ export class CppProperties {
             return;
         }
         const compileCommandsFile: string | undefined = this.resolvePath(compileCommands);
-        const compileCommandsLastChanged: Date | undefined = this.compileCommandsFileWatcherFallbackTime.get(compileCommandsFile);
         fs.stat(compileCommandsFile, (err, stats) => {
             if (err) {
                 if (err.code === "ENOENT" && this.compileCommandsFile) {
@@ -2339,10 +2338,13 @@ export class CppProperties {
                     this.onCompileCommandsChanged(compileCommandsFile);
                     this.compileCommandsFile = null; // File deleted
                 }
-            } else if (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged) {
-                this.compileCommandsFileWatcherFallbackTime.set(compileCommandsFile, new Date());
-                this.onCompileCommandsChanged(compileCommandsFile);
-                this.compileCommandsFile = vscode.Uri.file(compileCommandsFile); // File created.
+            } else {
+                const compileCommandsLastChanged: Date | undefined = this.compileCommandsFileWatcherFallbackTime.get(compileCommandsFile);
+                if (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged) {
+                    this.compileCommandsFileWatcherFallbackTime.set(compileCommandsFile, new Date());
+                    this.onCompileCommandsChanged(compileCommandsFile);
+                    this.compileCommandsFile = vscode.Uri.file(compileCommandsFile); // File created.
+                }
             }
         });
     }

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1116,6 +1116,8 @@ export class CppProperties {
     }
 
     private clearStaleCompileCommandsFileWatcherFallbackTimes(): void {
+        // We need to keep track of relevant timestamps, so we cannot simply clear all entries.
+        // Instead, we clear entries that are no longer relevant.
         const trackedCompileCommandsPaths: Set<string> = new Set();
         this.configurationJson?.configurations.forEach((config: Configuration) => {
             const path = this.resolvePath(config.compileCommands);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1116,6 +1116,7 @@ export class CppProperties {
     // Dispose existing and loop through cpp and populate with each file (exists or not) as you go.
     // paths are expected to have variables resolved already
     public updateCompileCommandsFileWatchers(): void {
+        console.log("updating file watchers");
         if (this.configurationJson) {
             this.compileCommandsFileWatchers.forEach((watcher: fs.FSWatcher) => watcher.close());
             this.compileCommandsFileWatchers = []; // reset it
@@ -2310,6 +2311,7 @@ export class CppProperties {
         fs.stat(compileCommandsFile, (err, stats) => {
             if (err) {
                 if (err.code === "ENOENT" && this.compileCommandsFile) {
+                    this.compileCommandsFileWatchers.forEach((watcher: fs.FSWatcher) => watcher.close());
                     this.compileCommandsFileWatchers = []; // reset file watchers
                     this.onCompileCommandsChanged(compileCommandsFile);
                     this.compileCommandsFile = null; // File deleted

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1137,7 +1137,6 @@ export class CppProperties {
     // Dispose existing and loop through cpp and populate with each file (exists or not) as you go.
     // paths are expected to have variables resolved already
     public updateCompileCommandsFileWatchers(): void {
-        console.log("updating file watchers");
         if (this.configurationJson) {
             this.compileCommandsFileWatchers.forEach((watcher: fs.FSWatcher) => watcher.close());
             this.compileCommandsFileWatchers = []; // reset it


### PR DESCRIPTION
- closes #12946 
    - File watchers are closed before being disposed.
- closes #12947 
    - Changed the fallback timestamp `CppProperties.compileCommandsFileWatcherFallbackTime` to be a `Map<string, Date>` which keeps track of a timestamp per file instead of a single one.