### PR TITLE
Work around missing visible editor notifications

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1366,12 +1366,6 @@ export class DefaultClient implements Client {
                 this.registerNotifications();
 
                 initializeIntervalTimer();
-
-                // If a file is already open when we activate, sometimes we don't get any notifications about visible
-                // or active text editors, visible ranges, or text selection. As a workaround, we trigger
-                // onDidChangeVisibleTextEditors here.
-                const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-                await this.onDidChangeVisibleTextEditors(cppEditors);
             }
 
             // update all client configurations

--- a/Extension/src/LanguageServer/clientCollection.ts
+++ b/Extension/src/LanguageServer/clientCollection.ts
@@ -144,8 +144,6 @@ export class ClientCollection {
             this.activeClient.activate();
             await this.activeClient.didChangeActiveEditor(vscode.window.activeTextEditor);
         }
-        const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-        await this.defaultClient.onDidChangeVisibleTextEditors(cppEditors);
     }
 
     private async onDidChangeWorkspaceFolders(e?: vscode.WorkspaceFoldersChangeEvent): Promise<void> {

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { Middleware } from 'vscode-languageclient';
 import * as util from '../common';
+import { logAndReturn } from '../Utility/Async/returns';
 import { Client } from './client';
 import { clients } from './extension';
 import { shouldChangeFromCToCpp } from './utils';
@@ -40,6 +41,10 @@ export function createProtocolFilter(): Middleware {
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
                     void sendMessage(document);
+                    const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(editor => editor.document === document);
+                    if (editor) {
+                        client.onDidChangeVisibleTextEditors([editor]).catch(logAndReturn.undefined);
+                    }
                 }
             }
         },


### PR DESCRIPTION
I noticed that when updating the language of a file, although we do get a `didClose` and `didOpen`, we do not get a `onDidChangeVisibleTextEditors`.  Without any other context, a `didClose` and `didOpen` without a `onDidChangeVisibleTextEditors` looks to us like that file is not visible. https://github.com/microsoft/vscode/issues/246043

This fix always triggers a `onDidChangeVisibleTextEditors` callback whenever we see a `didOpen` for a file that appears to be currently visible in the editor.