### PR TITLE
No error message shown in config UI for invalid compilerPath

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1612,7 +1612,7 @@ export class CppProperties {
             resolvedCompilerPath = which.sync(config.compilerPath, { nothrow: true });
         }
 
-        if (resolvedCompilerPath === undefined) {
+        if (!resolvedCompilerPath) {
             resolvedCompilerPath = this.resolvePath(config.compilerPath);
         }
         const settings: CppSettings = new CppSettings(this.rootUri);


### PR DESCRIPTION
Fixes: #12661

`which.sync` returns `null`, not `undefined` so invalid paths never had a chance to go through the logic that added the errors.