### PR TITLE
Fix an unnecessary cancel/re-request with GitHub Copilot requests (and fix some other bugs with Copilot exception handling)

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2320,11 +2320,10 @@ export class DefaultClient implements Client {
 
         // Don't cancel if the result has already been computed, because the result might still be usable
         // without needing to send an unnecessary re-request, which is the case for the callback to registerRelatedFilesProvider.
-        /*
         if (token.isCancellationRequested) {
-            throw new vscode.CancellationError();
+            return result;
+            // throw new vscode.CancellationError();
         }
-        */
 
         return result;
     }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2321,8 +2321,7 @@ export class DefaultClient implements Client {
         // Don't cancel if the result has already been computed, because the result might still be usable
         // without needing to send an unnecessary re-request, which is the case for the callback to registerRelatedFilesProvider.
         if (token.isCancellationRequested) {
-            return result;
-            // throw new vscode.CancellationError();
+            return result; // throw new vscode.CancellationError();
         }
 
         return result;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2318,9 +2318,13 @@ export class DefaultClient implements Client {
             }
         }
 
+        // Don't cancel if the result has already been computed, because the result might still be usable
+        // without needing to send an unnecessary re-request, which is the case for the callback to registerRelatedFilesProvider.
+        /*
         if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
+        */
 
         return result;
     }

