### PR TITLE
Fix how `C_Cpp.default` recursive include settings are defined

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -900,31 +900,31 @@
                     "C_Cpp.default.recursiveIncludes.reduce": {
                         "type": "string",
                         "enum": [
+                            "",
                             "always",
                             "never",
                             "default"
                         ],
-                        "default": "default",
                         "markdownDescription": "%c_cpp.configuration.default.recursiveIncludes.reduce.markdownDescription%",
                         "scope": "resource"
                     },
                     "C_Cpp.default.recursiveIncludes.priority": {
                         "type": "string",
                         "enum": [
+                            "",
                             "beforeSystemIncludes",
                             "afterSystemIncludes"
                         ],
-                        "default": "afterSystemIncludes",
                         "markdownDescription": "%c_cpp.configuration.default.recursiveIncludes.priority.markdownDescription%",
                         "scope": "resource"
                     },
                     "C_Cpp.default.recursiveIncludes.order": {
                         "type": "string",
                         "enum": [
+                            "",
                             "depthFirst",
                             "breadthFirst"
                         ],
-                        "default": "depthFirst",
                         "markdownDescription": "%c_cpp.configuration.default.recursiveIncludes.order.markdownDescription%",
                         "scope": "resource"
                     },


### PR DESCRIPTION
Providing a blank string value and no default, to match existing settings such as `cStandard` and `cppStandard`.  This provides a way to effectively 'unset' the value in the VS Code settings UI, and fixes an issue with their `IsExplicit` values.