### PR TITLE
Fix a warning with copilotHover.

### DIFF
--- a/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
@@ -33,9 +33,10 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
         await this.client.ready;
 
         const settings: CppSettings = new CppSettings(vscode.workspace.getWorkspaceFolder(document.uri)?.uri);
+        const workspaceSettings: CppSettings = new CppSettings();
         if (settings.hover === "disabled" ||
-            settings.copilotHover === "disabled" ||
-            (settings.copilotHover === "default" && await telemetry.isFlightEnabled("CppCopilotHoverDisabled"))) {
+            workspaceSettings.copilotHover === "disabled" ||
+            (workspaceSettings.copilotHover === "default" && await telemetry.isFlightEnabled("CppCopilotHoverDisabled"))) {
             // Either disabled by the user or by the flight.
             return undefined;
         }


### PR DESCRIPTION
Fixes this warning in the Extension Host logging pane: `[warning] [ms-vscode.cpptools] Accessing a window scoped configuration for a resource is not expected. To associate 'C_Cpp.copilotHover' to a resource, define its scope to 'resource' in configuration contributions in 'package.json'.