### PR TITLE
Fix the Debug button disappearing.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1892,10 +1892,6 @@ export class DefaultClient implements Client {
         if (document.uri.scheme === "file") {
             const uri: string = document.uri.toString();
             openFileVersions.set(uri, document.version);
-            void SessionState.buildAndDebugIsSourceFile.set(util.isCppOrCFile(document.uri));
-            void SessionState.buildAndDebugIsFolderOpen.set(util.isFolderOpen(document.uri));
-        } else {
-            void SessionState.buildAndDebugIsSourceFile.set(false);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/13400

Or at least one cause of it.

The debug state is supposed to be set when the file becomes active and didOpen should not affect that, since didOpen can be triggered for various reasons in the background by VS Code.