### PR TITLE
Remove updateChannel setting

### DIFF
--- a/Extension/i18n/chs/package.i18n.json
+++ b/Extension/i18n/chs/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "要用于系统包含路径的值。如果设置，则其将替换通过 `compilerPath` 和 `compileCommands` 设置获取的系统包含路径。",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "控制扩展是否将报告在 `c_cpp_properties.json` 中检测到的错误。",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "未设置 `customConfigurationVariables` 时要在配置中使用的值，或 `${default}` 在 `customConfigurationVariables` 中作为键存在时要插入的值。",
-	"c_cpp.configuration.updateChannel.markdownDescription": "设置为 `Insiders` 以自动下载并安装扩展的最新预览体验版本，其中包含即将推出的功能和 bug 修复。",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "此设置已弃用。预发行版扩展现在可通过市场获得。",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "未指定 `dotConfig` 时要在配置中使用的值，或 `dotConfig` 中存在 `${default}` 时要插入的值。",
 	"c_cpp.configuration.experimentalFeatures.description": "控制“实验性”功能是否可用。",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "如果为 `true`，则由语言服务器提供片段。",

--- a/Extension/i18n/cht/package.i18n.json
+++ b/Extension/i18n/cht/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "要用於系統包含路徑的值。若設定，會覆寫透過 `compilerPath` 和 `compileCommands` 設定所取得的系統包含路徑。",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "控制延伸模組是否會回報 `c_cpp_properties.json` 中偵測到的錯誤。",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "當未設定 `customConfigurationVariables` 時要在組態中使用的值，或當 `${default}` 在 `customConfigurationVariables` 中顯示為索引鍵時要插入的值。",
-	"c_cpp.configuration.updateChannel.markdownDescription": "設定為 `Insiders` 以自動下載並安裝最新的延伸模組測試人員組建，其中包括即將推出的功能和錯誤修正。",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "此設定已過時。發行前版本擴充功能現在可透過 Marketplace 取得。",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "當 `dotConfig` 未指定時，要在設定中使用的值，或 `dotConfig` 中有 `${default}` 時要插入的值。",
 	"c_cpp.configuration.experimentalFeatures.description": "控制「實驗性」功能是否可用。",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "若為 `true`，則由語言伺服器提供程式碼片段。",

--- a/Extension/i18n/csy/package.i18n.json
+++ b/Extension/i18n/csy/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Hodnota, která se použije pro systémovou cestu pro vložené soubory. Pokud se nastaví, přepíše systémovou cestu pro vložené soubory získanou z nastavení `compilerPath` a `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Určuje, jestli rozšíření ohlásí chyby zjištěné v souboru `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Hodnota, která se použije v konfiguraci, pokud se nenastaví `customConfigurationVariables`, nebo hodnoty, které se mají vložit, pokud se v `customConfigurationVariables` jako klíč nachází `${default}`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Pokud chcete automaticky stahovat a instalovat nejnovější sestavení rozšíření v programu Insider, která zahrnují připravované funkce a opravy chyb, nastavte možnost `Insiders`.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Toto nastavení je zastaralé. Předběžné verze rozšíření jsou teď dostupné přes Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Hodnota, která se použije v konfiguraci, pokud se nezadá `dotConfig`, nebo hodnota, která se má vložit, pokud se v `dotConfig` nachází `${default}`",
 	"c_cpp.configuration.experimentalFeatures.description": "Určuje, jestli je možné použít experimentální funkce.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Pokud se nastaví na `true`, jazykový server poskytne fragmenty kódu.",

--- a/Extension/i18n/deu/package.i18n.json
+++ b/Extension/i18n/deu/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Der Wert, der für den System-Includepfad verwendet werden soll. Wenn diese Option festgelegt ist, wird der über die Einstellungen `compilerPath` und `compileCommands` abgerufene System-Includepfad überschrieben.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Steuert, ob die Erweiterung in `c_cpp_properties.json` erkannte Fehler meldet.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Der Wert, der in einer Konfiguration verwendet werden soll, wenn `customConfigurationVariables` nicht festgelegt ist, oder die Werte, die eingefügt werden sollen, wenn `${default}` als Schlüssel in `customConfigurationVariables` vorhanden ist.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Legen Sie den Wert auf `Insiders` fest, um die neuesten Insiders-Builds der Erweiterung (die neue Features und Bugfixes enthalten) automatisch herunterzuladen und zu installieren.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Diese Einstellung ist veraltet. Erweiterungen der Vorabversionen sind jetzt über den Marketplace verfügbar.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Der Wert, der in einer Konfiguration verwendet werden soll, wenn `dotConfig` nicht angegeben ist, oder der einzufügende Wert, wenn `${default}` in `dotConfig` vorhanden ist.",
 	"c_cpp.configuration.experimentalFeatures.description": "Hiermit wird gesteuert, ob experimentelle Features verwendet werden können.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Wenn `true` festgelegt ist, werden Codeschnipsel vom Sprachserver bereitgestellt.",

