### PR TITLE
match Copilot's CanceledError which has name == message == "Canceled".

### DIFF
--- a/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
@@ -23,12 +23,13 @@ class DefaultValueFallback extends Error {
 
 class CancellationError extends Error {
     static readonly Canceled = "Canceled";
-    constructor() { super(CancellationError.Canceled); }
+    constructor() {
+        super(CancellationError.Canceled);
+        this.name = this.message;
+    }
 }
 
-class InternalCancellationError extends Error {
-    static readonly Canceled = "CpptoolsCanceled";
-    constructor() { super(InternalCancellationError.Canceled); }
+class InternalCancellationError extends CancellationError {
 }
 
 class CopilotCancellationError extends CancellationError {


### PR DESCRIPTION
This avoids having error entries logged for a CancellationError.