### PR TITLE
Fix an issue with editorconfig tab_size

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2914,15 +2914,21 @@ export class DefaultClient implements Client {
             const settings: CppSettings = new CppSettings(this.RootUri);
             if (settings.useVcFormat(editor.document)) {
                 const editorConfigSettings: any = getEditorConfigSettings(editor.document.uri.fsPath);
-                if (editorConfigSettings.indent_style === "space" || editorConfigSettings.indent_style === "tab") {
-                    editor.options.insertSpaces = editorConfigSettings.indent_style === "space";
+                if (editorConfigSettings.indent_style === "tab") {
+                    editor.options.insertSpaces = false;
+                } else if (editorConfigSettings.indent_style === "space") {
+                    editor.options.insertSpaces = true;
+                }
+                if (editorConfigSettings.indent_size !== undefined) {
                     if (editorConfigSettings.indent_size === "tab") {
-                        if (!editorConfigSettings.tab_width !== undefined) {
-                            editor.options.tabSize = editorConfigSettings.tab_width;
-                        }
-                    } else if (editorConfigSettings.indent_size !== undefined) {
+                        editor.options.indentSize = "tabSize";
+                    } else {
+                        editor.options.indentSize = editorConfigSettings.indent_size;
                         editor.options.tabSize = editorConfigSettings.indent_size;
                     }
+                }
+                if (editorConfigSettings.tab_width !== undefined) {
+                    editor.options.tabSize = editorConfigSettings.tab_width;
                 }
                 if (editorConfigSettings.end_of_line !== undefined) {
                     void editor.edit((edit) => {


### PR DESCRIPTION
Fixes an issue with `.editorconfig` `tab_size` not being applied to VS Code's tab size when in "space" (soft tab) mode.

I ran into this with the EDG codebase. (`host_envir.c/.h` are much easier to look at now).

The new check seems simpler:
- First, `indent_style` is applied, only if present, to VS Code's `insertSpaces` option.
- Independently of that, `indent_size` is applied to VS Code's `indentSize` AND `tabSize` (as a fallback/default). 
    - Or, if it's the special value `tab`, VS Code's `indentSize` option is set to its own special value of `tabSize` (telling VS Code to use the value of `tabSize` instead). 
- Then, also independent of the other two options, if `tab_width` is specified, it's applied to VS Code's `tabSize` option.

Based on information here:
 - https://editorconfig.org
 - https://github.com/microsoft/vscode/blob/92fb591f1b8f26539a80c5269fa6fb6f0b9499ee/src/vscode-dts/vscode.d.ts#L672-L696
 