### PR TITLE
Fix cpptools-wordexp

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1069,7 +1069,7 @@ function extractArgs(argsString: string): string[] {
     } else {
         try {
             const executablePath: string = getExtensionFilePath("bin/cpptools-wordexp");
-            const executableDir = path.dirname(executablePath);
+            const executableDir: string = path.dirname(executablePath);
             process.chdir(executableDir);
             const wordexpResult: any = child_process.execFileSync(executablePath, [argsString], { shell: false });
             if (wordexpResult === undefined) {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1068,7 +1068,10 @@ function extractArgs(argsString: string): string[] {
         return result;
     } else {
         try {
-            const wordexpResult: any = child_process.execFileSync(getExtensionFilePath("bin/cpptools-wordexp"), [argsString], { shell: false });
+            const executablePath: string = getExtensionFilePath("bin/cpptools-wordexp");
+            const executableDir = path.dirname(executablePath);
+            process.chdir(executableDir);
+            const wordexpResult: any = child_process.execFileSync(executablePath, [argsString], { shell: false });
             if (wordexpResult === undefined) {
                 return [];
             }


### PR DESCRIPTION
This fixes an issue with `cpptools-wordexp`. Due to how the native code is currently built, it's necessary to set the current working directory to the same directory as MUSL `libc.so`.  Currently, the only thing broken is the undocumented ability to paste a full command line into the `compilerPath` field and have the arguments automatically interpreted using shell parsing.

This issue could have been avoided by: https://github.com/microsoft/vscode-cpptools/issues/9681
... which would allow us to leverage the `wordexp` node module instead.,