### PR TITLE
Fix issue with lost edits in config UI

### DIFF
--- a/Extension/src/LanguageServer/settingsPanel.ts
+++ b/Extension/src/LanguageServer/settingsPanel.ts
@@ -121,6 +121,7 @@ export class SettingsPanel {
             {
                 enableCommandUris: true,
                 enableScripts: true,
+                retainContextWhenHidden: true,
 
                 // Restrict the webview to only loading content from these directories
                 localResourceRoots: [


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/13636

Without `retainContextWhenHidden`, a webview will be destroyed when obscured (not visible).

Alternatively, it may be possible to set aside some data while editing a field so the edit can be applied when the webview is disposed. (We definitely don't want to be applying edits to the configuration while values are still being typed). Not disposing when hidden is much simpler.

My opinion is that this is working around a VS Code bug.  We should be able to leverage "change" events, without having to be aware of the disposal behavior.  https://github.com/microsoft/vscode/issues/253146#issuecomment-3046201187
