### PR TITLE
Missing npmrc for other extensions

### DIFF
--- a/Extension/.npmrc
+++ b/Extension/.npmrc
@@ -1,2 +1,1 @@
 registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-always-auth=true

--- a/ExtensionPack/.npmrc
+++ b/ExtensionPack/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+always-auth=true

--- a/ExtensionPack/.npmrc
+++ b/ExtensionPack/.npmrc
@@ -1,2 +1,1 @@
 registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-always-auth=true

--- a/Themes/.npmrc
+++ b/Themes/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
+always-auth=true


### PR DESCRIPTION
I saw a warning in the last build for the extension pack that we're not linked to CFS for these extensions. These extensions don't actually download any node modules, but adding these configs should make the warnings go away.