### PR TITLE
Don't show bogus errors for compilerPath + args in config UI

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1617,7 +1617,11 @@ export class CppProperties {
         }
         const settings: CppSettings = new CppSettings(this.rootUri);
         const compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(!!settings.legacyCompilerArgsBehavior, resolvedCompilerPath);
+
+        // compilerPath + args in the same string isn't working yet.
+        const skipFullCommandString = !compilerPathAndArgs.compilerName && resolvedCompilerPath.indexOf(" ") >= 0;
         if (resolvedCompilerPath
+            && !skipFullCommandString
             // Don't error cl.exe paths because it could be for an older preview build.
             && compilerPathAndArgs.compilerName.toLowerCase() !== "cl.exe"
             && compilerPathAndArgs.compilerName.toLowerCase() !== "cl") {
@@ -1795,7 +1799,7 @@ export class CppProperties {
         if (!this.configurationJson) {
             return;
         }
-        if ((this.configurationJson.enableConfigurationSquiggles !== undefined && !this.configurationJson.enableConfigurationSquiggles) ||
+        if ((this.configurationJson.enableConfigurationSquiggles === false) ||
             (this.configurationJson.enableConfigurationSquiggles === undefined && !settings.defaultEnableConfigurationSquiggles)) {
             this.diagnosticCollection.clear();
             return;

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -1619,7 +1619,7 @@ export class CppProperties {
         const compilerPathAndArgs: util.CompilerPathAndArgs = util.extractCompilerPathAndArgs(!!settings.legacyCompilerArgsBehavior, resolvedCompilerPath);
 
         // compilerPath + args in the same string isn't working yet.
-        const skipFullCommandString = !compilerPathAndArgs.compilerName && resolvedCompilerPath.indexOf(" ") >= 0;
+        const skipFullCommandString = !compilerPathAndArgs.compilerName && resolvedCompilerPath.includes(" ");
         if (resolvedCompilerPath
             && !skipFullCommandString
             // Don't error cl.exe paths because it could be for an older preview build.


### PR DESCRIPTION
My previous PR exposed an issue with incorrect squiggles in the config UI. I'm quickly patching it to ignore these errors until a proper fix can go in.