--- a/Extension/i18n/esn/package.i18n.json
+++ b/Extension/i18n/esn/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Valor que debe usarse para la ruta de acceso de inclusión del sistema. Si se establece, invalida la ruta de acceso de inclusión del sistema adquirida a través de las opciones de configuración `compilerPath` y `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Controla si la extensión notificará los errores detectados en `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Valor que debe usarse en una configuración si no se establece `customConfigurationVariables`, o bien los valores que se deben insertar si se especifica `${default}` como clave en `customConfigurationVariables`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Establezca esta opción en `Insiders` para descargar e instalar automáticamente las compilaciones más recientes de Insiders para la extensión, que incluyen nuevas características y correcciones de errores.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Esta configuración está en desuso. Las extensiones de versión preliminar ya están disponibles a través de Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Valor que debe usarse en una configuración si no se especifica `dotConfig`, o bien los valores que se deben insertar si se especifica `${default}` en `dotConfig`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Controla si se pueden usar las características \"experimentales\".",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Si se establece en `true`, el servidor de lenguaje proporciona los fragmentos de código.",

--- a/Extension/i18n/fra/package.i18n.json
+++ b/Extension/i18n/fra/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Valeur à utiliser pour le chemin d'inclusion système. Si cette option est définie, elle remplace le chemin d'inclusion système obtenu via les paramètres `compilerPath` et `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Contrôle si l'extension signale les erreurs détectées dans `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Valeur à utiliser dans une configuration si `customConfigurationVariables` n'est pas défini, ou valeurs à insérer si `${default}` est présent dans `customConfigurationVariables`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Définissez la valeur `Insiders` pour télécharger et installer automatiquement les dernières builds Insider de l’extension, qui incluent les fonctionnalités à venir et les correctifs de bogues.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Ce paramètre est déconseillé. Les extensions en version préliminaire sont désormais disponibles via marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "La valeur à utiliser dans une configuration si `dotConfig` n'est pas spécifié, ou la valeur à insérer si `${default}` est présent dans `dotConfig`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Contrôle si les fonctionnalités \"expérimentales\" sont utilisables.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Si la valeur est `true`, les extraits de code sont fournis par le serveur de langage.",

