### PR TITLE
Combine ProjectContext and RelatedFilesProvider Telemetry in One Event

### DIFF
--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -48,7 +48,7 @@ export async function registerRelatedFilesProvider(): Promise<void> {
                         try {
                             const getIncludesHandler = async () => (await getIncludes(uri, 1))?.includedFiles.map(file => vscode.Uri.file(file)) ?? [];
                             const getTraitsHandler = async () => {
-                                const projectContext = await getProjectContext(uri, context);
+                                const projectContext = await getProjectContext(uri, context, telemetryProperties, telemetryMetrics);
 
                                 if (!projectContext) {
                                     return undefined;


### PR DESCRIPTION
- This allows calculating the time spent on the extension side vs the language server side.
- Also send filter telemetry if available.