### PR TITLE
Fix crash call stack filtering.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1161,8 +1161,8 @@ function handleMacCrashFileRead(err: NodeJS.ErrnoException | undefined | null, d
     logMacCrashTelemetry(data);
 }
 
+const regex: RegExp = /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i;
 function containsFilteredTelemetryData(str: string): boolean {
-    const regex: RegExp = /(key|token|sig|secret|signature|password|passwd|pwd|android:value)[^a-zA-Z0-9]/i;
     return regex.test(str);
 }
 
@@ -1311,17 +1311,18 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
         crashCallStack += pendingCallStack;
     }
 
+    crashCallStack = crashCallStack.trimEnd();
+    addressData = addressData.trimEnd();
+
     if (crashCallStack !== prevCppCrashCallStackData) {
         prevCppCrashCallStackData = crashCallStack;
 
         if (lines.length >= 6 && util.getLoggingLevel() >= 1) {
-            getCrashCallStacksChannel().appendLine(`\n${isCppToolsSrv ? "cpptools-srv" : "cpptools"}\n${crashDate.toLocaleString()}\n${signalType}${crashCallStack}\n\n${crashLog}`);
+            getCrashCallStacksChannel().appendLine(`\n${isCppToolsSrv ? "cpptools-srv" : "cpptools"}\n${crashDate.toLocaleString()}\n${signalType}${crashCallStack}${crashLog.length > 0 ? "\n\n" + crashLog : ""}`);
         }
     }
 
     data += crashCallStack;
-
-    addressData = addressData.trimEnd();
 
     logCppCrashTelemetry(data, addressData, crashLog);
 


### PR DESCRIPTION
Refactoring the code so that every new potential call stack line is added at a single spot in the loop.

The issue was that previously the offsetStr or "..." could be added to the crashCallStack after the filter was checked, which could cause the filter to then give a match, e.g. if the call stack line ended with "token" when the "+" or "..." was added.