### PR TITLE
Don't show the output window for "references may be missing" when the loggingLevel is less than Warning

### DIFF
--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -13,6 +13,7 @@ import * as telemetry from '../telemetry';
 import { DefaultClient } from './client';
 import { PersistentState } from './persistentState';
 import { FindAllRefsView } from './referencesView';
+import { CppSettings } from './settings';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -469,19 +470,24 @@ export class ReferencesManager {
         }
 
         if (this.referencesStartedWhileTagParsing) {
+            const showLog: boolean = util.getNumericLoggingLevel(new CppSettings().loggingLevel) >= 3;
             const msg: string = localize("some.references.may.be.missing", "[Warning] Some references may be missing, because workspace parsing was incomplete when {0} was started.",
                 referencesCommandModeToString(this.client.ReferencesCommandMode));
             if (this.client.ReferencesCommandMode === ReferencesCommandMode.Peek) {
                 if (this.referencesChannel) {
                     this.referencesChannel.appendLine(msg);
                     this.referencesChannel.appendLine("");
-                    this.referencesChannel.show(true);
+                    if (showLog) {
+                        this.referencesChannel.show(true);
+                    }
                 }
             } else if (this.client.ReferencesCommandMode === ReferencesCommandMode.Find) {
                 const logChannel: vscode.OutputChannel = logger.getOutputChannel();
                 logChannel.appendLine(msg);
                 logChannel.appendLine("");
-                logChannel.show(true);
+                if (showLog) {
+                    logChannel.show(true);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: #13066

The references logging does not respect the `C_Cpp.loggingLevel` setting. We do want this message to be logged so that the user can understand why some references may be missing, but we don't want to pop open the output window unless the logging level is at least `Warning` or more verbose.

A better solution might entail presenting this information in the References panel, but this will provide some relief in the event that cannot happen.