### PR TITLE
Support Compiler Argument Trait AB Experiment

### DIFF
--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -5,9 +5,13 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import { localize } from 'vscode-nls';
 import * as util from '../common';
-import { ChatContextResult, GetIncludesResult } from './client';
+import * as logger from '../logger';
+import * as telemetry from '../telemetry';
+import { GetIncludesResult } from './client';
 import { getActiveClient } from './extension';
+import { getCompilerArgumentFilterMap, getProjectContext } from './lmTool';
 
 export interface CopilotTrait {
     name: string;
@@ -34,35 +38,113 @@ export async function registerRelatedFilesProvider(): Promise<void> {
             for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
                 api.registerRelatedFilesProvider(
                     { extensionId: util.extensionContext.extension.id, languageId },
-                    async (_uri: vscode.Uri, context: { flags: Record<string, unknown> }, token: vscode.CancellationToken) => {
+                    async (uri: vscode.Uri, context: { flags: Record<string, unknown> }, token: vscode.CancellationToken) => {
+                        const start = performance.now();
+                        const telemetryProperties: Record<string, string> = {};
+                        const telemetryMetrics: Record<string, number> = {};
+                        try {
+                            const getIncludesHandler = async () => (await getIncludesWithCancellation(1, token))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [];
+                            const getTraitsHandler = async () => {
+                                const projectContext = await getProjectContext(uri, context, token);
 
-                        const getIncludesHandler = async () => (await getIncludesWithCancellation(1, token))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [];
-                        const getTraitsHandler = async () => {
-                            const chatContext: ChatContextResult | undefined = await (getActiveClient().getChatContext(token) ?? undefined);
+                                if (!projectContext) {
+                                    return undefined;
+                                }
 
-                            if (!chatContext) {
-                                return undefined;
+                                let traits: CopilotTrait[] = [
+                                    { name: "intelliSenseDisclaimer", value: '', includeInPrompt: true, promptTextOverride: `IntelliSense is currently configured with the following compiler information. It reflects the active configuration, and the project may have more configurations targeting different platforms.` },
+                                    { name: "intelliSenseDisclaimerBeginning", value: '', includeInPrompt: true, promptTextOverride: `Beginning of IntelliSense information.` }
+                                ];
+                                if (projectContext.language) {
+                                    traits.push({ name: "language", value: projectContext.language, includeInPrompt: true, promptTextOverride: `The language is ${projectContext.language}.` });
+                                }
+                                if (projectContext.compiler) {
+                                    traits.push({ name: "compiler", value: projectContext.compiler, includeInPrompt: true, promptTextOverride: `This project compiles using ${projectContext.compiler}.` });
+                                }
+                                if (projectContext.standardVersion) {
+                                    traits.push({ name: "standardVersion", value: projectContext.standardVersion, includeInPrompt: true, promptTextOverride: `This project uses the ${projectContext.standardVersion} language standard.` });
+                                }
+                                if (projectContext.targetPlatform) {
+                                    traits.push({ name: "targetPlatform", value: projectContext.targetPlatform, includeInPrompt: true, promptTextOverride: `This build targets ${projectContext.targetPlatform}.` });
+                                }
+                                if (projectContext.targetArchitecture) {
+                                    traits.push({ name: "targetArchitecture", value: projectContext.targetArchitecture, includeInPrompt: true, promptTextOverride: `This build targets ${projectContext.targetArchitecture}.` });
+                                }
+
+                                if (projectContext.compiler) {
+                                    // We will process compiler arguments based on copilotcppXXXCompilerArgumentFilters and copilotcppCompilerArgumentDirectAskMap feature flags.
+                                    // The copilotcppXXXCompilerArgumentFilters are maps. The keys are regex strings for filtering and the values, if not empty,
+                                    // are the prompt text to use when no arguments are found.
+                                    // copilotcppCompilerArgumentDirectAskMap map individual matched argument to a prompt text.
+                                    // For duplicate matches, the last one will be used.
+                                    const filterMap = getCompilerArgumentFilterMap(projectContext.compiler, context);
+                                    if (filterMap !== undefined) {
+                                        const directAskMap: Record<string, string> = context.flags.copilotcppCompilerArgumentDirectAskMap ? JSON.parse(context.flags.copilotcppCompilerArgumentDirectAskMap as string) : {};
+                                        let directAsks: string = '';
+                                        const remainingArguments: string[] = [];
+
+                                        for (const key in filterMap) {
+                                            if (!key) {
+                                                continue;
+                                            }
+
+                                            const matchedArgument = projectContext.compilerArguments[key] as string;
+                                            if (matchedArgument?.length > 0) {
+                                                if (directAskMap[matchedArgument]) {
+                                                    directAsks += `${directAskMap[matchedArgument]} `;
+                                                } else {
+                                                    remainingArguments.push(matchedArgument);
+                                                }
+                                            } else if (filterMap[key]) {
+                                                // Use the prompt text in the absence of argument.
+                                                directAsks += `${filterMap[key]} `;
+                                            }
+                                        }
+
+                                        if (remainingArguments.length > 0) {
+                                            const compilerArgumentsValue = remainingArguments.join(", ");
+                                            traits.push({ name: "compilerArguments", value: compilerArgumentsValue, includeInPrompt: true, promptTextOverride: `The compiler arguments include: ${compilerArgumentsValue}.` });
+                                        }
+
+                                        if (directAsks) {
+                                            traits.push({ name: "directAsks", value: directAsks, includeInPrompt: true, promptTextOverride: directAsks });
+                                        }
+                                    }
+                                }
+
+                                traits.push({ name: "intelliSenseDisclaimerEnd", value: '', includeInPrompt: true, promptTextOverride: `End of IntelliSense information.` });
+
+                                const includeTraitsArray = context.flags.copilotcppIncludeTraits ? context.flags.copilotcppIncludeTraits as string[] : [];
+                                const includeTraits = new Set(includeTraitsArray);
+                                telemetryProperties["includeTraits"] = includeTraitsArray.join(',');
+
+                                // standardVersion trait is enabled by default.
+                                traits = traits.filter(trait => includeTraits.has(trait.name) || trait.name === 'standardVersion');
+
+                                telemetryProperties["traits"] = traits.map(trait => trait.name).join(',');
+                                return traits.length > 0 ? traits : undefined;
+                            };
+
+                            // Call both handlers in parallel
+                            const traitsPromise = getTraitsHandler();
+                            const includesPromise = getIncludesHandler();
+
+                            return { entries: await includesPromise, traits: await traitsPromise };
+                        }
+                        catch (exception) {
+                            try {
+                                const err: Error = exception as Error;
+                                logger.getOutputChannelLogger().appendLine(localize("copilot.relatedfilesprovider.error", "Error while retrieving result. Reason: {0}", err.message));
                             }
-
-                            let traits: CopilotTrait[] = [
-                                { name: "language", value: chatContext.language, includeInPrompt: true, promptTextOverride: `The language is ${chatContext.language}.` },
-                                { name: "compiler", value: chatContext.compiler, includeInPrompt: true, promptTextOverride: `This project compiles using ${chatContext.compiler}.` },
-                                { name: "standardVersion", value: chatContext.standardVersion, includeInPrompt: true, promptTextOverride: `This project uses the ${chatContext.standardVersion} language standard.` },
-                                { name: "targetPlatform", value: chatContext.targetPlatform, includeInPrompt: true, promptTextOverride: `This build targets ${chatContext.targetPlatform}.` },
-                                { name: "targetArchitecture", value: chatContext.targetArchitecture, includeInPrompt: true, promptTextOverride: `This build targets ${chatContext.targetArchitecture}.` }
-                            ];
-
-                            const excludeTraits = context.flags.copilotcppExcludeTraits as string[] ?? [];
-                            traits = traits.filter(trait => !excludeTraits.includes(trait.name));
-
-                            return traits.length > 0 ? traits : undefined;
-                        };
-
-                        // Call both handlers in parallel
-                        const traitsPromise = ((context.flags.copilotcppTraits as boolean) ?? false) ? getTraitsHandler() : Promise.resolve(undefined);
-                        const includesPromise = getIncludesHandler();
-
-                        return { entries: await includesPromise, traits: await traitsPromise };
+                            catch {
+                                // Intentionally swallow any exception.
+                            }
+                            telemetryProperties["error"] = "true";
+                            throw exception; // Throw the exception for auto-retry.
+                        } finally {
+                            telemetryMetrics['duration'] = performance.now() - start;
+                            telemetry.logCopilotEvent('RelatedFilesProvider', telemetryProperties, telemetryMetrics);
+                        }
                     }
                 );
             }

--- a/Extension/src/LanguageServer/lmTool.ts
+++ b/Extension/src/LanguageServer/lmTool.ts
@@ -9,9 +9,13 @@ import { localize } from 'vscode-nls';
 import * as util from '../common';
 import * as logger from '../logger';
 import * as telemetry from '../telemetry';
-import { ChatContextResult } from './client';
+import { ChatContextResult, ProjectContextResult } from './client';
 import { getClients } from './extension';
+import { checkDuration } from './utils';
 
+const MSVC: string = 'MSVC';
+const Clang: string = 'Clang';
+const GCC: string = 'GCC';
 const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: string } } = {
     language: {
         'c': 'C',
@@ -19,9 +23,9 @@ const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: str
         'cuda-cpp': 'CUDA C++'
     },
     compiler: {
-        'msvc': 'MSVC',
-        'clang': 'Clang',
-        'gcc': 'GCC'
+        'msvc': MSVC,
+        'clang': Clang,
+        'gcc': GCC
     },
     standardVersion: {
         'c++98': 'C++98',
@@ -44,6 +48,141 @@ const knownValues: { [Property in keyof ChatContextResult]?: { [id: string]: str
     }
 };
 
+function formatChatContext(context: ChatContextResult | ProjectContextResult): void {
+    type KnownKeys = 'language' | 'standardVersion' | 'compiler' | 'targetPlatform';
+    for (const key in knownValues) {
+        const knownKey = key as KnownKeys;
+        if (knownValues[knownKey] && context[knownKey]) {
+            // Clear the value if it's not in the known values.
+            context[knownKey] = knownValues[knownKey][context[knownKey]] || "";
+        }
+    }
+}
+
+export interface ProjectContext {
+    language: string;
+    standardVersion: string;
+    compiler: string;
+    targetPlatform: string;
+    targetArchitecture: string;
+    compilerArguments: Record<string, string>;
+}
+
+export function getCompilerArgumentFilterMap(compiler: string, context: { flags: Record<string, unknown> }): Record<string, string> | undefined {
+    // The copilotcppXXXCompilerArgumentFilters are maps.
+    // The keys are regex strings and the values, if not empty, are the prompt text to use when no arguments are found.
+    let filterMap: Record<string, string> | undefined;
+    try {
+        switch (compiler) {
+            case MSVC:
+                if (context.flags.copilotcppMsvcCompilerArgumentFilter !== undefined) {
+                    filterMap = JSON.parse(context.flags.copilotcppMsvcCompilerArgumentFilter as string);
+                }
+                break;
+            case Clang:
+                if (context.flags.copilotcppClangCompilerArgumentFilter !== undefined) {
+                    filterMap = JSON.parse(context.flags.copilotcppClangCompilerArgumentFilter as string);
+                }
+                break;
+            case GCC:
+                if (context.flags.copilotcppGccCompilerArgumentFilter !== undefined) {
+                    filterMap = JSON.parse(context.flags.copilotcppGccCompilerArgumentFilter as string);
+                }
+                break;
+        }
+    }
+    catch {
+        // Intentionally swallow any exception.
+    }
+    return filterMap;
+}
+
+function filterCompilerArguments(compiler: string, compilerArguments: string[], context: { flags: Record<string, unknown> }, telemetryProperties: Record<string, string>): Record<string, string> {
+    const filterMap = getCompilerArgumentFilterMap(compiler, context);
+    if (filterMap === undefined) {
+        return {};
+    }
+
+    const combinedArguments = compilerArguments.join(' ');
+    const result: Record<string, string> = {};
+    const filteredCompilerArguments: string[] = [];
+    for (const key in filterMap) {
+        if (!key) {
+            continue;
+        }
+        const filter = new RegExp(key, 'g');
+        const filtered = combinedArguments.match(filter);
+        if (filtered) {
+            filteredCompilerArguments.push(...filtered);
+            result[key] = filtered[filtered.length - 1];
+        }
+    }
+
+    if (filteredCompilerArguments.length > 0) {
+        // Telemetry to learn about the argument distribution. The filtered arguments are expected to be non-PII.
+        telemetryProperties["filteredCompilerArguments"] = filteredCompilerArguments.join(',');
+        telemetryProperties["filters"] = Object.keys(filterMap).filter(filter => !!filter).join(',');
+    }
+
+    return result;
+}
+
+export async function getProjectContext(uri: vscode.Uri, context: { flags: Record<string, unknown> }, token: vscode.CancellationToken): Promise<ProjectContext | undefined> {
+    const telemetryProperties: Record<string, string> = {};
+    const telemetryMetrics: Record<string, number> = {};
+    try {
+        const projectContext = await checkDuration<ProjectContextResult | undefined>(async () => await getClients()?.ActiveClient?.getProjectContext(uri, token) ?? undefined);
+        telemetryMetrics["duration"] = projectContext.duration;
+        if (!projectContext.result) {
+            return undefined;
+        }
+
+        formatChatContext(projectContext.result);
+
+        const result: ProjectContext = {
+            language: projectContext.result.language,
+            standardVersion: projectContext.result.standardVersion,
+            compiler: projectContext.result.compiler,
+            targetPlatform: projectContext.result.targetPlatform,
+            targetArchitecture: projectContext.result.targetArchitecture,
+            compilerArguments: {}
+        };
+
+        if (projectContext.result.language) {
+            telemetryProperties["language"] = projectContext.result.language;
+        }
+        if (projectContext.result.compiler) {
+            telemetryProperties["compiler"] = projectContext.result.compiler;
+        }
+        if (projectContext.result.standardVersion) {
+            telemetryProperties["standardVersion"] = projectContext.result.standardVersion;
+        }
+        if (projectContext.result.targetPlatform) {
+            telemetryProperties["targetPlatform"] = projectContext.result.targetPlatform;
+        }
+        if (projectContext.result.targetArchitecture) {
+            telemetryProperties["targetArchitecture"] = projectContext.result.targetArchitecture;
+        }
+        telemetryMetrics["compilerArgumentCount"] = projectContext.result.fileContext.compilerArguments.length;
+        result.compilerArguments = filterCompilerArguments(projectContext.result.compiler, projectContext.result.fileContext.compilerArguments, context, telemetryProperties);
+
+        return result;
+    }
+    catch (exception) {
+        try {
+            const err: Error = exception as Error;
+            logger.getOutputChannelLogger().appendLine(localize("copilot.projectcontext.error", "Error while retrieving the project context. Reason: {0}", err.message));
+        }
+        catch {
+            // Intentionally swallow any exception.
+        }
+        telemetryProperties["error"] = "true";
+        return undefined;
+    } finally {
+        telemetry.logCopilotEvent('ProjectContext', telemetryProperties, telemetryMetrics);
+    }
+}
+
 export class CppConfigurationLanguageModelTool implements vscode.LanguageModelTool<void> {
     public async invoke(options: vscode.LanguageModelToolInvocationOptions<void>, token: vscode.CancellationToken): Promise<vscode.LanguageModelToolResult> {
         return new vscode.LanguageModelToolResult([
@@ -58,18 +197,12 @@ export class CppConfigurationLanguageModelTool implements vscode.LanguageModelTo
                 return 'The active document is not a C, C++, or CUDA file.';
             }
 
-            const chatContext: ChatContextResult | undefined = await (getClients()?.ActiveClient?.getChatContext(token) ?? undefined);
+            const chatContext: ChatContextResult | undefined = await (getClients()?.ActiveClient?.getChatContext(currentDoc.uri, token) ?? undefined);
             if (!chatContext) {
                 return 'No configuration information is available for the active document.';
             }
 
-            for (const key in knownValues) {
-                const knownKey = key as keyof ChatContextResult;
-                if (knownValues[knownKey] && chatContext[knownKey]) {
-                    // Clear the value if it's not in the known values.
-                    chatContext[knownKey] = knownValues[knownKey][chatContext[knownKey]] || "";
-                }
-            }
+            formatChatContext(chatContext);
 
             let contextString = "";
             if (chatContext.language) {
@@ -100,7 +233,7 @@ export class CppConfigurationLanguageModelTool implements vscode.LanguageModelTo
             telemetryProperties["error"] = "true";
             return "";
         } finally {
-            telemetry.logLanguageModelToolEvent('cpp', telemetryProperties);
+            telemetry.logCopilotEvent('Chat/Tool/cpp', telemetryProperties);
         }
     }
 

--- a/Extension/src/LanguageServer/utils.ts
+++ b/Extension/src/LanguageServer/utils.ts
@@ -112,3 +112,9 @@ export async function withCancellation<T>(promise: Promise<T>, token: vscode.Can
         });
     });
 }
+
+export async function checkDuration<T>(fn: () => Promise<T>): Promise<{ result: T; duration: number }> {
+    const start = performance.now();
+    const result = await fn();
+    return { result, duration: performance.now() - start };
+}

--- a/Extension/src/telemetry.ts
+++ b/Extension/src/telemetry.ts
@@ -123,10 +123,10 @@ export function logLanguageServerEvent(eventName: string, properties?: Record<st
     sendTelemetry();
 }
 
-export function logLanguageModelToolEvent(eventName: string, properties?: Record<string, string>, metrics?: Record<string, number>): void {
+export function logCopilotEvent(eventName: string, properties?: Record<string, string>, metrics?: Record<string, number>): void {
     const sendTelemetry = () => {
         if (experimentationTelemetry) {
-            const eventNamePrefix: string = "C_Cpp/Copilot/Chat/Tool/";
+            const eventNamePrefix: string = "C_Cpp/Copilot/";
             experimentationTelemetry.sendTelemetryEvent(eventNamePrefix + eventName, properties, metrics);
         }
     };

--- a/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
@@ -1,0 +1,388 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { ok } from 'assert';
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as util from '../../../../src/common';
+import { ChatContextResult, DefaultClient, ProjectContextResult } from '../../../../src/LanguageServer/client';
+import { ClientCollection } from '../../../../src/LanguageServer/clientCollection';
+import * as extension from '../../../../src/LanguageServer/extension';
+import { CppConfigurationLanguageModelTool, getProjectContext } from '../../../../src/LanguageServer/lmTool';
+import * as telemetry from '../../../../src/telemetry';
+
+describe('CppConfigurationLanguageModelTool Tests', () => {
+    let mockLanguageModelToolInvocationOptions: sinon.SinonStubbedInstance<vscode.LanguageModelToolInvocationOptions<void>>;
+    let activeClientStub: sinon.SinonStubbedInstance<DefaultClient>;
+    let mockTextEditorStub: MockTextEditor;
+    let mockTextDocumentStub: sinon.SinonStubbedInstance<vscode.TextDocument>;
+    let telemetryStub: sinon.SinonStub;
+
+    class MockLanguageModelToolInvocationOptions implements vscode.LanguageModelToolInvocationOptions<void> {
+        tokenizationOptions?: vscode.LanguageModelToolTokenizationOptions | undefined;
+        toolInvocationToken: undefined;
+        input: undefined;
+    }
+    class MockTextEditor implements vscode.TextEditor {
+        constructor(selection: vscode.Selection, selections: readonly vscode.Selection[], visibleRanges: readonly vscode.Range[], options: vscode.TextEditorOptions, document: vscode.TextDocument, viewColumn?: vscode.ViewColumn) {
+            this.selection = selection;
+            this.selections = selections;
+            this.visibleRanges = visibleRanges;
+            this.options = options;
+            this.viewColumn = viewColumn;
+            this.document = document;
+        }
+        selection: vscode.Selection;
+        selections: readonly vscode.Selection[];
+        visibleRanges: readonly vscode.Range[];
+        options: vscode.TextEditorOptions;
+        viewColumn: vscode.ViewColumn | undefined;
+        edit(_callback: (editBuilder: vscode.TextEditorEdit) => void, _options?: { readonly undoStopBefore: boolean; readonly undoStopAfter: boolean }): Thenable<boolean> {
+            throw new Error('Method not implemented.');
+        }
+        insertSnippet(_snippet: vscode.SnippetString, _location?: vscode.Position | vscode.Range | readonly vscode.Position[] | readonly vscode.Range[], _options?: { readonly undoStopBefore: boolean; readonly undoStopAfter: boolean }): Thenable<boolean> {
+            throw new Error('Method not implemented.');
+        }
+        setDecorations(_decorationType: vscode.TextEditorDecorationType, _rangesOrOptions: readonly vscode.Range[] | readonly vscode.DecorationOptions[]): void {
+            throw new Error('Method not implemented.');
+        }
+        revealRange(_range: vscode.Range, _revealType?: vscode.TextEditorRevealType): void {
+            throw new Error('Method not implemented.');
+        }
+        show(_column?: vscode.ViewColumn): void {
+            throw new Error('Method not implemented.');
+        }
+        hide(): void {
+            throw new Error('Method not implemented.');
+        }
+        document: vscode.TextDocument;
+    }
+    class MockTextDocument implements vscode.TextDocument {
+        uri: vscode.Uri;
+        constructor(uri: vscode.Uri, fileName: string, isUntitled: boolean, languageId: string, version: number, isDirty: boolean, isClosed: boolean, eol: vscode.EndOfLine, lineCount: number) {
+            this.uri = uri;
+            this.fileName = fileName;
+            this.isUntitled = isUntitled;
+            this.languageId = languageId;
+            this.version = version;
+            this.isDirty = isDirty;
+            this.isClosed = isClosed;
+            this.eol = eol;
+            this.lineCount = lineCount;
+        }
+        fileName: string;
+        isUntitled: boolean;
+        languageId: string;
+        version: number;
+        isDirty: boolean;
+        isClosed: boolean;
+        save(): Thenable<boolean> {
+            throw new Error('Method not implemented.');
+        }
+        eol: vscode.EndOfLine;
+        lineCount: number;
+
+        lineAt(line: number): vscode.TextLine;
+        // eslint-disable-next-line @typescript-eslint/unified-signatures
+        lineAt(position: vscode.Position): vscode.TextLine;
+        lineAt(_arg: number | vscode.Position): vscode.TextLine {
+            throw new Error('Method not implemented.');
+        }
+        offsetAt(_position: vscode.Position): number {
+            throw new Error('Method not implemented.');
+        }
+        positionAt(_offset: number): vscode.Position {
+            throw new Error('Method not implemented.');
+        }
+        getText(_range?: vscode.Range): string {
+            throw new Error('Method not implemented.');
+        }
+        getWordRangeAtPosition(_position: vscode.Position, _regex?: RegExp): vscode.Range | undefined {
+            throw new Error('Method not implemented.');
+        }
+        validateRange(_range: vscode.Range): vscode.Range {
+            throw new Error('Method not implemented.');
+        }
+        validatePosition(_position: vscode.Position): vscode.Position {
+            throw new Error('Method not implemented.');
+        }
+    }
+    beforeEach(() => {
+        sinon.stub(util, 'extensionContext').value({ extension: { id: 'test-extension-id' } });
+
+        mockTextDocumentStub = sinon.createStubInstance(MockTextDocument);
+        mockTextEditorStub = new MockTextEditor(new vscode.Selection(0, 0, 0, 0), [], [], { tabSize: 4 }, mockTextDocumentStub);
+        mockLanguageModelToolInvocationOptions = new MockLanguageModelToolInvocationOptions();
+        activeClientStub = sinon.createStubInstance(DefaultClient);
+        const clientsStub = sinon.createStubInstance(ClientCollection);
+        sinon.stub(extension, 'getClients').returns(clientsStub);
+        sinon.stub(clientsStub, 'ActiveClient').get(() => activeClientStub);
+        activeClientStub.getIncludes.resolves({ includedFiles: [] });
+        sinon.stub(vscode.window, 'activeTextEditor').get(() => mockTextEditorStub);
+        telemetryStub = sinon.stub(telemetry, 'logCopilotEvent').returns();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const arrangeChatContextFromCppTools = ({ chatContextFromCppTools, isCpp, isHeaderFile }:
+    { chatContextFromCppTools?: ChatContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+    { chatContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+    ) => {
+        activeClientStub.getChatContext.resolves(chatContextFromCppTools);
+        sinon.stub(util, 'isCpp').returns(isCpp ?? true);
+        sinon.stub(util, 'isHeaderFile').returns(isHeaderFile ?? false);
+    };
+
+    const arrangeProjectContextFromCppTools = ({ projectContextFromCppTools, isCpp, isHeaderFile }:
+    { projectContextFromCppTools?: ProjectContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+    { projectContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+    ) => {
+        activeClientStub.getProjectContext.resolves(projectContextFromCppTools);
+        sinon.stub(util, 'isCpp').returns(isCpp ?? true);
+        sinon.stub(util, 'isHeaderFile').returns(isHeaderFile ?? false);
+    };
+
+    it('should log telemetry and provide #cpp chat context.', async () => {
+        arrangeChatContextFromCppTools({
+            chatContextFromCppTools: {
+                language: 'cpp',
+                standardVersion: 'c++20',
+                compiler: 'msvc',
+                targetPlatform: 'windows',
+                targetArchitecture: 'x64'
+            }
+        });
+
+        const result = await new CppConfigurationLanguageModelTool().invoke(mockLanguageModelToolInvocationOptions, new vscode.CancellationTokenSource().token);
+
+        ok(telemetryStub.calledOnce, 'Telemetry should be called once');
+        ok(telemetryStub.calledWithMatch('Chat/Tool/cpp', sinon.match({
+            "language": 'C++',
+            "compiler": 'MSVC',
+            "standardVersion": 'C++20',
+            "targetPlatform": 'Windows',
+            "targetArchitecture": 'x64'
+        })));
+        ok(result, 'result should not be undefined');
+        const text = result.content[0] as vscode.LanguageModelTextPart;
+        ok(text, 'result should contain a text part');
+        ok(text.value === 'The user is working on a C++ project. The project uses language version C++20. The project compiles using the MSVC compiler. The project targets the Windows platform. The project targets the x64 architecture. ');
+    });
+
+    const testGetProjectContext = async ({
+        compiler,
+        expectedCompiler,
+        context,
+        compilerArguments: compilerArguments,
+        expectedCompilerArguments
+    }: {
+        compiler: string;
+        expectedCompiler: string;
+        context: { flags: Record<string, unknown> };
+        compilerArguments: string[];
+        expectedCompilerArguments: Record<string, string>;
+    }) => {
+        arrangeProjectContextFromCppTools({
+            projectContextFromCppTools: {
+                language: 'cpp',
+                standardVersion: 'c++20',
+                compiler: compiler,
+                targetPlatform: 'windows',
+                targetArchitecture: 'x64',
+                fileContext: {
+                    compilerArguments: compilerArguments
+                }
+            }
+        });
+
+        const result = await getProjectContext(mockTextDocumentStub.uri, context, new vscode.CancellationTokenSource().token);
+
+        ok(result, 'result should not be undefined');
+        ok(result.language === 'C++');
+        ok(result.compiler === expectedCompiler);
+        ok(result.standardVersion === 'C++20');
+        ok(result.targetPlatform === 'Windows');
+        ok(result.targetArchitecture === 'x64');
+        ok(JSON.stringify(result.compilerArguments) === JSON.stringify(expectedCompilerArguments));
+    };
+
+    it('should provide compilerArguments based on copilotcppMsvcCompilerArgumentFilter.', async () => {
+        await testGetProjectContext({
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: { flags: { copilotcppMsvcCompilerArgumentFilter: '{"foo-?": ""}' } },
+            compilerArguments: ['foo', 'bar', 'abc', 'foo-'],
+            expectedCompilerArguments: { 'foo-?': 'foo-' }
+        });
+    });
+
+    it('should provide compilerArguments based on copilotcppClangCompilerArgumentFilter.', async () => {
+        await testGetProjectContext({
+            compiler: 'clang',
+            expectedCompiler: 'Clang',
+            context: { flags: { copilotcppClangCompilerArgumentFilter: '{"foo": "", "bar": ""}' } },
+            compilerArguments: ['foo', 'bar', 'abc'],
+            expectedCompilerArguments: { 'foo': 'foo', 'bar': 'bar' }
+        });
+    });
+
+    it('should support spaces between argument and value.', async () => {
+        await testGetProjectContext({
+            compiler: 'clang',
+            expectedCompiler: 'Clang',
+            context: { flags: { copilotcppClangCompilerArgumentFilter: '{"-std\\\\sc\\\\+\\\\+\\\\d+": ""}' } },
+            compilerArguments: ['-std', 'c++17', '-std', 'foo', '-std', 'c++11', '-std', 'bar'],
+            expectedCompilerArguments: { '-std\\sc\\+\\+\\d+': '-std c++11' }
+        });
+    });
+
+    it('should provide compilerArguments based on copilotcppGccCompilerArgumentFilter.', async () => {
+        await testGetProjectContext({
+            compiler: 'gcc',
+            expectedCompiler: 'GCC',
+            context: { flags: { copilotcppGccCompilerArgumentFilter: '{"foo": "", "bar": ""}' } },
+            compilerArguments: ['foo', 'bar', 'abc', 'bar', 'foo', 'bar'],
+            expectedCompilerArguments: { 'foo': 'foo', 'bar': 'bar' }
+        });
+    });
+
+    it('should provide empty array for each regex if nothing matches.', async () => {
+        await testGetProjectContext({
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: { flags: { copilotcppMsvcCompilerArgumentFilter: '{"foo": "", "bar": ""}' } },
+            compilerArguments: [],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should filter out all compilerArguments by default.', async () => {
+        await testGetProjectContext({
+            compiler: 'gcc',
+            expectedCompiler: 'GCC',
+            context: { flags: {} },
+            compilerArguments: ['foo', 'bar'],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should filter out all compilerArguments for empty regex.', async () => {
+        await testGetProjectContext({
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: { flags: { copilotcppMsvcCompilerArgumentFilter: '{"": ""}' } },
+            compilerArguments: ['foo', 'bar'],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should filter out all compilerArguments for empty copilotcppMsvcCompilerArgumentFilter.', async () => {
+        await testGetProjectContext({
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: {
+                flags: {
+                    copilotcppMsvcCompilerArgumentFilter: ''
+                }
+            },
+            compilerArguments: ['foo', 'bar'],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should filter out all compilerArguments for invalid copilotcppMsvcCompilerArgumentFilter.', async () => {
+        await testGetProjectContext({
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: {
+                flags: {
+                    copilotcppMsvcCompilerArgumentFilter: 'Not a map'
+                }
+            },
+            compilerArguments: ['foo', 'bar'],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should filter out all compilerArguments for unknown compilers.', async () => {
+        await testGetProjectContext({
+            compiler: 'unknown',
+            expectedCompiler: '',
+            context: {
+                flags: {
+                    copilotcppMsvcCompilerArgumentFilter: '{"(foo|bar)": ""}',
+                    copilotcppClangCompilerArgumentFilter: '{"(foo|bar)": ""}',
+                    copilotcppGccCompilerArgumentFilter: '{"(foo|bar)": ""}'
+                }
+            },
+            compilerArguments: ['foo', 'bar'],
+            expectedCompilerArguments: {}
+        });
+    });
+
+    it('should send telemetry.', async () => {
+        const input = {
+            compiler: 'msvc',
+            expectedCompiler: 'MSVC',
+            context: { flags: { copilotcppMsvcCompilerArgumentFilter: '{"foo-?": "", "": "", "bar": "", "xyz": ""}' } },
+            compilerArguments: ['foo', 'bar', 'foo-', 'abc'],
+            expectedCompilerArguments: { 'foo-?': 'foo-', 'bar': 'bar' }
+        };
+        await testGetProjectContext(input);
+
+        ok(telemetryStub.calledOnce, 'Telemetry should be called once');
+        ok(telemetryStub.calledWithMatch('ProjectContext', sinon.match({
+            "language": 'C++',
+            "compiler": input.expectedCompiler,
+            "standardVersion": 'C++20',
+            "targetPlatform": 'Windows',
+            "targetArchitecture": 'x64',
+            "filteredCompilerArguments": "foo,foo-,bar",
+            "filters": "foo-?,bar,xyz"
+        }), sinon.match({
+            "compilerArgumentCount": input.compilerArguments.length,
+            'duration': sinon.match.number
+        })));
+    });
+
+    it('should not send telemetry for unknown values', async () => {
+        arrangeProjectContextFromCppTools({
+            projectContextFromCppTools: {
+                language: 'java',
+                standardVersion: 'gnu++17',
+                compiler: 'javac',
+                targetPlatform: 'arduino',
+                targetArchitecture: 'bar',
+                fileContext: {
+                    compilerArguments: []
+                }
+            }
+        });
+
+        const result = await getProjectContext(mockTextDocumentStub.uri, { flags: {} }, new vscode.CancellationTokenSource().token);
+
+        ok(telemetryStub.calledOnce, 'Telemetry should be called once');
+        ok(telemetryStub.calledWithMatch('ProjectContext', sinon.match({
+            "targetArchitecture": 'bar'
+        }), sinon.match({
+            "compilerArgumentCount": 0
+        })));
+        ok(telemetryStub.calledWithMatch('ProjectContext', sinon.match(property =>
+            property['language'] === undefined &&
+            property['compiler'] === undefined &&
+            property['standardVersion'] === undefined &&
+            property['targetPlatform'] === undefined)));
+        ok(result, 'result should not be undefined');
+        ok(result.language === '');
+        ok(result.compiler === '');
+        ok(result.standardVersion === '');
+        ok(result.targetPlatform === '');
+        ok(result.targetArchitecture === 'bar');
+        ok(Object.keys(result.compilerArguments).length === 0);
+    });
+});


### PR DESCRIPTION
- Depends on cpptools' update to provide ProjectContextResult.
- Send "standardVersion" trait in completion prompt by default.
- Added the following new traits
  - intelliSenseDisclaimer: compiler information disclaimer.
  - intelliSenseDisclaimerBeginning: to note the beginning of IntelliSense information.
  - compilerArguments: a list of compiler command arguments that could affect Copilot generating completions.
  - directAsks: direct asking Copilot to do something instead of providing an argument.
  - intelliSenseDisclaimerEnd: to note the end of IntelliSense information.
- A/B Experimental flags
  - copilotcppTraits: deprecated, no longer used.
  - copilotcppExcludeTraits:: deprecated, no longer used.
  - copilotcppIncludeTraits: string array to include individual trait, i.e., compilerArguments.
  - copilotcppMsvcCompilerArgumentFilter: map of regex string to absence prompt for MSVC.
  - copilotcppClangCompilerArgumentFilter: map of regex string to absence prompt for Clang.
  - copilotcppGccCompilerArgumentFilter: map of regex string to absence prompt for GCC.
  - copilotcppCompilerArgumentDirectAskMap: map of argument to prompt.
