### PR TITLE
Ensure #cpp tool isn't accidentally enabled in agent mode

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6549,7 +6549,7 @@
                 "userDescription": "%c_cpp.languageModelTools.configuration.userDescription%",
                 "modelDescription": "For the active C or C++ file, this tool provides: the language (C, C++, or CUDA), the language standard version (such as C++11, C++14, C++17, or C++20), the compiler (such as GCC, Clang, or MSVC), the target platform (such as x86, x64, or ARM), and the target architecture (such as 32-bit or 64-bit).",
                 "icon": "$(file-code)",
-                "when": "(config.C_Cpp.experimentalFeatures =~ /^[eE]nabled$/)"
+                "when": "(config.C_Cpp.experimental.configuration_lmtool =~ /^[eE]nabled$/)"
             }
         ]
     },


### PR DESCRIPTION
This ensures that users who have experimental features enabled won't accidentally invoke #cpp in agent mode while we rework the way we provide language model tools. The new setting is intentionally undocumented.