### PR TITLE
Fix issues with remapping of `.C` files

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -34,9 +34,10 @@ export function createProtocolFilter(): Middleware {
                         const mappingString: string = baseFileName + "@" + document.fileName;
                         client.addFileAssociations(mappingString, "cpp");
                         client.sendDidChangeSettings();
-                        // Changes to the languageId in the editor take precendence over setTextDocumentLanguage.
-                        // So, this may or may not cause the file to be closed and reopened.
+                        // This will definitely cause the file to be closed and reopened.
+                        // setTextDocumentLanguage takes precedence over setting the languageId in UI.
                         void vscode.languages.setTextDocumentLanguage(document, "cpp");
+                        return;
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -11,6 +11,7 @@ import * as util from '../common';
 import { logAndReturn } from '../Utility/Async/returns';
 import { Client } from './client';
 import { clients } from './extension';
+import { hasFileAssociation } from './settings';
 import { shouldChangeFromCToCpp } from './utils';
 
 export const RequestCancelled: number = -32800;
@@ -30,14 +31,16 @@ export function createProtocolFilter(): Middleware {
                     client.TrackedDocuments.set(uriString, document);
                     // Work around vscode treating ".C" or ".H" as c, by adding this file name to file associations as cpp
                     if (document.languageId === "c" && shouldChangeFromCToCpp(document)) {
-                        const baseFileName: string = path.basename(document.fileName);
-                        const mappingString: string = baseFileName + "@" + document.fileName;
-                        client.addFileAssociations(mappingString, "cpp");
-                        client.sendDidChangeSettings();
-                        // This will definitely cause the file to be closed and reopened.
-                        // setTextDocumentLanguage takes precedence over setting the languageId in UI.
-                        void vscode.languages.setTextDocumentLanguage(document, "cpp");
-                        return;
+                        // Don't override the user's setting.
+                        if (!hasFileAssociation(path.basename(document.uri.fsPath))) {
+                            const baseFileName: string = path.basename(document.fileName);
+                            const mappingString: string = baseFileName + "@" + document.fileName;
+                            client.addFileAssociations(mappingString, "cpp");
+                            client.sendDidChangeSettings();
+                            // The following will cause the file to be closed and reopened.
+                            void vscode.languages.setTextDocumentLanguage(document, "cpp");
+                            return;
+                        }
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -34,7 +34,8 @@ export function createProtocolFilter(): Middleware {
                         const mappingString: string = baseFileName + "@" + document.fileName;
                         client.addFileAssociations(mappingString, "cpp");
                         client.sendDidChangeSettings();
-                        // This cause the file to be closed and reopened.
+                        // Changes to the languageId in the editor take precendence over setTextDocumentLanguage.
+                        // So, this may or may not cause the file to be closed and reopened.
                         void vscode.languages.setTextDocumentLanguage(document, "cpp");
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -34,9 +34,8 @@ export function createProtocolFilter(): Middleware {
                         const mappingString: string = baseFileName + "@" + document.fileName;
                         client.addFileAssociations(mappingString, "cpp");
                         client.sendDidChangeSettings();
-                        // This will cause the file to be closed and reopened.
+                        // This cause the file to be closed and reopened.
                         void vscode.languages.setTextDocumentLanguage(document, "cpp");
-                        return;
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -41,10 +41,8 @@ export function createProtocolFilter(): Middleware {
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
                     void sendMessage(document);
-                    const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(editor => editor.document === document);
-                    if (editor) {
-                        client.onDidChangeVisibleTextEditors([editor]).catch(logAndReturn.undefined);
-                    }
+                    const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
+                    client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
                 }
             }
         },

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -1099,3 +1099,17 @@ export class OtherSettings {
     public get searchExclude(): Excludes { return this.getAsExcludes("search", "exclude", this.defaultSearchExcludes, this.resource); }
     public get workbenchSettingsEditor(): string { return this.getAsString("workbench.settings", "editor", this.resource, "ui"); }
 }
+
+export function hasFileAssociation(fileName: string): boolean {
+    const associations: Associations = new OtherSettings().filesAssociations;
+    if (associations[fileName]) {
+        return true;
+    } else {
+        for (const pattern in associations) {
+            if (pattern.startsWith('*.') && fileName.endsWith(pattern.slice(1))) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -1101,14 +1101,14 @@ export class OtherSettings {
 }
 
 export function hasFileAssociation(fileName: string): boolean {
-    const associations: Associations = new OtherSettings().filesAssociations;
+    const otherSettings: OtherSettings = new OtherSettings()
+    const associations: Associations = otherSettings.filesAssociations;
     if (associations[fileName]) {
         return true;
-    } else {
-        for (const pattern in associations) {
-            if (pattern.startsWith('*.') && fileName.endsWith(pattern.slice(1))) {
-                return true;
-            }
+    }
+    for (const pattern in associations) {
+        if (pattern.startsWith('*.') && fileName.endsWith(pattern.slice(1))) {
+            return true;
         }
     }
     return false;

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -1101,7 +1101,7 @@ export class OtherSettings {
 }
 
 export function hasFileAssociation(fileName: string): boolean {
-    const otherSettings: OtherSettings = new OtherSettings()
+    const otherSettings: OtherSettings = new OtherSettings();
     const associations: Associations = otherSettings.filesAssociations;
     if (associations[fileName]) {
         return true;


### PR DESCRIPTION
Fixes an issue where the explicit association of `.C` files in `files.associations` was not respected. We will now only remap a `.C` file to C++ if there is not an existing mapping for the file.

Because the first attempt to open the file wrote to the `files.associations`, subsequent attempts to change the language ID using the UI will now properly take precedence (as long as the `files.associations` entry exists, regardless of what it's set to).

Also fixes a bug in a prior change that could result in visible files not being tracked properly.