--- a/Extension/i18n/ita/package.i18n.json
+++ b/Extension/i18n/ita/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Valore da usare per il percorso di inclusione di sistema. Se è impostato, esegue l'override del percorso di inclusione di sistema acquisito con le impostazioni `compilerPat` e `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Controlla se l'estensione segnala errori rilevati in `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Valore da usare in una configurazione se `customConfigurationVariables` non è impostato oppure valori da inserire se `${default}` è presente come chiave in `customConfigurationVariables`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Impostare su `Insiders` per scaricare e installare automaticamente le build Insider più recenti dell'estensione, che includono funzionalità in arrivo e correzioni di bug.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Questa impostazione è deprecata. Le versioni preliminari delle estensioni ora sono disponibili tramite il Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Il valore da usare in una configurazione se `dotConfig` non è specificato oppure il valore da inserire se `${default}` è presente in `dotConfig`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Controlla se le funzionalità \"sperimentali\" sono utilizzabili.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Se è `true`, i frammenti vengono forniti dal server di linguaggio.",

--- a/Extension/i18n/jpn/package.i18n.json
+++ b/Extension/i18n/jpn/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "システム インクルード パスに使用する値です。これを設定した場合、`compilerPath` および `compileCommands` の設定によって取得されるシステム インクルード パスが上書きされます。",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "拡張機能が、`c_cpp_properties.json` で検出されたエラーを報告するかどうかを制御します。",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "`customConfigurationVariables` が設定されていない場合に構成で使用される値、または `customConfigurationVariables` 内に `${default}` がキーとして存在する場合に挿入される値。",
-	"c_cpp.configuration.updateChannel.markdownDescription": "`Insider` に設定すると、拡張機能の最新の Insider ビルドが自動的にダウンロードされてインストールされます。これには、次期バージョンの機能とバグ修正が含まれています。",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "この設定は非推奨です。プレリリース版の拡張機能は、Marketplace で利用できるようになりました。",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "`dotConfig` が指定されていない場合に構成で使用される値、または `dotConfig` 内に `${default}` が存在する場合に挿入される値。",
 	"c_cpp.configuration.experimentalFeatures.description": "\"experimental\" の機能を使用できるかどうかを制御します。",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "`true` の場合、スニペットは言語サーバーによって提供されます。",

--- a/Extension/i18n/kor/package.i18n.json
+++ b/Extension/i18n/kor/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "시스템 포함 경로에 사용할 값입니다. 설정하는 경우 `compilerPath` 및 `compileCommands` 설정을 통해 얻은 시스템 포함 경로를 재정의합니다.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "확장이 `c_cpp_properties.json`에서 검색된 오류를 보고하도록 할지를 제어합니다.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "`customConfigurationVariables`가 설정되지 않은 경우 구성에서 사용할 값 또는 `${default}`가 `customConfigurationVariables`에 키로 존재하는 경우 삽입할 값입니다.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "예정된 기능과 버그 수정을 포함하는 확장의 최신 참가자 빌드를 자동으로 다운로드하여 설치하려면 `Insiders`로 설정합니다.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "이 설정은 사용되지 않습니다. 이제 Marketplace를 통해 시험판 확장을 사용할 수 있습니다.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "`dotConfig`가 지정되지 않은 경우 구성에서 사용할 값 또는 `${default}`가 `dotConfig`에 있는 경우 삽입할 값입니다.",
 	"c_cpp.configuration.experimentalFeatures.description": "\"실험적\" 기능을 사용할 수 있는지 여부를 제어합니다.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "`true`이면 언어 서버에서 코드 조각을 제공합니다.",

--- a/Extension/i18n/plk/package.i18n.json
+++ b/Extension/i18n/plk/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Wartość do użycia na potrzeby ścieżki dołączania systemu. Jeśli jest ustawiona, zastępuje systemową ścieżką dołączania, którą można uzyskać za pomocą ustawień `compilerPath` oraz `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Określa, czy rozszerzenie będzie raportować błędy wykryte w pliku `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Wartość do użycia w konfiguracji, jeśli element `customConfigurationVariables` nie został ustawiony, lub wartości do wstawienia, jeśli element `${default}` istnieje jako klucz w elemencie `customConfigurationVariables`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Ustaw na wartość `Insiders`, aby automatycznie pobierać i instalować najnowsze kompilacje niejawnych testerów rozszerzenia, które zawierają nadchodzące funkcje i poprawki błędów.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "To ustawienie jest przestarzałe. Rozszerzenia w wersji wstępnej są teraz dostępne za pomocą witryny Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Wartość do użycia w konfiguracji, jeśli element `dotConfig` nie został określony, lub wartość do wstawienia, jeśli element `${default}` istnieje w elemencie `dotConfig`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Określa, czy można używać funkcji „eksperymentalnych”.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Jeśli wartość to `true`, fragmenty kodu będą dostarczane przez serwer języka.",

--- a/Extension/i18n/ptb/package.i18n.json
+++ b/Extension/i18n/ptb/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "O valor a ser usado para o sistema inclui o caminho. Se definido, ele substitui o sistema inclui o caminho adquirido através das configurações `compilerPath` e `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Controla se a extensão reportará erros detectados em `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "O valor a ser usado em uma configuração se `customConfigurationVariables` não estiver definido, ou os valores a serem inseridos se `${default}` estiver presente como uma chave em `customConfigurationVariables`.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Defina como `Insiders` para baixar e instalar automaticamente as compilações mais recentes dos Insiders da extensão, que incluem os próximos recursos e correções de bugs.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Esta configuração foi preterida. As extensões de pré-lançamento agora estão disponíveis por meio do Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "O valor a ser usado em uma configuração se `dotConfig` não for especificado, ou o valor a ser inserido se `${default}` estiver presente em `dotConfig`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Controla se os recursos \"experimentais\" podem ser usados.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Se `true`, os snippets são fornecidos pelo servidor de linguagem.",

--- a/Extension/i18n/rus/package.i18n.json
+++ b/Extension/i18n/rus/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Значение, используемое для системного пути включения. Если этот параметр задан, он переопределяет системный путь включения, полученный с помощью параметров `compilerPath` и `compileCommands`.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Определяет, будет ли расширение сообщать об ошибках, обнаруженных в `c_cpp_properties.json`.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "Значение, используемое в конфигурации, если параметр `customConfigurationVariables` не установлен, или вставляемые значения, если в `customConfigurationVariables` присутствует значение `${default}` в качестве ключа.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Задайте значение `Insiders`, чтобы автоматически скачать и установить последние выпуски расширения для предварительной оценки, включающие в себя запланированные функции и исправления ошибок.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Этот параметр не рекомендуется. Предварительные версии расширений теперь доступны через Marketplace.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "Значение, используемое в конфигурации, если параметр `dotConfig` не указан, или вставляемое значение, если в `dotConfig` присутствует значение `${default}`.",
 	"c_cpp.configuration.experimentalFeatures.description": "Определяет, можно ли использовать \"экспериментальные\" функции.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Если задано значение `true`, фрагменты кода предоставляются языковым сервером.",

--- a/Extension/i18n/trk/package.i18n.json
+++ b/Extension/i18n/trk/package.i18n.json
@@ -238,8 +238,6 @@
 	"c_cpp.configuration.default.systemIncludePath.markdownDescription": "Sistem ekleme yolu için kullanılacak değer. Ayarlanırsa `compilerPath` ve `compileCommands` ayarları aracılığıyla elde edilen sistem ekleme yolunu geçersiz kılar.",
 	"c_cpp.configuration.default.enableConfigurationSquiggles.markdownDescription": "Uzantının `c_cpp_properties.json` dosyasında algılanan hataları bildirip bildirmeyeceğini denetler.",
 	"c_cpp.configuration.default.customConfigurationVariables.markdownDescription": "`customConfigurationVariables` ayarlanmamışsa bir yapılandırmada kullanılacak değer veya `customConfigurationVariables` içinde anahtar olarak `${default}` varsa eklenecek değerler.",
-	"c_cpp.configuration.updateChannel.markdownDescription": "Uzantının, gelecek özellikleri ve hata düzeltmelerini de içeren en son Insider üyeleri derlemelerini otomatik olarak indirip yüklemek için `Insider üyeleri` olarak ayarlayın.",
-	"c_cpp.configuration.updateChannel.deprecationMessage": "Bu ayar kullanım dışı. Yayın öncesi uzantılar artık Market üzerinden kullanılabilir.",
 	"c_cpp.configuration.default.dotConfig.markdownDescription": "`dotConfig` belirtilmemişse bir yapılandırmada kullanılacak değer veya `dotConfig` içinde `${default}` varsa eklenecek değerler.",
 	"c_cpp.configuration.experimentalFeatures.description": "\"Deneysel\" özelliklerin kullanılabilir olup olmadığını denetler.",
 	"c_cpp.configuration.suggestSnippets.markdownDescription": "Değer `true` ise, parçacıklar dil sunucusu tarafından sağlanır.",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3309,17 +3309,6 @@
                         "markdownDescription": "%c_cpp.configuration.preferredPathSeparator.markdownDescription%",
                         "scope": "machine-overridable"
                     },
-                    "C_Cpp.updateChannel": {
-                        "type": "string",
-                        "enum": [
-                            "Default",
-                            "Insiders"
-                        ],
-                        "default": "Default",
-                        "markdownDescription": "%c_cpp.configuration.updateChannel.markdownDescription%",
-                        "scope": "application",
-                        "deprecationMessage": "%c_cpp.configuration.updateChannel.deprecationMessage%"
-                    },
                     "C_Cpp.experimentalFeatures": {
                         "type": "string",
                         "enum": [

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -723,13 +723,6 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
-    "c_cpp.configuration.updateChannel.markdownDescription": {
-        "message": "Set to `Insiders` to automatically download and install the latest Insiders builds of the extension, which include upcoming features and bug fixes.",
-        "comment": [
-            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
-        ]
-    },
-    "c_cpp.configuration.updateChannel.deprecationMessage": "This setting is deprecated. Pre-release extensions are now available via the Marketplace.",
     "c_cpp.configuration.default.dotConfig.markdownDescription": {
         "message": "The value to use in a configuration if `dotConfig` is not specified, or the value to insert if `${default}` is present in `dotConfig`.",
         "comment": [

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -392,7 +392,6 @@ export class CppSettings extends Settings {
     }
     public get isConfigurationWarningsEnabled(): boolean { return this.getAsString("configurationWarnings").toLowerCase() === "enabled"; }
     public get preferredPathSeparator(): string { return this.getAsString("preferredPathSeparator"); }
-    public get updateChannel(): string { return this.getAsString("updateChannel"); }
     public get vcpkgEnabled(): boolean { return this.getAsBoolean("vcpkg.enabled"); }
     public get addNodeAddonIncludePaths(): boolean { return this.getAsBoolean("addNodeAddonIncludePaths"); }
     public get renameRequiresIdentifier(): boolean { return this.getAsBoolean("renameRequiresIdentifier"); }

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -75,7 +75,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     // Notify users if debugging may not be supported on their OS.
     util.checkDistro(info);
     await checkVsixCompatibility();
-    LanguageServer.UpdateInsidersAccess();
 
     const ignoreRecommendations: boolean | undefined = vscode.workspace.getConfiguration("extensions", null).get<boolean>("ignoreRecommendations");
     if (ignoreRecommendations !== true) {


### PR DESCRIPTION
Removes old `updateChannel` setting and code that migrated from legacy insiders opt-in to marketplace prerelease opt-in.