### PR TITLE
Improve copilotHover description.

### DIFF
--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -785,9 +785,9 @@
         ]
     },
     "c_cpp.configuration.copilotHover.markdownDescription": {
-        "message": "If `disabled`, no Copilot information will appear in Hover.",
+        "message": "If `disabled`, no 'Generate Copilot summary' option will appear in Hover.",
         "comment": [
-            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+            " {Locked=\"`disabled`\"} Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
     "c_cpp.configuration.renameRequiresIdentifier.markdownDescription": {

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -785,7 +785,7 @@
         ]
     },
     "c_cpp.configuration.copilotHover.markdownDescription": {
-        "message": "If `disabled`, no 'Generate Copilot summary' option will appear in Hover.",
+        "message": "If `disabled`, no 'Generate Copilot summary' option will appear on hover.",
         "comment": [
             " {Locked=\"`disabled`\"} Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-cpptools/issues/13458

This enables words including 'Generate Copilot summary' to appear when entered into the settings search.

Also, changed "in Hover" to "on hover". All other VS Code settings references to hover use lowercase.