### PR TITLE
Fix .editorConfig setting precedence

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1285,6 +1285,8 @@ export class DefaultClient implements Client {
                 void vscode.window.showErrorMessage(localize("unable.to.start", "Unable to start the C/C++ language server. IntelliSense features will be disabled. Error: {0}", additionalInfo));
             }
         }
+
+        this.updateActiveDocumentTextOptions();
     }
 
     private async init(rootUri: vscode.Uri | undefined, isFirstClient: boolean) {

--- a/Extension/src/LanguageServer/editorConfig.ts
+++ b/Extension/src/LanguageServer/editorConfig.ts
@@ -165,8 +165,8 @@ function getEditorConfig(filePath: string): any {
             Object.keys(configData).forEach((section: string) => {
                 if (section !== '*' && matchesSection(currentDirForwardSlashes, filePath, section)) {
                     combinedConfig = {
-                        ...combinedConfig,
-                        ...configData[section]
+                        ...configData[section],
+                        ...combinedConfig
                     };
                 }
             });


### PR DESCRIPTION
Fixes an issue where conflicting settings from higher level files were used when the lower/closer values should have been used.

Also added a call to `updateActiveDocumentTextOptions`, to adjust editor settings immediately after init, to handle the already-active file.