### PR TITLE
Fix some file associations

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -165,19 +165,19 @@ export function getVcpkgRoot(): string {
 export function isHeaderFile(uri: vscode.Uri): boolean {
     const fileExt: string = path.extname(uri.fsPath);
     const fileExtLower: string = fileExt.toLowerCase();
-    return !fileExt || [".cuh", ".hpp", ".hh", ".hxx", ".h++", ".hp", ".h", ".ii", ".inl", ".idl", ""].some(ext => fileExtLower === ext);
+    return !fileExt || [".cuh", ".hpp", ".hh", ".hxx", ".h++", ".hp", ".h", ".inl", ".ipp", ".tcc", ".tlh", ".tli", ""].some(ext => fileExtLower === ext);
 }
 
 export function isCppFile(uri: vscode.Uri): boolean {
     const fileExt: string = path.extname(uri.fsPath);
     const fileExtLower: string = fileExt.toLowerCase();
-    return (fileExt === ".C") || [".cu", ".cpp", ".cc", ".cxx", ".c++", ".cp", ".ino", ".ipp", ".tcc"].some(ext => fileExtLower === ext);
+    return (fileExt === ".C") || [".cu", ".cpp", ".cc", ".cxx", ".c++", ".cp", ".ii", ".ino"].some(ext => fileExtLower === ext);
 }
 
 export function isCFile(uri: vscode.Uri): boolean {
     const fileExt: string = path.extname(uri.fsPath);
     const fileExtLower: string = fileExt.toLowerCase();
-    return (fileExt === ".C") || fileExtLower === ".c";
+    return fileExt === ".c" || fileExtLower === ".i";
 }
 
 export function isCppOrCFile(uri: vscode.Uri | undefined): boolean {


### PR DESCRIPTION
Aligns some hard-coded default file associations with the defaults on the native side. (There is a separate native PR for fixes there).

Fixes a bug where `.C` may be considered a C source file (uppercase implies C++).

Correctly considers `.i` a C source file, and `.ii` a C++ source file. Added missing header type: `.tlh`, `.tli`

Moves `.tcc` to the list of header files instead of source files.

Not addressed by this PR: These functions should also consider the contents of `files.assocations` (at least for source file types, as that does not distinguish between headers and sources).