### PR TITLE
Ensure default persistent values get persisted

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1385,6 +1385,9 @@ export class DefaultClient implements Client {
         let filesEncodingChanged: boolean = false;
         if (workspaceFolder) {
             const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", "", workspaceFolder);
+            if (lastFilesEncoding.Value === "") {
+                lastFilesEncoding.Value = filesEncoding;
+            }
             filesEncodingChanged = lastFilesEncoding.Value !== filesEncoding;
         }
         const result: WorkspaceFolderSettingsParams = {
@@ -1520,6 +1523,9 @@ export class DefaultClient implements Client {
         }
         const workspaceFallbackEncoding: string = workspaceOtherSettings.filesEncoding;
         const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", "");
+        if (lastWorkspaceFallbackEncoding.Value === "") {
+            lastWorkspaceFallbackEncoding.Value = workspaceFallbackEncoding;
+        }
         const workspaceFallbackEncodingChanged = lastWorkspaceFallbackEncoding.Value !== workspaceFallbackEncoding;
         return {
             filesAssociations: workspaceOtherSettings.filesAssociations,

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1384,7 +1384,10 @@ export class DefaultClient implements Client {
         const filesEncoding: string = otherSettings.filesEncoding;
         let filesEncodingChanged: boolean = false;
         if (workspaceFolder) {
-            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", filesEncoding, workspaceFolder);
+            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", "", workspaceFolder);
+            if (lastFilesEncoding.Value === "") {
+                lastFilesEncoding.Value = filesEncoding;
+            }
             filesEncodingChanged = lastFilesEncoding.Value !== filesEncoding;
         }
         const result: WorkspaceFolderSettingsParams = {
@@ -1519,7 +1522,10 @@ export class DefaultClient implements Client {
             void util.promptForReloadWindowDueToSettingsChange();
         }
         const workspaceFallbackEncoding: string = workspaceOtherSettings.filesEncoding;
-        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", workspaceFallbackEncoding);
+        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", "");
+        if (lastWorkspaceFallbackEncoding.Value === "") {
+            lastWorkspaceFallbackEncoding.Value = workspaceFallbackEncoding;
+        }
         const workspaceFallbackEncodingChanged = lastWorkspaceFallbackEncoding.Value !== workspaceFallbackEncoding;
         return {
             filesAssociations: workspaceOtherSettings.filesAssociations,

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1384,10 +1384,7 @@ export class DefaultClient implements Client {
         const filesEncoding: string = otherSettings.filesEncoding;
         let filesEncodingChanged: boolean = false;
         if (workspaceFolder) {
-            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", "", workspaceFolder);
-            if (lastFilesEncoding.Value === "") {
-                lastFilesEncoding.Value = filesEncoding;
-            }
+            const lastFilesEncoding: PersistentFolderState<string> = new PersistentFolderState<string>("CPP.lastFilesEncoding", filesEncoding, workspaceFolder);
             filesEncodingChanged = lastFilesEncoding.Value !== filesEncoding;
         }
         const result: WorkspaceFolderSettingsParams = {
@@ -1522,10 +1519,7 @@ export class DefaultClient implements Client {
             void util.promptForReloadWindowDueToSettingsChange();
         }
         const workspaceFallbackEncoding: string = workspaceOtherSettings.filesEncoding;
-        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", "");
-        if (lastWorkspaceFallbackEncoding.Value === "") {
-            lastWorkspaceFallbackEncoding.Value = workspaceFallbackEncoding;
-        }
+        const lastWorkspaceFallbackEncoding: PersistentState<string> = new PersistentState<string>("CPP.lastWorkspaceFallbackEncoding", workspaceFallbackEncoding);
         const workspaceFallbackEncodingChanged = lastWorkspaceFallbackEncoding.Value !== workspaceFallbackEncoding;
         return {
             filesAssociations: workspaceOtherSettings.filesAssociations,

--- a/Extension/src/LanguageServer/persistentState.ts
+++ b/Extension/src/LanguageServer/persistentState.ts
@@ -19,6 +19,11 @@ class PersistentStateBase<T> {
         this.defaultvalue = defaultValue;
         this.state = state;
         this.curvalue = defaultValue;
+
+        // Ensure the default is written to the state store.
+        if (this.state && this.state.get<T>(this.key) === undefined) {
+            void this.state.update(this.key, this.defaultvalue);
+        }
     }
 
     public get Value(): T {


### PR DESCRIPTION
This change enables dynamically passing different values for the 'default' value of a persistent state, persisting the first such default provided.  Without this change, the default would not be persisted, and specifying a different default value in the future would just alter the value to match the new default (if not otherwise given a non-default value).

This is needed to fix: https://github.com/microsoft/vscode-cpptools/pull/13073