### PR TITLE
 Add check for copilot access before providing copilot hover

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1316,8 +1316,7 @@ export class DefaultClient implements Client {
 
                 const settings: CppSettings = new CppSettings();
                 this.currentCopilotHoverEnabled = new PersistentWorkspaceState<string>("cpp.copilotHover", settings.copilotHover);
-                if (settings.copilotHover === "enabled" ||
-                    (settings.copilotHover === "default" && await telemetry.isFlightEnabled("CppCopilotHover"))) {
+                if (settings.copilotHover !== "disabled") {
                     this.copilotHoverProvider = new CopilotHoverProvider(this);
                     this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, this.copilotHoverProvider));
                 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1469,10 +1469,10 @@ async function onCopilotHover(): Promise<void> {
         vscode.LanguageModelChatMessage
             .User(requestInfo.content + locale)];
 
-    const [model] = await vscodelm.selectChatModels(modelSelector);
-
     let chatResponse: vscode.LanguageModelChatResponse | undefined;
     try {
+        const [model] = await vscodelm.selectChatModels(modelSelector);
+
         chatResponse = await model.sendRequest(
             messages,
             {},


### PR DESCRIPTION
This will prevent users from unintentionally seeing the copilot prompt if they do not have copilot enabled or are not signed in.

This also moves the A/B flight check to after the copilot validation, which should ensure only valid users are assigned a flight group.