### PR TITLE
Fix loc for link text "C/C++ Properties Schema Reference".

### DIFF
--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -426,7 +426,7 @@
 
         <div style="height: 30px; display: block"></div>
 
-        <span data-loc-id="check.the.schema">Learn more about the C/C++ properties by going to <a href="https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference" title="Properties Schema Reference" data-loc-id-title="view.schema.reference">C/C++ Properties Schema Reference</a>.</span><br>
+        <span data-loc-id="check.the.schema">Learn more about the C/C++ properties by going to <a data-loc-id="cpp.properties.schema.reference" href="https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference" title="Properties Schema Reference" data-loc-id-title="view.schema.reference">C/C++ Properties Schema Reference</a>.</span><br>
     </div>
 
   </div> <!-- sidebar end -->


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-cpptools/issues/13235