### PR TITLE
Don't use 'system' include/framework paths as fallback 'user' include/framework paths in the base config

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -120,8 +120,6 @@ export interface CompilerDefaults {
     knownCompilers: KnownCompiler[];
     cStandard: string;
     cppStandard: string;
-    includes: string[];
-    frameworks: string[];
     windowsSdkVersion: string;
     intelliSenseMode: string;
     trustedCompilerFound: boolean;
@@ -295,8 +293,6 @@ export class CppProperties {
         this.knownCompilers = compilerDefaults.knownCompilers;
         this.defaultCStandard = compilerDefaults.cStandard;
         this.defaultCppStandard = compilerDefaults.cppStandard;
-        this.defaultIncludes = compilerDefaults.includes;
-        this.defaultFrameworks = compilerDefaults.frameworks;
         this.defaultWindowsSdkVersion = compilerDefaults.windowsSdkVersion;
         this.defaultIntelliSenseMode = compilerDefaults.intelliSenseMode !== "" ? compilerDefaults.intelliSenseMode : undefined;
         this.trustedCompilerFound = compilerDefaults.trustedCompilerFound;
@@ -349,7 +345,7 @@ export class CppProperties {
     }
 
     private async applyDefaultIncludePathsAndFrameworks() {
-        if (this.configurationIncomplete && this.defaultIncludes && this.defaultFrameworks && this.vcpkgPathReady) {
+        if (this.configurationIncomplete && this.vcpkgPathReady) {
             const configuration: Configuration | undefined = this.CurrentConfiguration;
             if (configuration) {
                 this.applyDefaultConfigurationValues(configuration);

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -141,8 +141,6 @@ export class CppProperties {
     private knownCompilers?: KnownCompiler[];
     private defaultCStandard: string | null = null;
     private defaultCppStandard: string | null = null;
-    private defaultIncludes: string[] | null = null;
-    private defaultFrameworks?: string[];
     private defaultWindowsSdkVersion: string | null = null;
     private isCppPropertiesJsonVisible: boolean = false;
     private vcpkgIncludes: string[] = [];
@@ -377,9 +375,6 @@ export class CppProperties {
         // browse.path is not set by default anymore. When it is not set, the includePath will be used instead.
         if (isUnset(settings.defaultDefines)) {
             configuration.defines = (process.platform === 'win32') ? ["_DEBUG", "UNICODE", "_UNICODE"] : [];
-        }
-        if (isUnset(settings.defaultMacFrameworkPath) && process.platform === 'darwin') {
-            configuration.macFrameworkPath = this.defaultFrameworks;
         }
         if ((isUnset(settings.defaultWindowsSdkVersion) || settings.defaultWindowsSdkVersion === "") && this.defaultWindowsSdkVersion && process.platform === 'win32') {
             configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
@@ -967,13 +962,6 @@ export class CppProperties {
                         }
                         if (!configuration.windowsSdkVersion && !!this.defaultWindowsSdkVersion) {
                             configuration.windowsSdkVersion = this.defaultWindowsSdkVersion;
-                        }
-                        if (!origIncludePath && !!this.defaultIncludes) {
-                            const includePath: string[] = configuration.includePath || [];
-                            configuration.includePath = includePath.concat(this.defaultIncludes);
-                        }
-                        if (!configuration.macFrameworkPath && !!this.defaultFrameworks) {
-                            configuration.macFrameworkPath = this.defaultFrameworks;
                         }
                     }
                 } else {


### PR DESCRIPTION
It looks like this code was falling back to inserting the compiler default 'system' include paths (and framework search paths) into the 'user' base configuration.  I don't think this is correct.  If a compiler is not specified (the only case these includes were being used), the detected default compiler will be used (if trusted) and its system include paths used automatically (without requiring them added this way).

Maybe this was intended to fall back to inserting these into the 'user' config when falling back to a detected default compiler that isn't trusted?  But if the compiler isn't trusted, we wouldn't have been able to query it for system include paths.  In the case of cl.exe (which we don't need to query), that is implicitly trusted (since we don't actually need to query it).