### PR TITLE
Fix a potential race between `didChange` and `didOpen`

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -172,12 +172,11 @@ export async function activate(): Promise<void> {
         getCustomConfigProviders().forEach(provider => void client.onRegisterCustomConfigurationProvider(provider));
     });
 
-    // These handlers for didChangeTextDocument and didOpenTextDocument are intentionally non-async and are
+    // These handlers for didChangeTextDocument and didOpenTextDocument are intentionally synchronous and are
     // intended primarily to maintain openFileVersions with the most recent versions of files, as quickly as
-    // possible, without being invoked before complete, delayed by awaits or queued behind other LSP messages, etc..
+    // possible, without being delayed by awaits or queued behind other LSP messages, etc..
     disposables.push(vscode.workspace.onDidChangeTextDocument(onDidChangeTextDocument));
     disposables.push(vscode.workspace.onDidOpenTextDocument(onDidOpenTextDocument));
-
 
     disposables.push(vscode.workspace.onDidChangeConfiguration(onDidChangeSettings));
     disposables.push(vscode.window.onDidChangeTextEditorVisibleRanges((e) => clients.ActiveClient.enqueue(async () => onDidChangeTextEditorVisibleRanges(e))));

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -38,7 +38,6 @@ export function createProtocolFilter(): Middleware {
                         return;
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
-                    client.onDidOpenTextDocument(document);
                     client.takeOwnership(document);
                     void sendMessage(document);
                 }


### PR DESCRIPTION
Fixes a potential (probably rare?) issue where it's possible that a call to `onDidChangeTextDocument` might happen before a call to `onDidOpenTextDocument`, due to didOpen being delayed (processed by the protocol filter, after prior messages in queue). This could result the file's version in `openFileVersions` becoming incorrect (though would be corrected by subsequent edits).

`onDidOpenTextDocument` and `onDidChangeTextDocument` primarily maintain `openFileVersions`, and update UI state.  This change calls `onDidOpenTextDocument` using a synchronous handler, instead of being processed by the protocol filter, ensuring no awaiting or prior queue work will delay it, similar to what we were already doing with `onDidChangeTextDocument`.

Having `openFileVersions` kept as closely in sync as possible with the editor ensures we properly discard results for operations that shouldn't be applied if the document has since changed.