### PR TITLE
Set the extensionKind.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -23,6 +23,9 @@
     },
     "homepage": "https://github.com/Microsoft/vscode-cpptools",
     "qna": "https://github.com/Microsoft/vscode-cpptools/issues",
+    "extensionKind": [
+        "workspace"
+    ],
     "keywords": [
         "C",
         "C++",


### PR DESCRIPTION
Possibly related to https://github.com/microsoft/vscode-cpptools/issues/13360 . The user said VS Code was trying to load our extension in the web worker extensionhost, which shouldn't be possible, but this makes it explicit that the extensionKind should be "workspace" (hopefully not "web" which seems like it might be an internal value?).