### PR TITLE
Fix recursive includes settings UI

### DIFF
--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -723,7 +723,7 @@
         </div>
 
         <div class="section">
-            <div class="section-title" data-loc-id="recursiveIncludes.reduce">Recursive includes: priority</div>
+            <div class="section-title" data-loc-id="recursiveIncludes.reduce">Recursive includes: reduce</div>
             <div class="section-text">
                 <span data-loc-id="recursiveIncludes.reduce.description">Set to <code>always</code> to reduce the number of recursive include paths provided to IntelliSense to only those paths currently referenced by #include statements. This requires first parsing files to determine which files are included. Set to <code>never</code> to provide all recursive include paths to IntelliSense. Reducing the number of recursive include paths may improve IntelliSense performance when a very large number of recursive include paths are involved. Not reducing the number of recursive include paths can improve IntelliSense performance by avoiding the need to parse files to determine which include paths to provide.</span>
             </div>
@@ -752,7 +752,7 @@
         </div>
 
         <div class="section">
-            <div class="section-title" data-loc-id="recursiveIncludes.order">Recursive includes: priority</div>
+            <div class="section-title" data-loc-id="recursiveIncludes.order">Recursive includes: order</div>
             <div class="section-text">
                 <span data-loc-id="recursiveIncludes.order.description">The order in which subdirectories under recursive include paths are searched.</span>
                 </div>

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -285,35 +285,35 @@ class SettingsApp {
 
             // Basic settings
             (<HTMLInputElement>document.getElementById(elementId.configName)).value = config.name;
-            (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ? config.compilerPath : "";
+            (<HTMLInputElement>document.getElementById(elementId.compilerPath)).value = config.compilerPath ?? "";
             this.fixKnownCompilerSelection();
             (<HTMLInputElement>document.getElementById(elementId.compilerArgs)).value = joinEntries(config.compilerArgs);
 
-            (<HTMLInputElement>document.getElementById(elementId.intelliSenseMode)).value = config.intelliSenseMode ? config.intelliSenseMode : "${default}";
+            (<HTMLInputElement>document.getElementById(elementId.intelliSenseMode)).value = config.intelliSenseMode ?? "${default}";
             (<HTMLInputElement>document.getElementById(elementId.includePath)).value = joinEntries(config.includePath);
             (<HTMLInputElement>document.getElementById(elementId.defines)).value = joinEntries(config.defines);
             (<HTMLInputElement>document.getElementById(elementId.cStandard)).value = config.cStandard;
             (<HTMLInputElement>document.getElementById(elementId.cppStandard)).value = config.cppStandard;
 
             // Advanced settings
-            (<HTMLInputElement>document.getElementById(elementId.windowsSdkVersion)).value = config.windowsSdkVersion ? config.windowsSdkVersion : "";
+            (<HTMLInputElement>document.getElementById(elementId.windowsSdkVersion)).value = config.windowsSdkVersion ?? "";
             (<HTMLInputElement>document.getElementById(elementId.macFrameworkPath)).value = joinEntries(config.macFrameworkPath);
             (<HTMLInputElement>document.getElementById(elementId.compileCommands)).value = joinEntries(config.compileCommands);
             (<HTMLInputElement>document.getElementById(elementId.mergeConfigurations)).checked = config.mergeConfigurations;
-            (<HTMLInputElement>document.getElementById(elementId.configurationProvider)).value = config.configurationProvider ? config.configurationProvider : "";
+            (<HTMLInputElement>document.getElementById(elementId.configurationProvider)).value = config.configurationProvider ?? "";
             (<HTMLInputElement>document.getElementById(elementId.forcedInclude)).value = joinEntries(config.forcedInclude);
-            (<HTMLInputElement>document.getElementById(elementId.dotConfig)).value = config.dotConfig ? config.dotConfig : "";
+            (<HTMLInputElement>document.getElementById(elementId.dotConfig)).value = config.dotConfig ?? "";
             if (config.recursiveIncludes) {
-                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesReduce)).value = config.recursiveIncludes.reduce;
-                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesPriority)).value = config.recursiveIncludes.priority;
-                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesOrder)).value = config.recursiveIncludes.order;
+                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesReduce)).value = config.recursiveIncludes.reduce ?? "${default}";
+                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesPriority)).value = config.recursiveIncludes.priority ?? "${default}";
+                (<HTMLInputElement>document.getElementById(elementId.recursiveIncludesOrder)).value = config.recursiveIncludes.order ?? "${default}";
             }
 
             if (config.browse) {
                 (<HTMLInputElement>document.getElementById(elementId.browsePath)).value = joinEntries(config.browse.path);
                 (<HTMLInputElement>document.getElementById(elementId.limitSymbolsToIncludedHeaders)).checked =
                     config.browse.limitSymbolsToIncludedHeaders && config.browse.limitSymbolsToIncludedHeaders;
-                (<HTMLInputElement>document.getElementById(elementId.databaseFilename)).value = config.browse.databaseFilename ? config.browse.databaseFilename : "";
+                (<HTMLInputElement>document.getElementById(elementId.databaseFilename)).value = config.browse.databaseFilename ?? "";
             } else {
                 (<HTMLInputElement>document.getElementById(elementId.browsePath)).value = "";
                 (<HTMLInputElement>document.getElementById(elementId.limitSymbolsToIncludedHeaders)).checked = false;


### PR DESCRIPTION
 - Fix an issue with the incorrect settings titles in `settings.html`
 - Properly display `${default}` in other fields when only a subset of the recursive include settings are set.  (And switch existing cases to using the `??` syntax).