### PR TITLE
Fix stopAtEntry, sourceFileMap, processId.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -3839,7 +3839,7 @@
                             },
                             "stopAtEntry": {
                                 "type": "boolean",
-                                "description": "%c_cpp.debuggers.stopAtEntry.description%",
+                                "markdownDescription": "%c_cpp.debuggers.stopAtEntry.markdownDescription%",
                                 "default": false
                             },
                             "debugServerPath": {
@@ -3888,16 +3888,15 @@
                                 "default": false
                             },
                             "sourceFileMap": {
+                                "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
                                 "anyOf": [
                                     {
                                         "type": "object",
-                                        "description": "%c_cpp.debuggers.sourceFileMap.description%",
                                         "default": {
                                             "<source-path>": "<target-path>"
                                         }
                                     },
                                     {
-                                        "description": "%c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description%",
                                         "type": "object",
                                         "default": {
                                             "<source-path>": {
@@ -4652,15 +4651,14 @@
                                 "default": false
                             },
                             "processId": {
+                                "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",
                                 "anyOf": [
                                     {
                                         "type": "string",
-                                        "description": "%c_cpp.debuggers.processId.anyOf.description%",
                                         "default": "${command:pickProcess}"
                                     },
                                     {
                                         "type": "integer",
-                                        "description": "%c_cpp.debuggers.processId.anyOf.description%",
                                         "default": 0
                                     }
                                 ]
@@ -4676,16 +4674,15 @@
                                 "default": false
                             },
                             "sourceFileMap": {
+                                "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
                                 "anyOf": [
                                     {
                                         "type": "object",
-                                        "description": "%c_cpp.debuggers.sourceFileMap.description%",
                                         "default": {
                                             "<source-path>": "<target-path>"
                                         }
                                     },
                                     {
-                                        "description": "%c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description%",
                                         "type": "object",
                                         "default": {
                                             "<source-path>": {
@@ -5450,7 +5447,7 @@
                             },
                             "stopAtEntry": {
                                 "type": "boolean",
-                                "description": "%c_cpp.debuggers.stopAtEntry.description%",
+                                "markdownDescription": "%c_cpp.debuggers.stopAtEntry.markdownDescription%",
                                 "default": false
                             },
                             "dumpPath": {
@@ -5487,7 +5484,7 @@
                             },
                             "sourceFileMap": {
                                 "type": "object",
-                                "description": "%c_cpp.debuggers.sourceFileMap.description%",
+                                "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
                                 "default": {
                                     "<source-path>": "<target-path>"
                                 }
@@ -5631,15 +5628,14 @@
                                 "default": ""
                             },
                             "processId": {
+                                "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",
                                 "anyOf": [
                                     {
                                         "type": "string",
-                                        "description": "%c_cpp.debuggers.processId.anyOf.description%",
                                         "default": "${command:pickProcess}"
                                     },
                                     {
                                         "type": "integer",
-                                        "description": "%c_cpp.debuggers.processId.anyOf.description%",
                                         "default": 0
                                     }
                                 ]
@@ -5651,7 +5647,7 @@
                             },
                             "sourceFileMap": {
                                 "type": "object",
-                                "description": "%c_cpp.debuggers.sourceFileMap.description%",
+                                "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
                                 "default": {
                                     "<source-path>": "<target-path>"
                                 }

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -889,7 +889,12 @@
     "c_cpp.debuggers.miDebuggerArgs.description": "Additional arguments for the MI debugger (such as gdb).",
     "c_cpp.debuggers.miDebuggerServerAddress.description": "Network address of the MI Debugger Server to connect to (example: localhost:1234).",
     "c_cpp.debuggers.useExtendedRemote.description": "Connect to the MI Debugger Server with target extended-remote mode.",
-    "c_cpp.debuggers.stopAtEntry.description": "Optional parameter. If true, the debugger should stop at the entrypoint of the target. If processId is passed, has no effect.",
+    "c_cpp.debuggers.stopAtEntry.markdownDescription": {
+        "message": "Optional parameter. If `true`, the debugger should stop at the entry point of the target. If `processId` is passed, this has no effect.",
+        "comment": [
+            "{Locked=\"`true`\"} {Locked=\"`processId`\"}"
+        ]
+    },
     "c_cpp.debuggers.debugServerPath.description": "Optional full path to the debug server to launch. Defaults to null. It is used in conjunction with either \"miDebugServerAddress\" or your own server with a \"customSetupCommand\" that runs \"-target-select remote <server:port>\".",
     "c_cpp.debuggers.debugServerArgs.description": "Optional debug server args. Defaults to null.",
     "c_cpp.debuggers.serverStarted.description": "Optional server-started pattern to look for in the debug server output. Defaults to null.",
@@ -905,8 +910,18 @@
     "c_cpp.debuggers.cppvsdbg.console.externalTerminal.description": "Console applications will be launched in an external terminal window. The window will be reused in relaunch scenarios and will not automatically disappear when the application exits.",
     "c_cpp.debuggers.cppvsdbg.console.newExternalWindow.description": "Console applications will be launched in their own external console window which will end when the application stops. Non-console applications will run without a terminal, and stdout/stderr will be ignored.",
     "c_cpp.debuggers.avoidWindowsConsoleRedirection.description": "If true, disables debuggee console redirection that is required for Integrated Terminal support.",
-    "c_cpp.debuggers.sourceFileMap.description": "Optional source file mappings passed to the debug engine. Example: '{ \"/original/source/path\":\"/current/source/path\" }'.",
-    "c_cpp.debuggers.processId.anyOf.description": "Optional process id to attach the debugger to. Use \"${command:pickProcess}\" to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+    "c_cpp.debuggers.sourceFileMap.markdownDescription": {
+        "message": "Optional source file mappings passed to the debug engine. Example: `{ \"<original source path>\": \"<current source path>\" }`.",
+        "comment": [
+            "{Locked=\"`{ \\\"<\"} {Locked=\">\\\": \\\"<\"} {Locked=\">\\\" }`\"}"
+        ]
+    },
+    "c_cpp.debuggers.processId.anyOf.markdownDescription": {
+        "message": "Optional process ID to attach the debugger to. Use `${command:pickProcess}` to get a list of local running processes to attach to. Note that some platforms require administrator privileges in order to attach to a process.",
+        "comment": [
+            "{Locked=\"`${command:pickProcess}`\"}"
+        ]
+    },
     "c_cpp.debuggers.symbolSearchPath.description": "Semicolon separated list of directories to use to search for symbol (that is, pdb) files. Example: \"c:\\dir1;c:\\dir2\".",
     "c_cpp.debuggers.dumpPath.description": "Optional full path to a dump file for the specified program. Example: \"c:\\temp\\app.dmp\". Defaults to null.",
     "c_cpp.debuggers.enableDebugHeap.description": "If false, the process will be launched with debug heap disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -728,7 +728,7 @@
         },
         "stopAtEntry": {
           "type": "boolean",
-          "description": "%c_cpp.debuggers.stopAtEntry.description%",
+          "markdownDescription": "%c_cpp.debuggers.stopAtEntry.markdownDescription%",
           "default": false
         },
         "debugServerPath": {
@@ -777,17 +777,16 @@
           "default": false
         },
         "sourceFileMap": {
+          "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
           "anyOf": [
             {
               "type": "object",
-              "description": "%c_cpp.debuggers.sourceFileMap.description%",
               "default": {
                 "<source-path>": "<target-path>"
               }
             },
             {
-              "$ref": "#/definitions/SourceFileMapEntry",
-              "description": "%c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description%"
+              "$ref": "#/definitions/SourceFileMapEntry"
             }
           ]
         },
@@ -888,15 +887,14 @@
           "default": false
         },
         "processId": {
+          "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",
           "anyOf": [
             {
               "type": "string",
-              "description": "%c_cpp.debuggers.processId.anyOf.description%",
               "default": "${command:pickProcess}"
             },
             {
               "type": "integer",
-              "description": "%c_cpp.debuggers.processId.anyOf.description%",
               "default": 0
             }
           ]
@@ -912,17 +910,16 @@
           "default": false
         },
         "sourceFileMap": {
+          "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
           "anyOf": [
             {
               "type": "object",
-              "description": "%c_cpp.debuggers.sourceFileMap.description%",
               "default": {
                 "<source-path>": "<target-path>"
               }
             },
             {
-              "$ref": "#/definitions/SourceFileMapEntry",
-              "description": "%c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description%"
+              "$ref": "#/definitions/SourceFileMapEntry"
             }
           ]
         },
@@ -999,7 +996,7 @@
         },
         "stopAtEntry": {
           "type": "boolean",
-          "description": "%c_cpp.debuggers.stopAtEntry.description%",
+          "markdownDescription": "%c_cpp.debuggers.stopAtEntry.markdownDescription%",
           "default": false
         },
         "dumpPath": {
@@ -1036,7 +1033,7 @@
         },
         "sourceFileMap": {
           "type": "object",
-          "description": "%c_cpp.debuggers.sourceFileMap.description%",
+          "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
           "default": {
             "<source-path>": "<target-path>"
           }
@@ -1111,15 +1108,14 @@
           "default": ""
         },
         "processId": {
+          "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",
           "anyOf": [
             {
               "type": "string",
-              "description": "%c_cpp.debuggers.processId.anyOf.description%",
               "default": "${command:pickProcess}"
             },
             {
               "type": "integer",
-              "description": "%c_cpp.debuggers.processId.anyOf.description%",
               "default": 0
             }
           ]
@@ -1131,7 +1127,7 @@
         },
         "sourceFileMap": {
           "type": "object",
-          "description": "%c_cpp.debuggers.sourceFileMap.description%",
+          "markdownDescription": "%c_cpp.debuggers.sourceFileMap.markdownDescription%",
           "default": {
             "<source-path>": "<target-path>"
           }


### PR DESCRIPTION
Fix more issues with debugger properties from reviewing https://github.com/microsoft/vscode-cpptools/pull/13569 .

I used Locked for strings I noticed were translated when they should not have been.