### PR TITLE
Detect compile_commands.json after containing folder deleted and recreated on Windows

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -2340,7 +2340,9 @@ export class CppProperties {
                 }
             } else {
                 const compileCommandsLastChanged: Date | undefined = this.compileCommandsFileWatcherFallbackTime.get(compileCommandsFile);
-                if ((this.compileCommandsFile === null) || (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged)) {
+                if ((this.compileCommandsFile === undefined) ||
+                    (this.compileCommandsFile === null) ||
+                    (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged)) {
                     this.compileCommandsFileWatcherFallbackTime.set(compileCommandsFile, new Date());
                     this.onCompileCommandsChanged(compileCommandsFile);
                     this.compileCommandsFile = vscode.Uri.file(compileCommandsFile); // File created.

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -2340,7 +2340,7 @@ export class CppProperties {
                 }
             } else {
                 const compileCommandsLastChanged: Date | undefined = this.compileCommandsFileWatcherFallbackTime.get(compileCommandsFile);
-                if (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged) {
+                if ((this.compileCommandsFile === null) || (compileCommandsLastChanged !== undefined && stats.mtime > compileCommandsLastChanged)) {
                     this.compileCommandsFileWatcherFallbackTime.set(compileCommandsFile, new Date());
                     this.onCompileCommandsChanged(compileCommandsFile);
                     this.compileCommandsFile = vscode.Uri.file(compileCommandsFile); // File created.


### PR DESCRIPTION
closes #7030  
On my setup (`Windows 10 Home 22H2`), when a folder is copied, it's containing files' `stats.mtime` remain the same (even though the containing folder's stats are new), which is the root cause of this issue.  
For comparison on my WSL (`Ubuntu 20.04 LTS`), the new files' `stats.mtime` will be the time when the copied files were created.  
The fix adds the check if the `compileCommandsFile` is `undefined | null` which means it was previously not "present".   
  
***note:*** a side effect of this fix is that on every initial load of a workspace, (if `fs.stats` didn't return an error) we fire the `onCompileCommandsChanged` event because `CppProperties.compileCommandsFile` is initially marked as `undefined`.  
if we remove the `undefined` case from the condition check, the fix will only work if the `compileCommandsFile` was actually changed at least once (since the workspace was loaded) before the containing folder is deleted and re-created.
  
cases tested:
- containing folder deleted after workspace was loaded, and copied back on a Windows machine. (the issue, tested on Linux as well)
- containing folder doesn't exist and copied back after workspace was loaded on a Windows machine. (the issue, tested on Linux as well)
- `compile_commands.json` file deleted after workspace was loaded and re-created (with a new timestamp)
- `compile_commands.json` doesn't exist and generated after workspace is loaded.
