### PR TITLE
replace CmdLine tasks with 'script'

### DIFF
--- a/Build/cg/cg.yml
+++ b/Build/cg/cg.yml
@@ -84,35 +84,26 @@ extends:
           inputs:
             version: 18.x
 
-        - task: CmdLine@2
+        - script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           displayName: Delete .npmrc if it exists
-          inputs:
-            script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
 
         - task: Npm@0
-          name: NpmInstall_2
           displayName: Install vsce
           inputs:
             arguments: --global @vscode/vsce
 
-        - task: CmdLine@1
-          name: ProcessRunner_11
+        - script: mkdir $(Build.ArtifactStagingDirectory)\Extension
           displayName: Create Extension Staging Directory
-          inputs:
-            filename: mkdir
-            arguments: $(Build.ArtifactStagingDirectory)\Extension
 
         - script: yarn run vsix-prepublish
           displayName: Build files
           workingDirectory: $(Build.SourcesDirectory)\Extension
 
-        - task: CmdLine@1
+        - script: |
+            cd $(Build.SourcesDirectory)\Extension
+            vsce package --yarn -o $(Build.ArtifactStagingDirectory)\Extension\cpptools.vsix
           name: ProcessRunner_12
           displayName: Run VSCE to package vsix
-          inputs:
-            filename: vsce
-            arguments: package --yarn -o $(Build.ArtifactStagingDirectory)\Extension\cpptools.vsix
-            workingFolder: $(Build.SourcesDirectory)\Extension
 
         - task: Npm@0
           displayName: Uninstall vsce

--- a/Build/package/jobs_package_vsix.yml
+++ b/Build/package/jobs_package_vsix.yml
@@ -34,18 +34,13 @@ jobs:
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
     displayName: Use Yarn 1.x
 
-  - task: CmdLine@1
+  - script: mkdir $(Build.ArtifactStagingDirectory)\vsix
     displayName: Create Staging Directory
-    inputs:
-      filename: mkdir
-      arguments: $(Build.ArtifactStagingDirectory)\vsix
 
-  - task: CmdLine@1
+  - script: |
+      cd $(Build.SourcesDirectory)\${{ parameters.srcDir }}
+      vsce package -o $(Build.ArtifactStagingDirectory)\vsix\${{ parameters.vsixName }}
     displayName: Run VSCE to package vsix
-    inputs:
-      filename: vsce
-      arguments: package -o $(Build.ArtifactStagingDirectory)\vsix\${{ parameters.vsixName }}
-      workingFolder: $(Build.SourcesDirectory)\${{ parameters.srcDir }}
 
   - task: Npm@0
     displayName: Uninstall vsce


### PR DESCRIPTION
CmdLine@1 depends on an old version of node and generates a warning when used. This PR migrates all CmdLine task usage to use the built-in 'script' type instead.