### PR TITLE
Don't abort instantly, keep searching

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1450,7 +1450,7 @@ export function findPowerShell(): string | undefined {
                     return name;
                 }
             } catch (e) {
-                return undefined;
+                // ignore, try next candidate
             }
         }
     }


### PR DESCRIPTION
It should not abort instantly when looking for powershell or pwsh

fixes #13137 