### PR TITLE
Fix an undefined access when an edit is done before cpptools starts

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1839,11 +1839,11 @@ export class DefaultClient implements Client {
         await this.languageClient.sendNotification(DidChangeTextEditorVisibleRangesNotification, params);
     }
 
-    public async onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): Promise<void> {
-        await this.ready;
+    public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
         if (util.isCpp(textDocumentChangeEvent.document)) {
             // If any file has changed, we need to abort the current rename operation
-            if (workspaceReferences.renamePending) {
+            if (workspaceReferences !== undefined // Occurs when a document changes before cpptools starts.
+                && workspaceReferences.renamePending) {
                 workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.User);
             }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1858,11 +1858,7 @@ export class DefaultClient implements Client {
     public onDidOpenTextDocument(document: vscode.TextDocument): void {
         if (document.uri.scheme === "file") {
             const uri: string = document.uri.toString();
-            const oldVersion: number | undefined = openFileVersions.get(uri);
-            const newVersion: number = document.version;
-            if (oldVersion === undefined || newVersion > oldVersion) {
-                openFileVersions.set(uri, document.version);
-            }
+            openFileVersions.set(uri, document.version);
             void SessionState.buildAndDebugIsSourceFile.set(util.isCppOrCFile(document.uri));
             void SessionState.buildAndDebugIsFolderOpen.set(util.isFolderOpen(document.uri));
         } else {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1839,11 +1839,11 @@ export class DefaultClient implements Client {
         await this.languageClient.sendNotification(DidChangeTextEditorVisibleRangesNotification, params);
     }
 
-    public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
+    public async onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): Promise<void> {
+        await this.ready;
         if (util.isCpp(textDocumentChangeEvent.document)) {
             // If any file has changed, we need to abort the current rename operation
-            if (workspaceReferences !== undefined // Occurs when a document changes before cpptools starts.
-                && workspaceReferences.renamePending) {
+            if (workspaceReferences.renamePending) {
                 workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.User);
             }
 

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1858,7 +1858,11 @@ export class DefaultClient implements Client {
     public onDidOpenTextDocument(document: vscode.TextDocument): void {
         if (document.uri.scheme === "file") {
             const uri: string = document.uri.toString();
-            openFileVersions.set(uri, document.version);
+            const oldVersion: number | undefined = openFileVersions.get(uri);
+            const newVersion: number = document.version;
+            if (oldVersion === undefined || newVersion > oldVersion) {
+                openFileVersions.set(uri, document.version);
+            }
             void SessionState.buildAndDebugIsSourceFile.set(util.isCppOrCFile(document.uri));
             void SessionState.buildAndDebugIsFolderOpen.set(util.isFolderOpen(document.uri));
         } else {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1842,7 +1842,8 @@ export class DefaultClient implements Client {
     public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
         if (util.isCpp(textDocumentChangeEvent.document)) {
             // If any file has changed, we need to abort the current rename operation
-            if (workspaceReferences.renamePending) {
+            if (workspaceReferences !== undefined // Occurs when a document changes before cpptools starts.
+                && workspaceReferences.renamePending) {
                 workspaceReferences.cancelCurrentReferenceRequest(refs.CancellationSender.User);
             }
 

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -298,7 +298,7 @@ async function onDidChangeSettings(event: vscode.ConfigurationChangeEvent): Prom
     }
 }
 
-async function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): Promise<void> {
+function onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
     const me: Client = clients.getClientFor(event.document.uri);
     me.onDidChangeTextDocument(event);
 }


### PR DESCRIPTION
I reproed it with 1.23.4, but not 1.22.11, so it seems like a regression, but I don't know from what change.

![image](https://github.com/user-attachments/assets/fb43dc4d-2610-4d69-8630-679ff7e16456)
