### PR TITLE
Work around E2E test failure

### DIFF
--- a/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
+++ b/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
@@ -12,10 +12,11 @@ import { suite } from 'mocha';
 import * as vscode from 'vscode';
 import * as api from 'vscode-cpptools';
 import * as apit from 'vscode-cpptools/out/testApi';
+import { sleep } from '../../../../src/Utility/Async/sleep';
 import { timeout } from '../../../../src/Utility/Async/timeout';
 import * as testHelpers from '../../../common/testHelpers';
 
-suite("[Inlay hints test]", function(): void {
+suite("[Inlay hints test]", function (): void {
     // Settings
     const inlayHintSettings: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('C_Cpp.inlayHints');
     const autoDeclarationTypesEnabled: string = "autoDeclarationTypes.enabled";
@@ -41,7 +42,7 @@ suite("[Inlay hints test]", function(): void {
     const fileUri: vscode.Uri = vscode.Uri.file(filePath);
     const disposables: vscode.Disposable[] = [];
 
-    suiteSetup(async function(): Promise<void> {
+    suiteSetup(async function (): Promise<void> {
         await testHelpers.activateCppExtension();
 
         const cpptools = await apit.getCppToolsTestApi(api.Version.latest) ?? assert.fail("Could not get cpptools test api");
@@ -74,7 +75,7 @@ suite("[Inlay hints test]", function(): void {
         await useDefaultSettings();
     });
 
-    suiteTeardown(async function(): Promise<void> {
+    suiteTeardown(async function (): Promise<void> {
         await restoreOriginalSettings();
         disposables.forEach(d => d.dispose());
     });
@@ -298,6 +299,9 @@ suite("[Inlay hints test]", function(): void {
             await inlayHintSettings.update(inlayHintSetting, valueNew, vscode.ConfigurationTarget.Global);
             const valueAfterChange: any = inlayHintSettings.inspect(inlayHintSetting)!.globalValue;
             assert.strictEqual(valueAfterChange, valueNew, `Unable to change setting: ${inlayHintSetting}`);
+            // TODO: We need a way to synchronize with native process having completely processed the setting change
+            // and any changes in behavior being fully applied.
+            sleep(5000);
         }
     }
 

--- a/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
+++ b/Extension/test/scenarios/MultirootDeadlockTest/tests/inlayhints.test.ts
@@ -301,7 +301,7 @@ suite("[Inlay hints test]", function (): void {
             assert.strictEqual(valueAfterChange, valueNew, `Unable to change setting: ${inlayHintSetting}`);
             // TODO: We need a way to synchronize with native process having completely processed the setting change
             // and any changes in behavior being fully applied.
-            sleep(5000);
+            await sleep(5000);
         }
     }
 


### PR DESCRIPTION
Recent changes impacted the performance of `didChangeCppProperties` on macOS, due to needing to resolve sub-frameworks up-front.  This surfaced an existing issue in the E2E tests.

Issue 1: When settings are changed, that is always resulting in **TWO** `didChangeCppProperties` messages.  One appears to be redundant. If the changed setting(s) would not impact the configuration, neither are actually needed.  I haven't yet investigated that.  I'm guessing that addressing it may require some refactoring of settings processing on the TypeScript side.  That issue is not addressed by this PR.

Issue 2: The inlay hints tests were changing settings 39 times without synchronizing with completed processing of those setting changes.  As a result, there's a backlog of settings changes in queue as the next test starts, causing it to timeout waiting for the result of later requests.

This change works around the issue with a (large/safe) sleep as each setting change is made.

A proper fix would involve finding some way to synchronize with the setting changes being completely applied.