### PR TITLE
The other extensions don't build with yarn

### DIFF
--- a/Build/package/jobs_package_vsix.yml
+++ b/Build/package/jobs_package_vsix.yml
@@ -44,7 +44,7 @@ jobs:
     displayName: Run VSCE to package vsix
     inputs:
       filename: vsce
-      arguments: package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\${{ parameters.vsixName }}
+      arguments: package -o $(Build.ArtifactStagingDirectory)\vsix\${{ parameters.vsixName }}
       workingFolder: $(Build.SourcesDirectory)\${{ parameters.srcDir }}
 
   - task: Npm@0


### PR DESCRIPTION
We hadn't needed to republish the themes or extension pack extensions since we migrated to yaml, so this issue was not caught yet. 