### PR TITLE
Trigger reparsing when `files.encoding` setting changes

### DIFF
--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -131,6 +131,7 @@ export interface WorkspaceFolderSettingsParams {
     filesExclude: Excludes;
     filesAutoSaveAfterDelay: boolean;
     filesEncoding: string;
+    filesEncodingChanged: boolean;
     searchExclude: Excludes;
     editorAutoClosingBrackets: string;
     editorInlayHintsEnabled: boolean;
@@ -141,6 +142,7 @@ export interface WorkspaceFolderSettingsParams {
 export interface SettingsParams {
     filesAssociations: Associations;
     workspaceFallbackEncoding: string;
+    workspaceFallbackEncodingChanged: boolean;
     maxConcurrentThreads: number | null;
     maxCachedProcesses: number | null;
     maxMemory: number | null;


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/10892

This is a simple fix which will reindex the database if `files.encoding` changes. It's possible to do a more granular reparse of only those files that would have been impacted by the change.  A related issue with that may be: https://github.com/microsoft/vscode/issues/209503#issuecomment-2537626506

There is a native-side change as well.