### PR TITLE
support goto definition for inlay hints

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add support for passing an additional parameter to `C_Cpp.ConfigurationSelect` command. [PR #12993](https://github.com/microsoft/vscode-cpptools/pull/12993)
   * Thank you for the contribution. [@adrianstephens](https://github.com/adrianstephens)
 * Update clang-format and clang-tidy from 19.1.2 to 19.1.5.
+* Add support for providing the definition with inlay hint for the specific symbol. [#13010](https://github.com/microsoft/vscode-cpptools/issues/13010)
 
 ### Bug Fixes
 * Increase clang-format timeout from 10 seconds to 30 seconds. [#10213](https://github.com/microsoft/vscode-cpptools/issues/10213)

--- a/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
+++ b/Extension/src/LanguageServer/Providers/inlayHintProvider.ts
@@ -207,7 +207,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
         const resolvedHints: vscode.InlayHint[] = [];
         for (const hint of hints) {
             const showOnLeft: boolean = settings.inlayHintsAutoDeclarationTypesShowOnLeft && hint.identifierLength > 0;
-            let labelPart: vscode.InlayHintLabelPart = this.createInlayHintLabelPart(hint, showOnLeft ? hint.label : ": " + hint.label);
+            const labelPart: vscode.InlayHintLabelPart = this.createInlayHintLabelPart(hint, showOnLeft ? hint.label : ": " + hint.label);
             const inlayHint: vscode.InlayHint = new vscode.InlayHint(
                 new vscode.Position(hint.line, hint.character +
                     (showOnLeft ? 0 : hint.identifierLength)),
@@ -248,7 +248,7 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
             if (paramHintLabel === "" && refOperatorString === "") {
                 continue;
             }
-            let labelPart: vscode.InlayHintLabelPart = this.createInlayHintLabelPart(hint, refOperatorString + paramHintLabel + ":");
+            const labelPart: vscode.InlayHintLabelPart = this.createInlayHintLabelPart(hint, refOperatorString + paramHintLabel + ":");
             const inlayHint: vscode.InlayHint = new vscode.InlayHint(
                 new vscode.Position(hint.line, hint.character),
                 [labelPart],
@@ -260,9 +260,9 @@ export class InlayHintsProvider implements vscode.InlayHintsProvider {
     }
 
     private createInlayHintLabelPart(hint: CppInlayHint, hintLabel: string): vscode.InlayHintLabelPart {
-        let labelPart: vscode.InlayHintLabelPart = new vscode.InlayHintLabelPart(hintLabel);
+        const labelPart: vscode.InlayHintLabelPart = new vscode.InlayHintLabelPart(hintLabel);
         if (hint.definitionUri !== undefined) {
-            let definitionPos = new vscode.Position(
+            const definitionPos = new vscode.Position(
                 hint.definitionLine as number,
                 hint.character as number);
             const option: vscode.TextDocumentShowOptions = { selection: new vscode.Range(definitionPos, definitionPos) };


### PR DESCRIPTION
 closes issue [#13010](https://github.com/microsoft/vscode-cpptools/issues/13010)
This PR adds the "go to definition" feature for inlay hints.

Note: Not all inlay hints support this feature, as it may depend on how `cpptools` handles `cppInlayHint` results.