### PR TITLE
Rename `depthFirst` setting value to `preOrder`

### DIFF
--- a/Extension/c_cpp_properties.schema.json
+++ b/Extension/c_cpp_properties.schema.json
@@ -239,7 +239,7 @@
                                 "markdownDescription": "The order in which subdirectories of recursive includes are searched.",
                                 "type": "string",
                                 "enum": [
-                                    "depthFirst",
+                                    "preOrder",
                                     "breadthFirst",
                                     "${default}"
                                 ]

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -922,7 +922,7 @@
                         "type": "string",
                         "enum": [
                             "",
-                            "depthFirst",
+                            "preOrder",
                             "breadthFirst"
                         ],
                         "markdownDescription": "%c_cpp.configuration.default.recursiveIncludes.order.markdownDescription%",

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -759,7 +759,7 @@
             <div>
             <select name="inputValue" id="recursiveIncludes.order" class="select-default">
                 <option value="${default}">${default}</option>
-                <option value="depthFirst">depthFirst</option>
+                <option value="preOrder">preOrder</option>
                 <option value="breadthFirst">breadthFirst</option>
             </select>
             </div>


### PR DESCRIPTION
As pointed out by this issue: https://github.com/microsoft/vscode-cpptools/issues/13604 
`depthFirst` is not technically correct. A more accurate setting value would be `preOrder`.