--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -38,14 +38,14 @@ export async function registerRelatedFilesProvider(): Promise<void> {
             for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
                 api.registerRelatedFilesProvider(
                     { extensionId: util.extensionContext.extension.id, languageId },
-                    async (uri: vscode.Uri, context: { flags: Record<string, unknown> }, token: vscode.CancellationToken) => {
+                    async (uri: vscode.Uri, context: { flags: Record<string, unknown> }) => {
                         const start = performance.now();
                         const telemetryProperties: Record<string, string> = {};
                         const telemetryMetrics: Record<string, number> = {};
                         try {
-                            const getIncludesHandler = async () => (await getIncludesWithCancellation(1, token))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [];
+                            const getIncludesHandler = async () => (await getIncludes(1))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [];
                             const getTraitsHandler = async () => {
-                                const projectContext = await getProjectContext(uri, context, token);
+                                const projectContext = await getProjectContext(uri, context);
 
                                 if (!projectContext) {
                                     return undefined;
@@ -154,9 +154,9 @@ export async function registerRelatedFilesProvider(): Promise<void> {
     }
 }
 
-async function getIncludesWithCancellation(maxDepth: number, token: vscode.CancellationToken): Promise<GetIncludesResult> {
+async function getIncludes(maxDepth: number): Promise<GetIncludesResult> {
     const activeClient = getActiveClient();
-    const includes = await activeClient.getIncludes(maxDepth, token);
+    const includes = await activeClient.getIncludes(maxDepth);
     const wksFolder = activeClient.RootUri?.toString();
 
     if (!wksFolder) {

--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -5,13 +5,16 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { localize } from 'vscode-nls';
+import * as nls from 'vscode-nls';
 import * as util from '../common';
 import * as logger from '../logger';
 import * as telemetry from '../telemetry';
 import { GetIncludesResult } from './client';
 import { getActiveClient } from './extension';
 import { getCompilerArgumentFilterMap, getProjectContext } from './lmTool';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export interface CopilotTrait {
     name: string;

--- a/Extension/src/LanguageServer/lmTool.ts
+++ b/Extension/src/LanguageServer/lmTool.ts
@@ -5,13 +5,16 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { localize } from 'vscode-nls';
+import * as nls from 'vscode-nls';
 import * as util from '../common';
 import * as logger from '../logger';
 import * as telemetry from '../telemetry';
 import { ChatContextResult, ProjectContextResult } from './client';
 import { getClients } from './extension';
 import { checkDuration } from './utils';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const MSVC: string = 'MSVC';
 const Clang: string = 'Clang';
@@ -177,7 +180,7 @@ export async function getProjectContext(uri: vscode.Uri, context: { flags: Recor
             // Intentionally swallow any exception.
         }
         telemetryProperties["error"] = "true";
-        return undefined;
+        throw exception; // Throw the exception for auto-retry.
     } finally {
         telemetry.logCopilotEvent('ProjectContext', telemetryProperties, telemetryMetrics);
     }

--- a/Extension/src/LanguageServer/lmTool.ts
+++ b/Extension/src/LanguageServer/lmTool.ts
@@ -127,11 +127,11 @@ function filterCompilerArguments(compiler: string, compilerArguments: string[], 
     return result;
 }
 
-export async function getProjectContext(uri: vscode.Uri, context: { flags: Record<string, unknown> }, token: vscode.CancellationToken): Promise<ProjectContext | undefined> {
+export async function getProjectContext(uri: vscode.Uri, context: { flags: Record<string, unknown> }): Promise<ProjectContext | undefined> {
     const telemetryProperties: Record<string, string> = {};
     const telemetryMetrics: Record<string, number> = {};
     try {
-        const projectContext = await checkDuration<ProjectContextResult | undefined>(async () => await getClients()?.ActiveClient?.getProjectContext(uri, token) ?? undefined);
+        const projectContext = await checkDuration<ProjectContextResult | undefined>(async () => await getClients()?.ActiveClient?.getProjectContext(uri) ?? undefined);
         telemetryMetrics["duration"] = projectContext.duration;
         if (!projectContext.result) {
             return undefined;

--- a/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
@@ -130,8 +130,8 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
     });
 
     const arrangeChatContextFromCppTools = ({ chatContextFromCppTools, isCpp, isHeaderFile }:
-    { chatContextFromCppTools?: ChatContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
-    { chatContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+        { chatContextFromCppTools?: ChatContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+        { chatContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
     ) => {
         activeClientStub.getChatContext.resolves(chatContextFromCppTools);
         sinon.stub(util, 'isCpp').returns(isCpp ?? true);
@@ -139,8 +139,8 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
     };
 
     const arrangeProjectContextFromCppTools = ({ projectContextFromCppTools, isCpp, isHeaderFile }:
-    { projectContextFromCppTools?: ProjectContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
-    { projectContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+        { projectContextFromCppTools?: ProjectContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+        { projectContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
     ) => {
         activeClientStub.getProjectContext.resolves(projectContextFromCppTools);
         sinon.stub(util, 'isCpp').returns(isCpp ?? true);
@@ -200,7 +200,7 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
             }
         });
 
-        const result = await getProjectContext(mockTextDocumentStub.uri, context, new vscode.CancellationTokenSource().token);
+        const result = await getProjectContext(mockTextDocumentStub.uri, context);
 
         ok(result, 'result should not be undefined');
         ok(result.language === 'C++');
@@ -364,7 +364,7 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
             }
         });
 
-        const result = await getProjectContext(mockTextDocumentStub.uri, { flags: {} }, new vscode.CancellationTokenSource().token);
+        const result = await getProjectContext(mockTextDocumentStub.uri, { flags: {} });
 
         ok(telemetryStub.calledOnce, 'Telemetry should be called once');
         ok(telemetryStub.calledWithMatch('ProjectContext', sinon.match({

--- a/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/lmTool.test.ts
@@ -130,8 +130,8 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
     });
 
     const arrangeChatContextFromCppTools = ({ chatContextFromCppTools, isCpp, isHeaderFile }:
-        { chatContextFromCppTools?: ChatContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
-        { chatContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+    { chatContextFromCppTools?: ChatContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+    { chatContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
     ) => {
         activeClientStub.getChatContext.resolves(chatContextFromCppTools);
         sinon.stub(util, 'isCpp').returns(isCpp ?? true);
@@ -139,8 +139,8 @@ describe('CppConfigurationLanguageModelTool Tests', () => {
     };
 
     const arrangeProjectContextFromCppTools = ({ projectContextFromCppTools, isCpp, isHeaderFile }:
-        { projectContextFromCppTools?: ProjectContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
-        { projectContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
+    { projectContextFromCppTools?: ProjectContextResult; isCpp?: boolean; isHeaderFile?: boolean } =
+    { projectContextFromCppTools: undefined, isCpp: undefined, isHeaderFile: false }
     ) => {
         activeClientStub.getProjectContext.resolves(projectContextFromCppTools);
         sinon.stub(util, 'isCpp').returns(isCpp ?? true);


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-cpptools/pull/12773 and https://github.com/microsoft/vscode-cpptools/pull/12979 .

Fixes a GeneralError from a getProjectContext request returning undefined instead of throwing an exception (which triggers the retry).

Fixes this exception being thrown: ![image](https://github.com/user-attachments/assets/9177b193-77e1-4e6e-bd6b-7f62d412539e)
and
![image](https://github.com/user-attachments/assets/687db037-c003-41c6-9ca2-cbb5ffae4fe8)
