### PR TITLE
Fix ${workspaceFolder} being added to browse.path if ${workspaceFolder}/* is used.

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -998,10 +998,15 @@ export class CppProperties {
                 } else if (configuration.includePath) {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
-                    if (configuration.includePath.findIndex((value: string) =>
-                        !!value.match(/^\$\{(workspaceRoot|workspaceFolder)\}(\\\*{0,2}|\/\*{0,2})?$/g)) === -1
-                    ) {
-                        configuration.browse.path.push("${workspaceFolder}");
+                    if (this.rootUri) {
+                        let normalizedRootUriFsPath: string = escapeStringRegExp(this.rootUri.fsPath.replace(/\\/g, "/"));
+                        let regexPattern = `^${normalizedRootUriFsPath}(\\*{0,2}|\/\\*{0,2})?$`;
+                        let regex = new RegExp(regexPattern, "g");
+                        if (configuration.includePath.findIndex((value: string) =>
+                            !!value.match(regex)) === -1
+                        ) {
+                            configuration.browse.path.push("${workspaceFolder}");
+                        }
                     }
                 } else {
                     configuration.browse.path = ["${workspaceFolder}"];

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -999,9 +999,9 @@ export class CppProperties {
                     // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
                     configuration.browse.path = configuration.includePath.slice(0);
                     if (this.rootUri) {
-                        let normalizedRootUriFsPath: string = escapeStringRegExp(this.rootUri.fsPath.replace(/\\/g, "/"));
-                        let regexPattern = `^${normalizedRootUriFsPath}(\\*{0,2}|\/\\*{0,2})?$`;
-                        let regex = new RegExp(regexPattern, "g");
+                        const normalizedRootUriFsPath: string = escapeStringRegExp(this.rootUri.fsPath.replace(/\\/g, "/"));
+                        const regexPattern = `^${normalizedRootUriFsPath}(\\*{0,2}|\/\\*{0,2})?$`;
+                        const regex = new RegExp(regexPattern, "g");
                         if (configuration.includePath.findIndex((value: string) =>
                             !!value.match(regex)) === -1
                         ) {


### PR DESCRIPTION
This was working with 1.16.3, but then some change caused the ${workspaceFolder} variable to be resolved before it checked for ${workspaceFolder} at this spot, so the regex match would always fail. This just fixes it so that the previously working case works now.