### PR TITLE
Remove cpptools1 experiment flag from Symbol Search

### DIFF
--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
 import { ResponseError } from 'vscode-languageclient';
-import { isExperimentEnabled } from '../../telemetry';
 import { DefaultClient, GetSymbolInfoRequest, LocalizeSymbolInformation, SymbolScope, WorkspaceSymbolParams } from '../client';
 import { getLocalizedString, getLocalizedSymbolScope } from '../localization';
 import { RequestCancelled, ServerCancelled } from '../protocolFilter';

--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -23,8 +23,7 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
         }
 
         const params: WorkspaceSymbolParams = {
-            query: query,
-            experimentEnabled: await isExperimentEnabled('CppTools1')
+            query: query
         };
 
         let symbols: LocalizeSymbolInformation[];

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -307,7 +307,6 @@ export interface GetDocumentSymbolRequestParams {
 
 export interface WorkspaceSymbolParams extends WorkspaceFolderParams {
     query: string;
-    experimentEnabled: boolean;
 }
 
 export enum SymbolScope {


### PR DESCRIPTION
No longer needed, so removing the flag from the API call. 