### PR TITLE
Add IsExplicit for new recursive include properties

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -87,6 +87,9 @@ export interface Configuration {
     browse?: Browse;
     recursiveIncludes?: RecursiveIncludes;
     customConfigurationVariables?: { [key: string]: string };
+    recursiveIncludesReduceIsExplicit?: boolean;
+    recursiveIncludesPriorityIsExplicit?: boolean;
+    recursiveIncludesOrderIsExplicit?: boolean;
 }
 
 export interface ConfigurationErrors {
@@ -940,8 +943,11 @@ export class CppProperties {
                 configuration.recursiveIncludes = {};
             }
             configuration.recursiveIncludes.reduce = this.updateConfigurationString(configuration.recursiveIncludes.reduce, settings.defaultRecursiveIncludesReduce);
+            configuration.recursiveIncludesReduceIsExplicit = configuration.recursiveIncludesReduceIsExplicit || settings.defaultRecursiveIncludesReduce !== "";
             configuration.recursiveIncludes.priority = this.updateConfigurationString(configuration.recursiveIncludes.priority, settings.defaultRecursiveIncludesPriority);
+            configuration.recursiveIncludesPriorityIsExplicit = configuration.recursiveIncludesPriorityIsExplicit || settings.defaultRecursiveIncludesPriority !== "";
             configuration.recursiveIncludes.order = this.updateConfigurationString(configuration.recursiveIncludes.order, settings.defaultRecursiveIncludesOrder);
+            configuration.recursiveIncludesOrderIsExplicit = configuration.recursiveIncludesOrderIsExplicit || settings.defaultRecursiveIncludesOrder !== "";
             if (!configuration.compileCommands) {
                 // compile_commands.json already specifies a compiler. compilerPath overrides the compile_commands.json compiler so
                 // don't set a default when compileCommands is in use.
@@ -1508,7 +1514,10 @@ export class CppProperties {
                 if ((this.configurationJson.configurations[i].compilerPathIsExplicit !== undefined)
                     || (this.configurationJson.configurations[i].cStandardIsExplicit !== undefined)
                     || (this.configurationJson.configurations[i].cppStandardIsExplicit !== undefined)
-                    || (this.configurationJson.configurations[i].intelliSenseModeIsExplicit !== undefined)) {
+                    || (this.configurationJson.configurations[i].intelliSenseModeIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].recursiveIncludesReduceIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].recursiveIncludesPriorityIsExplicit !== undefined)
+                    || (this.configurationJson.configurations[i].recursiveIncludesOrderIsExplicit !== undefined)) {
                     dirty = true;
                     break;
                 }
@@ -1529,6 +1538,9 @@ export class CppProperties {
                 e.cStandardIsExplicit = e.cStandard !== undefined;
                 e.cppStandardIsExplicit = e.cppStandard !== undefined;
                 e.intelliSenseModeIsExplicit = e.intelliSenseMode !== undefined;
+                e.recursiveIncludesReduceIsExplicit = e.recursiveIncludes?.reduce !== undefined;
+                e.recursiveIncludesPriorityIsExplicit = e.recursiveIncludes?.priority !== undefined;
+                e.recursiveIncludesOrderIsExplicit = e.recursiveIncludes?.order !== undefined;
             });
 
         } catch (errJS) {
@@ -2296,6 +2308,9 @@ export class CppProperties {
         const savedCStandardIsExplicit: boolean[] = [];
         const savedCppStandardIsExplicit: boolean[] = [];
         const savedIntelliSenseModeIsExplicit: boolean[] = [];
+        const savedRecursiveIncludesReduceIsExplicit: boolean[] = [];
+        const savedRecursiveIncludesPriorityIsExplicit: boolean[] = [];
+        const savedRecursiveIncludesOrderIsExplicit: boolean[] = [];
 
         if (this.configurationJson) {
             this.configurationJson.configurations.forEach(e => {
@@ -2315,6 +2330,18 @@ export class CppProperties {
                 if (e.intelliSenseModeIsExplicit !== undefined) {
                     delete e.intelliSenseModeIsExplicit;
                 }
+                savedRecursiveIncludesReduceIsExplicit.push(!!e.recursiveIncludesReduceIsExplicit);
+                if (e.recursiveIncludesReduceIsExplicit !== undefined) {
+                    delete e.recursiveIncludesReduceIsExplicit;
+                }
+                savedRecursiveIncludesPriorityIsExplicit.push(!!e.recursiveIncludesPriorityIsExplicit);
+                if (e.recursiveIncludesPriorityIsExplicit !== undefined) {
+                    delete e.recursiveIncludesPriorityIsExplicit;
+                }
+                savedRecursiveIncludesOrderIsExplicit.push(!!e.recursiveIncludesOrderIsExplicit);
+                if (e.recursiveIncludesOrderIsExplicit !== undefined) {
+                    delete e.recursiveIncludesOrderIsExplicit;
+                }
             });
         }
 
@@ -2329,6 +2356,9 @@ export class CppProperties {
                 this.configurationJson.configurations[i].cStandardIsExplicit = savedCStandardIsExplicit[i];
                 this.configurationJson.configurations[i].cppStandardIsExplicit = savedCppStandardIsExplicit[i];
                 this.configurationJson.configurations[i].intelliSenseModeIsExplicit = savedIntelliSenseModeIsExplicit[i];
+                this.configurationJson.configurations[i].recursiveIncludesReduceIsExplicit = savedRecursiveIncludesReduceIsExplicit[i];
+                this.configurationJson.configurations[i].recursiveIncludesPriorityIsExplicit = savedRecursiveIncludesPriorityIsExplicit[i];
+                this.configurationJson.configurations[i].recursiveIncludesOrderIsExplicit = savedRecursiveIncludesOrderIsExplicit[i];
             }
         }
     }


### PR DESCRIPTION
This basically just replicates the code used for other IsExplicit's, for the new recursive include properties.

There is a corresponding native PR that uses this information to avoid sending telemetry when defaults are used (not explicitly set by the user).
