### PR TITLE
Fix Copilot hover reprompting.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1340,6 +1340,9 @@ export class DefaultClient implements Client {
                     this.copilotHoverProvider = new CopilotHoverProvider(this);
                     this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, this.copilotHoverProvider));
                 }
+                if (settings.copilotHover !== this.currentCopilotHoverEnabled.Value) {
+                    this.currentCopilotHoverEnabled.Value = settings.copilotHover;
+                }
                 this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, this.hoverProvider));
                 this.disposables.push(vscode.languages.registerInlayHintsProvider(util.documentSelector, this.inlayHintsProvider));
                 this.disposables.push(vscode.languages.registerRenameProvider(util.documentSelector, new RenameProvider(this)));


### PR DESCRIPTION
Reported by Colen. The persistent state value wasn't getting updated on load. I verified it fixes the reprompting on load after a settings change and that the prompt appears after a settings change (and not after the reload).

The currentCaseSensitiveFileSupport persistent state follows the same pattern.