### PR TITLE
Fix an error on startup if a file is open

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -45,8 +45,10 @@ export function createProtocolFilter(): Middleware {
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
                     void sendMessage(document);
-                    const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
-                    client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
+                    client.ready.then(() => {
+                        const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
+                        client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
+                    }).catch(logAndReturn.undefined);
                 }
             }
         },


### PR DESCRIPTION
This works around the issue by deferring the `onDidChangeVisibleTextEditors` until after `innerLanguageClient` is set.  It doesn't matter if this is slightly delayed, as it will report current visibility, etc., when run.