### PR TITLE
Address issue with `Attempting to use languageClient before initialized`

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1285,6 +1285,12 @@ export class DefaultClient implements Client {
 
                 // Listen for messages from the language server.
                 this.registerNotifications();
+
+                // If a file is already open when we activate, sometimes we don't get any notifications about visible
+                // or active text editors, visible ranges, or text selection. As a workaround, we trigger
+                // onDidChangeVisibleTextEditors here.
+                const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
+                await this.onDidChangeVisibleTextEditors(cppEditors);
             }
 
             // update all client configurations
@@ -1604,12 +1610,6 @@ export class DefaultClient implements Client {
         // A request is used in order to wait for completion and ensure that no subsequent
         // higher priority message may be processed before the Initialization request.
         await languageClient.sendRequest(InitializationRequest, cppInitializationParams);
-
-        // If a file is already open when we activate, sometimes we don't get any notifications about visible
-        // or active text editors, visible ranges, or text selection. As a workaround, we trigger
-        // onDidChangeVisibleTextEditors here.
-        const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-        await this.onDidChangeVisibleTextEditors(cppEditors);
     }
 
     public async sendDidChangeSettings(): Promise<void> {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1604,6 +1604,12 @@ export class DefaultClient implements Client {
         // A request is used in order to wait for completion and ensure that no subsequent
         // higher priority message may be processed before the Initialization request.
         await languageClient.sendRequest(InitializationRequest, cppInitializationParams);
+
+        // If a file is already open when we activate, sometimes we don't get any notifications about visible
+        // or active text editors, visible ranges, or text selection. As a workaround, we trigger
+        // onDidChangeVisibleTextEditors here.
+        const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
+        await this.onDidChangeVisibleTextEditors(cppEditors);
     }
 
     public async sendDidChangeSettings(): Promise<void> {

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -8,15 +8,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { Middleware } from 'vscode-languageclient';
 import * as util from '../common';
-import { logAndReturn } from '../Utility/Async/returns';
 import { Client } from './client';
 import { clients } from './extension';
 import { shouldChangeFromCToCpp } from './utils';
 
 export const RequestCancelled: number = -32800;
 export const ServerCancelled: number = -32802;
-
-let anyFileOpened: boolean = false;
 
 export function createProtocolFilter(): Middleware {
     return {
@@ -43,16 +40,7 @@ export function createProtocolFilter(): Middleware {
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.onDidOpenTextDocument(document);
                     client.takeOwnership(document);
-                    void sendMessage(document).then(() => {
-                        // For a file already open when we activate, sometimes we don't get any notifications about visible
-                        // or active text editors, visible ranges, or text selection. As a workaround, we trigger
-                        // onDidChangeVisibleTextEditors here, only for the first file opened.
-                        if (!anyFileOpened) {
-                            anyFileOpened = true;
-                            const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-                            client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
-                        }
-                    });
+                    void sendMessage(document);
                 }
             }
         },


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/12954

It looks like VS Code is trying to send us a `didOpen`, which is cause by our protocolFilter, before returning from `languageClient.start` (before we've set `this.innerLanguageClient`).

This moves the code that depends on `this.innerLanguageClient` to after that is set.