### PR TITLE
Fix interval timer not firing causing cpptools to exit after 4 minutes

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -59,7 +59,7 @@ import * as configs from './configurations';
 import { CopilotCompletionContextFeatures, CopilotCompletionContextProvider } from './copilotCompletionContextProvider';
 import { DataBinding } from './dataBinding';
 import { cachedEditorConfigSettings, getEditorConfigSettings } from './editorConfig';
-import { CppSourceStr, clients, configPrefix, updateLanguageConfigurations, usesCrashHandler, watchForCrashes } from './extension';
+import { CppSourceStr, clients, configPrefix, initializeIntervalTimer, updateLanguageConfigurations, usesCrashHandler, watchForCrashes } from './extension';
 import { LocalizeStringParams, getLocaleId, getLocalizedString } from './localization';
 import { PersistentFolderState, PersistentState, PersistentWorkspaceState } from './persistentState';
 import { RequestCancelled, ServerCancelled, createProtocolFilter } from './protocolFilter';
@@ -1364,6 +1364,8 @@ export class DefaultClient implements Client {
 
                 // Listen for messages from the language server.
                 this.registerNotifications();
+
+                initializeIntervalTimer();
 
                 // If a file is already open when we activate, sometimes we don't get any notifications about visible
                 // or active text editors, visible ranges, or text selection. As a workaround, we trigger

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -191,8 +191,6 @@ export async function activate(): Promise<void> {
 
     vcpkgDbPromise = initVcpkgDatabase();
 
-    void clients.ActiveClient.ready.then(() => intervalTimer = global.setInterval(onInterval, 2500));
-
     await registerCommands(true);
 
     vscode.tasks.onDidStartTask(() => getActiveClient().PauseCodeAnalysis());
@@ -364,6 +362,10 @@ async function onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor
 function onInterval(): void {
     // TODO: do we need to pump messages to all clients? depends on what we do with the icons, I suppose.
     clients.ActiveClient.onInterval();
+}
+
+export function initializeIntervalTimer(): void {
+    intervalTimer = global.setInterval(onInterval, 2500);
 }
 
 /**


### PR DESCRIPTION
This is causing cpptools to exit after 4 minutes when it should not, which incorrectly leads to these messages appearing in the screenshot below, which can confuse users into thinking there's an unexpected bug, see for example https://github.com/Microsoft/vscode-cpptools/issues/13465:

![image](https://github.com/user-attachments/assets/8a25f797-1435-4256-baba-a8b38ec97ba6)

This moves the initialization of the interval timer earlier before it could get blocked by the `await this.onDidChangeVisibleTextEditors(cppEditors);`.