### PR TITLE
Re-enable the SingleRootProject tests with check-in tests and fix the getIncludes test failure

### DIFF
--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -42,8 +42,9 @@ jobs:
         run: yarn test
         working-directory: Extension
 
+      # These tests don't require the binary.
       - name: Run SingleRootProject tests
-        run: yarn test --scenario=SingleRootProject
+        run: yarn test --scenario=SingleRootProject --skipCheckBinaries
         working-directory: Extension
 
       # NOTE : We can't run the test that require the native binary files

--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -43,7 +43,9 @@ jobs:
         working-directory: Extension
 
       # These tests don't require the binary.
+      # On Linux, it is failing with: Test run terminated with signal SIGSEGV
       - name: Run SingleRootProject tests
+        if: ${{ inputs.platform != 'linux' }}
         run: yarn test --scenario=SingleRootProject --skipCheckBinaries
         working-directory: Extension
 

--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -42,6 +42,10 @@ jobs:
         run: yarn test
         working-directory: Extension
 
+      - name: Run SingleRootProject tests
+        run: yarn test --scenario=SingleRootProject
+        working-directory: Extension
+
       # NOTE : We can't run the test that require the native binary files
       #        yet -- there will be an update soon that allows the tester to 
       #        acquire them on-the-fly

--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -43,7 +43,8 @@ jobs:
         working-directory: Extension
 
       # These tests don't require the binary.
-      # On Linux, it is failing with: Test run terminated with signal SIGSEGV
+      # On Linux, it is failing (before the tests actually run) with: Test run terminated with signal SIGSEGV.
+      # But it works on Linux during the E2E test.
       - name: Run SingleRootProject tests
         if: ${{ inputs.platform != 'linux' }}
         run: yarn test --scenario=SingleRootProject --skipCheckBinaries

