### PR TITLE
Turn Copilot Hover on by default. 

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3339,7 +3339,8 @@
                         "type": "string",
                         "enum": [
                             "default",
-                            "disabled"
+                            "disabled",
+                            "enabled"
                         ],
                         "default": "default",
                         "markdownDescription": "%c_cpp.configuration.copilotHover.markdownDescription%",

--- a/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
@@ -33,7 +33,10 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
         await this.client.ready;
 
         const settings: CppSettings = new CppSettings(vscode.workspace.getWorkspaceFolder(document.uri)?.uri);
-        if (settings.hover === "disabled") {
+        if (settings.hover === "disabled" ||
+            settings.copilotHover === "disabled" ||
+            (settings.copilotHover === "default" && await telemetry.isFlightEnabled("CppCopilotHoverDisabled"))) {
+            // Either disabled by the user or by the flight.
             return undefined;
         }
 
@@ -42,13 +45,6 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
         if (vscodelm) {
             const [model] = await vscodelm.selectChatModels(modelSelector);
             if (!model) {
-                return undefined;
-            }
-        }
-
-        if (new CppSettings().copilotHover === "default") {
-            // Check flight to make sure the feature is enabled.
-            if (!await telemetry.isFlightEnabled("CppCopilotHover")) {
                 return undefined;
             }
         }

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1332,17 +1332,9 @@ export class DefaultClient implements Client {
                 initializedClientCount = 0;
                 this.inlayHintsProvider = new InlayHintsProvider();
                 this.hoverProvider = new HoverProvider(this);
+                this.copilotHoverProvider = new CopilotHoverProvider(this);
 
-                const settings: CppSettings = new CppSettings();
-                this.currentCopilotHoverEnabled = new PersistentWorkspaceState<string>("cpp.copilotHover", settings.copilotHover);
-                if (settings.copilotHover !== "disabled") {
-                    this.copilotHoverProvider = new CopilotHoverProvider(this);
-                    this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, instrument(this.copilotHoverProvider)));
-                }
-
-                if (settings.copilotHover !== this.currentCopilotHoverEnabled.Value) {
-                    this.currentCopilotHoverEnabled.Value = settings.copilotHover;
-                }
+                this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, instrument(this.copilotHoverProvider)));
                 this.disposables.push(vscode.languages.registerHoverProvider(util.documentSelector, instrument(this.hoverProvider)));
                 this.disposables.push(vscode.languages.registerInlayHintsProvider(util.documentSelector, instrument(this.inlayHintsProvider)));
                 this.disposables.push(vscode.languages.registerRenameProvider(util.documentSelector, instrument(new RenameProvider(this))));
@@ -1362,6 +1354,7 @@ export class DefaultClient implements Client {
                 this.codeFoldingProvider = new FoldingRangeProvider(this);
                 this.codeFoldingProviderDisposable = vscode.languages.registerFoldingRangeProvider(util.documentSelector, instrument(this.codeFoldingProvider));
 
+                const settings: CppSettings = new CppSettings();
                 if (settings.isEnhancedColorizationEnabled && semanticTokensLegend) {
                     this.semanticTokensProvider = instrument(new SemanticTokensProvider());
                     this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(util.documentSelector, this.semanticTokensProvider, semanticTokensLegend);


### PR DESCRIPTION
Also includes:
React immediately to settings changes for copilot hover.
Change flight check to new flag to indicate a disabled state: "CppCopilotHoverDisabled".