### PR TITLE
Fix cl.exe.not.available loc.

### DIFF
--- a/Extension/.eslintrc.js
+++ b/Extension/.eslintrc.js
@@ -24,17 +24,6 @@ module.exports = {
         "eslint-plugin-header"
     ],
     "rules": {
-        "indent": [
-            "warn",
-            4,
-            {
-                "SwitchCase": 1,
-                "ObjectExpression": "first"
-            }
-        ],
-        "@typescript-eslint/indent": [
-            "error", 4
-        ],
         "@typescript-eslint/adjacent-overload-signatures": "error",
         "@typescript-eslint/array-type": "error",
         "@typescript-eslint/await-thenable": "error",

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -584,7 +584,9 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
     private showErrorIfClNotAvailable(_configurationLabel: string): boolean {
         if (!process.env.DevEnvDir || process.env.DevEnvDir.length === 0) {
-            void vscode.window.showErrorMessage(localize("cl.exe.not.available", "{0} build and debug is only usable when VS Code is run from the Developer Command Prompt for VS.", "cl.exe"));
+            void vscode.window.showErrorMessage(localize({ key: "cl.exe.not.available",
+                comment: ["{0} is a command option in a menu. {1} is the product name \"Developer Command Prompt for VS\"."] },
+                "{0} is only usable when VS Code is run from the {1}.", `cl.exe ${this.buildAndDebugActiveFileStr()}`, "Developer Command Prompt for VS"));
             return true;
         }
         return false;

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -587,8 +587,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
             void vscode.window.showErrorMessage(localize({
                 key: "cl.exe.not.available",
                 comment: ["{0} is a command option in a menu. {1} is the product name \"Developer Command Prompt for VS\"."]
-            },
-                "{0} is only usable when VS Code is run from the {1}.", `cl.exe ${this.buildAndDebugActiveFileStr()}`, "Developer Command Prompt for VS"));
+            }, "{0} is only usable when VS Code is run from the {1}.", `cl.exe ${this.buildAndDebugActiveFileStr()}`, "Developer Command Prompt for VS"));
             return true;
         }
         return false;

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -584,8 +584,10 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
 
     private showErrorIfClNotAvailable(_configurationLabel: string): boolean {
         if (!process.env.DevEnvDir || process.env.DevEnvDir.length === 0) {
-            void vscode.window.showErrorMessage(localize({ key: "cl.exe.not.available",
-                comment: ["{0} is a command option in a menu. {1} is the product name \"Developer Command Prompt for VS\"."] },
+            void vscode.window.showErrorMessage(localize({
+                key: "cl.exe.not.available",
+                comment: ["{0} is a command option in a menu. {1} is the product name \"Developer Command Prompt for VS\"."]
+            },
                 "{0} is only usable when VS Code is run from the {1}.", `cl.exe ${this.buildAndDebugActiveFileStr()}`, "Developer Command Prompt for VS"));
             return true;
         }


### PR DESCRIPTION
Fix for one case of https://github.com/microsoft/vscode-cpptools/issues/12909 .

Remove eslint indentation check which conflicts with the TypeScript formatter (eslint no longer formats).