### PR TITLE
Add `reduceRecursiveIncludes` setting

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -973,6 +973,12 @@
                             ]
                         },
                         "scope": "resource"
+                    },
+                    "C_Cpp.reduceRecursiveIncludes": {
+                        "type": "boolean",
+                        "default": true,
+                        "markdownDescription": "%c_cpp.configuration.reduceRecursiveIncludes.markdownDescription%",
+                        "scope": "window"
                     }
                 }
             },

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -809,6 +809,7 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
+    "c_cpp.configuration.reduceRecursiveIncludes.markdownDescription": "Indicates whether recursive include paths should be reduced to only those currently referenced by the translation unit. If enabled, performance is impacted if the database needs to be populated to determine headers used. If disabled, performance may be impacted due to passing a large number of include paths to the IntelliSense process.",
     "c_cpp.configuration.debugger.useBacktickCommandSubstitution.markdownDescription": {
         "message": "If `true`, debugger shell command substitution will use obsolete backtick ``(`)``.",
         "comment": [

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1574,6 +1574,7 @@ export class DefaultClient implements Client {
             enhancedColorization: workspaceSettings.isEnhancedColorizationEnabled,
             intellisenseMaxCachedProcesses: workspaceSettings.intelliSenseMaxCachedProcesses,
             intellisenseMaxMemory: workspaceSettings.intelliSenseMaxMemory,
+            reduceRecursiveIncludes: workspaceSettings.reduceRecursiveIncludes,
             referencesMaxConcurrentThreads: workspaceSettings.referencesMaxConcurrentThreads,
             referencesMaxCachedProcesses: workspaceSettings.referencesMaxCachedProcesses,
             referencesMaxMemory: workspaceSettings.referencesMaxMemory,

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -156,6 +156,7 @@ export interface SettingsParams {
     enhancedColorization: boolean;
     intellisenseMaxCachedProcesses: number | null;
     intellisenseMaxMemory: number | null;
+    reduceRecursiveIncludes: boolean;
     referencesMaxConcurrentThreads: number | null;
     referencesMaxCachedProcesses: number | null;
     referencesMaxMemory: number | null;
@@ -481,6 +482,7 @@ export class CppSettings extends Settings {
         return super.Section.get<string>("cppCodeSnippetsFeatureNames");
     }
     public get formattingEngine(): string { return this.getAsString("formatting"); }
+    public get reduceRecursiveIncludes(): boolean { return this.getAsBoolean("reduceRecursiveIncludes"); }
     public get vcFormatIndentBraces(): boolean { return this.getAsBoolean("vcFormat.indent.braces"); }
     public get vcFormatIndentMultiLineRelativeTo(): string { return this.getAsString("vcFormat.indent.multiLineRelativeTo"); }
     public get vcFormatIndentWithinParentheses(): string { return this.getAsString("vcFormat.indent.withinParentheses"); }


### PR DESCRIPTION
Adding as a fully-fledged setting, for now.  If we encounter issues when testing with it set to false, we could hide the setting.  Requires the corresponding PR in the language server.