### PR TITLE
Let native process populate default browse paths

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -995,17 +995,9 @@ export class CppProperties {
             if (!configuration.browse.path) {
                 if (settings.defaultBrowsePath) {
                     configuration.browse.path = settings.defaultBrowsePath;
-                } else if (configuration.includePath) {
-                    // If the user doesn't set browse.path, copy the includePath over. Make sure ${workspaceFolder} is in there though...
-                    configuration.browse.path = configuration.includePath.slice(0);
-                    if (configuration.includePath.findIndex((value: string) =>
-                        !!value.match(/^\$\{(workspaceRoot|workspaceFolder)\}(\\\*{0,2}|\/\*{0,2})?$/g)) === -1
-                    ) {
-                        configuration.browse.path.push("${workspaceFolder}");
-                    }
-                } else {
-                    configuration.browse.path = ["${workspaceFolder}"];
                 }
+                // Otherwise, if the browse path is not set, let the native process populate it
+                // with include paths, including any parsed from compilerArgs.
             } else {
                 configuration.browse.path = this.updateConfigurationPathsArray(configuration.browse.path, settings.defaultBrowsePath, env);
             }


### PR DESCRIPTION
There is a change (pending) on the native side that will populate the browse paths there, if undefined, after compiler arguments have been parsed, so any include paths there can be included by default.