### PR TITLE
Remove the .type.descriptions since they don't seem to have any effect.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3662,11 +3662,6 @@
                                 },
                                 "default": []
                             },
-                            "type": {
-                                "type": "string",
-                                "description": "%c_cpp.debuggers.cppdbg.type.description%",
-                                "default": "cppdbg"
-                            },
                             "targetArchitecture": {
                                 "type": "string",
                                 "description": "%c_cpp.debuggers.targetArchitecture.description%",
@@ -4611,11 +4606,6 @@
                                 "description": "%c_cpp.debuggers.program.description%",
                                 "default": "${workspaceRoot}/a.out"
                             },
-                            "type": {
-                                "type": "string",
-                                "description": "%c_cpp.debuggers.cppdbg.type.description%",
-                                "default": "cppdbg"
-                            },
                             "targetArchitecture": {
                                 "type": "string",
                                 "description": "%c_cpp.debuggers.targetArchitecture.description%",
@@ -5426,11 +5416,6 @@
                                 },
                                 "default": []
                             },
-                            "type": {
-                                "type": "string",
-                                "description": "%c_cpp.debuggers.cppvsdbg.type.description%",
-                                "default": "cppvsdbg"
-                            },
                             "cwd": {
                                 "type": "string",
                                 "description": "%c_cpp.debuggers.cwd.description%",
@@ -5640,11 +5625,6 @@
                             "processId"
                         ],
                         "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "%c_cpp.debuggers.cppvsdbg.type.description%",
-                                "default": "cppvsdbg"
-                            },
                             "symbolSearchPath": {
                                 "type": "string",
                                 "description": "%c_cpp.debuggers.symbolSearchPath.description%",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -866,8 +866,6 @@
     "c_cpp.debuggers.ignoreFailures.description": "If true, failures from the command should be ignored. Default value is false.",
     "c_cpp.debuggers.program.description": "Full path to program executable.",
     "c_cpp.debuggers.args.description": "Command line arguments passed to the program.",
-    "c_cpp.debuggers.cppdbg.type.description": "The type of the engine. Must be \"cppdbg\".",
-    "c_cpp.debuggers.cppvsdbg.type.description": "The type of the engine. Must be \"cppvsdbg\".",
     "c_cpp.debuggers.targetArchitecture.description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86, arm, arm64, mips, x64, amd64, x86_64.",
     "c_cpp.debuggers.cwd.description": "The working directory of the target.",
     "c_cpp.debuggers.setupCommands.description": "One or more GDB/LLDB commands to execute in order to setup the underlying debugger. Example: \"setupCommands\": [ { \"text\": \"-enable-pretty-printing\", \"description\": \"Enable GDB pretty printing\", \"ignoreFailures\": true }].",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -614,11 +614,6 @@
           },
           "default": []
         },
-        "type": {
-          "type": "string",
-          "description": "%c_cpp.debuggers.cppdbg.type.description%",
-          "default": "cppdbg"
-        },
         "targetArchitecture": {
           "type": "string",
           "description": "%c_cpp.debuggers.targetArchitecture.description%",
@@ -847,11 +842,6 @@
           "description": "%c_cpp.debuggers.program.description%",
           "default": "${workspaceRoot}/a.out"
         },
-        "type": {
-          "type": "string",
-          "description": "%c_cpp.debuggers.cppdbg.type.description%",
-          "default": "cppdbg"
-        },
         "targetArchitecture": {
           "type": "string",
           "description": "%c_cpp.debuggers.targetArchitecture.description%",
@@ -984,11 +974,6 @@
           },
           "default": []
         },
-        "type": {
-          "type": "string",
-          "description": "%c_cpp.debuggers.cppvsdbg.type.description%",
-          "default": "cppvsdbg"
-        },
         "cwd": {
           "type": "string",
           "description": "%c_cpp.debuggers.cwd.description%",
@@ -1120,11 +1105,6 @@
         "processId"
       ],
       "properties": {
-        "type": {
-          "type": "string",
-          "description": "%c_cpp.debuggers.cppvsdbg.type.description%",
-          "default": "cppvsdbg"
-        },
         "symbolSearchPath": {
           "type": "string",
           "description": "%c_cpp.debuggers.symbolSearchPath.description%",


### PR DESCRIPTION
I noticed this while code reviewing the lldb-dap changes which has a similar issue: https://github.com/microsoft/vscode-cpptools/pull/13569