### PR TITLE
Fix an issue with C: treated as a relative path

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1575,7 +1575,7 @@ export class CppProperties {
                 result = result.slice(1, -1);
             }
             // On Windows, isAbsolute does not handle root paths without a slash, such as "C:"
-            const isWindowsRootPath: boolean = (process.platform === 'win32' && /^[a-zA-Z]:$/.test(result));
+            const isWindowsRootPath: boolean = process.platform === 'win32' && /^[a-zA-Z]:$/.test(result);
             // Make sure all paths result to an absolute path.
             // Do not add the root path to an unresolved env variable.
             if (!isWindowsRootPath && !result.includes("env:") && !path.isAbsolute(result) && this.rootUri) {

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1574,9 +1574,11 @@ export class CppProperties {
                 quoted = true;
                 result = result.slice(1, -1);
             }
+            // On Windows, isAbsolute does not handle root paths without a slash, such as "C:"
+            const isWindowsRootPath: boolean = (process.platform === 'win32' && /^[a-zA-Z]:$/.test(result));
             // Make sure all paths result to an absolute path.
             // Do not add the root path to an unresolved env variable.
-            if (!result.includes("env:") && !path.isAbsolute(result) && this.rootUri) {
+            if (!isWindowsRootPath && !result.includes("env:") && !path.isAbsolute(result) && this.rootUri) {
                 result = path.join(this.rootUri.fsPath, result);
             }
             if (quoted) {


### PR DESCRIPTION
Fixes an issue where an include path or browse path that points to the root of a Windows drive without a trailing "\" is misinterpreted as a relative path.  This change prevents the workspace folder from being appended to it.