--- a/Extension/.scripts/common.ts
+++ b/Extension/.scripts/common.ts
@@ -334,6 +334,9 @@ export async function checkDTS() {
 }
 
 export async function checkBinaries() {
+    if ($switches.includes('--skipCheckBinaries')) {
+        return false;
+    }
     let failing = false;
     failing = !await assertAnyFile(['bin/cpptools.exe', 'bin/cpptools']) && (quiet || warn(`The native binary files are not present. You should either build or install the native binaries\n\n.`)) || failing;
 

--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -10,7 +10,7 @@ import * as util from '../common';
 import * as logger from '../logger';
 import * as telemetry from '../telemetry';
 import { GetIncludesResult } from './client';
-import { clients } from './extension';
+import { getClients } from './extension';
 import { getCompilerArgumentFilterMap, getProjectContext } from './lmTool';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -158,7 +158,7 @@ export async function registerRelatedFilesProvider(): Promise<void> {
 }
 
 async function getIncludes(uri: vscode.Uri, maxDepth: number): Promise<GetIncludesResult> {
-    const client = clients.getClientFor(uri);
+    const client = getClients().getClientFor(uri);
     const includes = await client.getIncludes(uri, maxDepth);
     const wksFolder = client.RootUri?.toString();
 

--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -10,7 +10,7 @@ import * as util from '../common';
 import * as logger from '../logger';
 import * as telemetry from '../telemetry';
 import { GetIncludesResult } from './client';
-import { getClients } from './extension';
+import { clients } from './extension';
 import { getCompilerArgumentFilterMap, getProjectContext } from './lmTool';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -158,7 +158,7 @@ export async function registerRelatedFilesProvider(): Promise<void> {
 }
 
 async function getIncludes(uri: vscode.Uri, maxDepth: number): Promise<GetIncludesResult> {
-    const client = getClients().getClientFor(uri);
+    const client = clients.getClientFor(uri);
     const includes = await client.getIncludes(uri, maxDepth);
     const wksFolder = client.RootUri?.toString();
 

--- a/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
@@ -32,7 +32,6 @@ describe('copilotProviders Tests', () => {
     const rootUri: vscode.Uri = vscode.Uri.file(process.platform === 'win32' ? 'C:\\src\\my_project' : '/home/src/my_project');
     const expectedInclude: string = process.platform === 'win32' ? 'file:///c%3A/src/my_project/foo.h' : 'file:///home/src/my_project/foo.h';
     const sourceFileUri: vscode.Uri = vscode.Uri.file(process.platform === 'win32' ? 'file:///c%3A/src/my_project/foo.cpp' : 'file:///home/src/my_project/foo.cpp');
-    const maxDepth: number = 10;
 
     beforeEach(() => {
         proxyquire.noPreserveCache(); // Tells proxyquire to not fetch the module from cache
@@ -73,7 +72,7 @@ describe('copilotProviders Tests', () => {
 
         activeClientStub = sinon.createStubInstance(DefaultClient);
         getActiveClientStub = sinon.stub(extension, 'getActiveClient').returns(activeClientStub);
-        activeClientStub.getIncludes.resolves({ includedFiles: [] })(sourceFileUri, maxDepth);
+        activeClientStub.getIncludes.resolves({ includedFiles: [] });
         telemetryStub = sinon.stub(telemetry, 'logCopilotEvent').returns();
     });
 
@@ -85,14 +84,14 @@ describe('copilotProviders Tests', () => {
     { vscodeExtension?: vscode.Extension<unknown>; getIncludeFiles?: GetIncludesResult; projectContext?: ProjectContext; rootUri?: vscode.Uri; flags?: Record<string, unknown> } =
     { vscodeExtension: undefined, getIncludeFiles: undefined, projectContext: undefined, rootUri: undefined, flags: {} }
     ) => {
-        activeClientStub.getIncludes.resolves(getIncludeFiles)(sourceFileUri, maxDepth);
+        activeClientStub.getIncludes.resolves(getIncludeFiles);
         sinon.stub(lmTool, 'getProjectContext').resolves(projectContext);
         sinon.stub(activeClientStub, 'RootUri').get(() => rootUri);
         mockCopilotApi.registerRelatedFilesProvider.callsFake((_providerId: { extensionId: string; languageId: string }, callback: (uri: vscode.Uri, context: { flags: Record<string, unknown> }, cancellationToken: vscode.CancellationToken) => Promise<{ entries: vscode.Uri[]; traits?: CopilotTrait[] }>) => {
             if (_providerId.languageId === 'cpp') {
                 const tokenSource = new vscode.CancellationTokenSource();
                 try {
-                    callbackPromise = callback(vscode.Uri.parse('file:///test-extension-path'), { flags: flags ?? {} }, tokenSource.token);
+                    callbackPromise = callback(sourceFileUri, { flags: flags ?? {} }, tokenSource.token);
                 } finally {
                     tokenSource.dispose();
                 }

--- a/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
@@ -10,6 +10,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as util from '../../../../src/common';
 import { DefaultClient, GetIncludesResult } from '../../../../src/LanguageServer/client';
+import { ClientCollection } from '../../../../src/LanguageServer/clientCollection';
 import { CopilotApi, CopilotTrait } from '../../../../src/LanguageServer/copilotProviders';
 import * as extension from '../../../../src/LanguageServer/extension';
 import * as lmTool from '../../../../src/LanguageServer/lmTool';
@@ -19,7 +20,7 @@ import * as telemetry from '../../../../src/telemetry';
 describe('copilotProviders Tests', () => {
     let moduleUnderTest: any;
     let mockCopilotApi: sinon.SinonStubbedInstance<CopilotApi>;
-    let getActiveClientStub: sinon.SinonStub;
+    let getClientsStub: sinon.SinonStub;
     let activeClientStub: sinon.SinonStubbedInstance<DefaultClient>;
     let vscodeGetExtensionsStub: sinon.SinonStub;
     let callbackPromise: Promise<{ entries: vscode.Uri[]; traits?: CopilotTrait[] }> | undefined;
@@ -71,7 +72,9 @@ describe('copilotProviders Tests', () => {
         };
 
         activeClientStub = sinon.createStubInstance(DefaultClient);
-        getActiveClientStub = sinon.stub(extension, 'getActiveClient').returns(activeClientStub);
+        const clientsStub = sinon.createStubInstance(ClientCollection);
+        getClientsStub = sinon.stub(extension, 'getClients').returns(clientsStub);
+        clientsStub.getClientFor.returns(activeClientStub);
         activeClientStub.getIncludes.resolves({ includedFiles: [] });
         telemetryStub = sinon.stub(telemetry, 'logCopilotEvent').returns();
     });
@@ -130,7 +133,7 @@ describe('copilotProviders Tests', () => {
 
         ok(vscodeGetExtensionsStub.calledOnce, 'vscode.extensions.getExtension should be called once');
         ok(mockCopilotApi.registerRelatedFilesProvider.calledWithMatch(sinon.match({ extensionId: 'test-extension-id', languageId: sinon.match.in(['c', 'cpp', 'cuda-cpp']) })), 'registerRelatedFilesProvider should be called with the correct providerId and languageId');
-        ok(getActiveClientStub.callCount !== 0, 'getActiveClient should be called');
+        ok(getClientsStub.callCount !== 0, 'getClients should be called');
         ok(callbackPromise, 'callbackPromise should be defined');
         ok(result, 'result should be defined');
         ok(result.entries.length === 1, 'result.entries should have 1 included file');


### PR DESCRIPTION
* Re-enable the SingleRootProject tests: A previous change stopped running it for check-in tests, so it was only getting run in the E2E tests.
* Fixed a test regression from https://github.com/microsoft/vscode-cpptools/pull/13059

Tests failed with

```
  1) copilotProviders Tests
       should not provide project context traits when project context isn't available.:
     TypeError: Cannot read properties of undefined (reading 'getClientFor')
```