### PR TITLE
Fix space around binary operator translation.

### DIFF
--- a/Extension/i18n/chs/package.i18n.json
+++ b/Extension/i18n/chs/package.i18n.json
@@ -160,7 +160,7 @@
 	"c_cpp.configuration.vcFormat.space.removeBeforeSemicolon.description": "将移除每个分号前的空格。",
 	"c_cpp.configuration.vcFormat.space.insertAfterSemicolon.description": "在每个分号后面插入一个空格。",
 	"c_cpp.configuration.vcFormat.space.removeAroundUnaryOperator.description": "移除一元运算符和操作数之间的空格。",
-	"c_cpp.configuration.vcFormat.space.aroundBinaryOperator.description": "二进制运算符周围的空格。",
+	"c_cpp.configuration.vcFormat.space.aroundBinaryOperator.description": "二元运算符周围的空格。",
 	"c_cpp.configuration.vcFormat.space.aroundAssignmentOperator.description": "赋值运算符周围的空格。",
 	"c_cpp.configuration.vcFormat.space.pointerReferenceAlignment.description": "指针和引用运算符周围的空格。",
 	"c_cpp.configuration.vcFormat.space.pointerReferenceAlignment.left.description": "指针和引用运算符左对齐。",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -413,7 +413,7 @@
     "c_cpp.configuration.vcFormat.space.aroundBinaryOperator.description": {
         "message": "Spaces around binary operators.",
         "comment": [
-            "The term \"binary operator\" refers to an operator that takes two operands and not an operator that accepts a binary number."
+            "The term \"binary operators\" refers to operators that takes two operands and not operators on binary numbers."
         ]
     },
     "c_cpp.configuration.vcFormat.space.aroundAssignmentOperator.description": "Spaces around assignment operators.",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -410,7 +410,12 @@
     "c_cpp.configuration.vcFormat.space.removeBeforeSemicolon.description": "Spaces are removed before every semicolon.",
     "c_cpp.configuration.vcFormat.space.insertAfterSemicolon.description": "A space is inserted after every semicolon.",
     "c_cpp.configuration.vcFormat.space.removeAroundUnaryOperator.description": "Spaces between unary operators and operands are removed.",
-    "c_cpp.configuration.vcFormat.space.aroundBinaryOperator.description": "Spaces around binary operators.",
+    "c_cpp.configuration.vcFormat.space.aroundBinaryOperator.description": {
+        "message": "Spaces around binary operators.",
+        "comment": [
+            "The term \"binary operator\" refers to an operator that takes two operands and not an operator that accepts a binary number."
+        ]
+    },
     "c_cpp.configuration.vcFormat.space.aroundAssignmentOperator.description": "Spaces around assignment operators.",
     "c_cpp.configuration.vcFormat.space.pointerReferenceAlignment.description": "Spaces around pointer and reference operators.",
     "c_cpp.configuration.vcFormat.space.pointerReferenceAlignment.left.description": "Pointer and reference operators are aligned to the left.",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/13048

I created internal issue 1019018 for fixing it on the translator's side (any maybe the changed comments might trigger a retranslation for other languages too, not sure).