### PR TITLE
Update README and metadata for extension pack

### DIFF
--- a/ExtensionPack/README.md
+++ b/ExtensionPack/README.md
@@ -3,5 +3,4 @@
 This extension pack includes a set of popular extensions for C++ development in Visual Studio Code:
 * [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 * [C/C++ Themes](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-themes)
-* [CMake](https://marketplace.visualstudio.com/items?itemName=twxs.cmake)
 * [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)

--- a/ExtensionPack/package.json
+++ b/ExtensionPack/package.json
@@ -9,12 +9,13 @@
       "name": "Microsoft Corporation"
     },
     "license": "SEE LICENSE IN LICENSE.txt",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "engines": {
         "vscode": "^1.48.0"
     },
     "categories": [
-        "Extension Packs"
+        "Extension Packs",
+        "Programming Languages"
     ],
     "activationEvents": [
         "onCommand:ms-vscode.cpptools-extension-pack.unavailableCommand"


### PR DESCRIPTION
CMake Tools no longer bundles the CMake extension by twxs.