### PR TITLE
pass optional parameter to C_Cpp.ConfigurationSelect

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -762,7 +762,7 @@ export interface Client {
     PauseCodeAnalysis(): void;
     ResumeCodeAnalysis(): void;
     CancelCodeAnalysis(): void;
-    handleConfigurationSelectCommand(): Promise<void>;
+    handleConfigurationSelectCommand(config?: string): Promise<void>;
     handleConfigurationProviderSelectCommand(): Promise<void>;
     handleShowActiveCodeAnalysisCommands(): Promise<void>;
     handleShowIdleCodeAnalysisCommands(): Promise<void>;
@@ -3248,11 +3248,11 @@ export class DefaultClient implements Client {
     /**
      * command handlers
      */
-    public async handleConfigurationSelectCommand(): Promise<void> {
+    public async handleConfigurationSelectCommand(config?: string): Promise<void> {
         await this.ready;
         const configNames: string[] | undefined = this.configuration.ConfigurationNames;
         if (configNames) {
-            const index: number = await ui.showConfigurations(configNames);
+            const index: number = config ? configNames.indexOf(config) : await ui.showConfigurations(configNames);
             if (index < 0) {
                 return;
             }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -584,13 +584,13 @@ async function installCompiler(sender?: any): Promise<void> {
     telemetry.logLanguageServerEvent('installCompiler', telemetryProperties);
 }
 
-async function onSelectConfiguration(): Promise<void> {
+async function onSelectConfiguration(config?: string): Promise<void> {
     if (!isFolderOpen()) {
         void vscode.window.showInformationMessage(localize("configuration.select.first", 'Open a folder first to select a configuration.'));
     } else {
         // This only applies to the active client. You cannot change the configuration for
         // a client that is not active since that client's UI will not be visible.
-        return clients.ActiveClient.handleConfigurationSelectCommand();
+        return clients.ActiveClient.handleConfigurationSelectCommand(config);
     }
 }
 


### PR DESCRIPTION
I would like to be able to switch the cpp configuration from within my extension, and I couldn't find an existing way to do that programmatically.

This change just adds an optional string parameter to the existing C_Cpp.ConfigurationSelect command which bypasses the quickpick if defined.

This is sort of a 'better to ask for forgiveness than permission' thing, but with pull requests I can't do any harm!
