### PR TITLE
Fix Copilot hover warning in the ExtensionHost logging.

### DIFF
--- a/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
@@ -46,7 +46,7 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
             }
         }
 
-        if (settings.copilotHover === "default") {
+        if (new CppSettings().copilotHover === "default") {
             // Check flight to make sure the feature is enabled.
             if (!await telemetry.isFlightEnabled("CppCopilotHover")) {
                 return undefined;


### PR DESCRIPTION
Fixes `[warning] [ms-vscode.cpptools] Accessing a window scoped configuration for a resource is not expected. To associate 'C_Cpp.copilotHover' to a resource, define its scope to 'resource' in configuration contributions in 'package.json'.`

It is strange for hover to per-workspace folder and copilot hover to per-workspace, but I don't think it matters, i.e. if enough users complain maybe we could make copilot hover per-workspace folder as well.