### PR TITLE
Don't reset everyones databases

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1385,6 +1385,9 @@ export class DefaultClient implements Client {
         let filesEncodingChanged: boolean = false;
         if (workspaceFolder) {
             const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", "", workspaceFolder);
+            if (lastFilesEncoding.Value === "") {
+                lastFilesEncoding.Value = filesEncoding;
+            }
             filesEncodingChanged = lastFilesEncoding.Value !== filesEncoding;
         }
         const result: WorkspaceFolderSettingsParams = {
@@ -1520,6 +1523,9 @@ export class DefaultClient implements Client {
         }
         const workspaceFallbackEncoding: string = workspaceOtherSettings.filesEncoding;
         const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", "");
+        if (lastWorkspaceFallbackEncoding.Value === "") {
+            lastWorkspaceFallbackEncoding.Value = workspaceFallbackEncoding;
+        }
         const workspaceFallbackEncodingChanged = lastWorkspaceFallbackEncoding.Value !== workspaceFallbackEncoding;
         return {
             filesAssociations: workspaceOtherSettings.filesAssociations,

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1384,10 +1384,7 @@ export class DefaultClient implements Client {
         const filesEncoding: string = otherSettings.filesEncoding;
         let filesEncodingChanged: boolean = false;
         if (workspaceFolder) {
-            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", "", workspaceFolder);
-            if (lastFilesEncoding.Value === "") {
-                lastFilesEncoding.Value = filesEncoding;
-            }
+            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", filesEncoding, workspaceFolder);
             filesEncodingChanged = lastFilesEncoding.Value !== filesEncoding;
         }
         const result: WorkspaceFolderSettingsParams = {
@@ -1522,10 +1519,7 @@ export class DefaultClient implements Client {
             void util.promptForReloadWindowDueToSettingsChange();
         }
         const workspaceFallbackEncoding: string = workspaceOtherSettings.filesEncoding;
-        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", "");
-        if (lastWorkspaceFallbackEncoding.Value === "") {
-            lastWorkspaceFallbackEncoding.Value = workspaceFallbackEncoding;
-        }
+        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", workspaceFallbackEncoding);
         const workspaceFallbackEncodingChanged = lastWorkspaceFallbackEncoding.Value !== workspaceFallbackEncoding;
         return {
             filesAssociations: workspaceOtherSettings.filesAssociations,


### PR DESCRIPTION
A follow up to: https://github.com/microsoft/vscode-cpptools/pull/13047

We shouldn't automatically reset everyone's databases with 1.23.3 due to these persistent values not being set yet.  This change considers empty value as not requiring a reset.