### PR TITLE
Update changelog for 1.27.0

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.27.0: July 15, 2025
+### Bug Fixes
+* Fix IntelliSense crash in `find_subobject_for_interpreter_address`. [#12464](https://github.com/microsoft/vscode-cpptools/issues/12464)
+* Fix changes to the active field being lost in the configuration UI when navigating away. [#13636](https://github.com/microsoft/vscode-cpptools/issues/13636)
+* Fix compiler query failing on Windows if optional job-related API calls fail. [#13679](https://github.com/microsoft/vscode-cpptools/issues/13679)
+* Fix bugs with Doxygen comments. [#13725](https://github.com/microsoft/vscode-cpptools/issues/13725), [#13726](https://github.com/microsoft/vscode-cpptools/issues/13726), [#13745](https://github.com/microsoft/vscode-cpptools/issues/13745)
+* Fix a bug with 'Create Definition'. [#13741](https://github.com/microsoft/vscode-cpptools/issues/13741)
+
 ## Version 1.26.3: June 24, 2025
 ### New Feature
 * Improve the context provided for C++ Copilot suggestions.
@@ -18,7 +26,7 @@
 * Fix `-iquote` not working after `-isystem`. [#13638](https://github.com/microsoft/vscode-cpptools/issues/13638)
 * Minor debugger fixes. [PR #13654](https://github.com/microsoft/vscode-cpptools/pull/13654), [PR #13671](https://github.com/microsoft/vscode-cpptools/pull/13671)
 * Fix `browse.path` merging with the configuration provider's `browse.path` with `"mergeConfigurations": false`. [#13660](https://github.com/microsoft/vscode-cpptools/issues/13660)
-* Fix doxygen comments with `[in]`, `[in,out]`, etc. attributes. [#13682](https://github.com/microsoft/vscode-cpptools/issues/13682), [#13698](https://github.com/microsoft/vscode-cpptools/issues/13698)
+* Fix Doxygen comments with `[in]`, `[in,out]`, etc. attributes. [#13682](https://github.com/microsoft/vscode-cpptools/issues/13682), [#13698](https://github.com/microsoft/vscode-cpptools/issues/13698)
 * Fix old `defines` accumulating after `defines` are changed with `"mergeConfigurations": true`. [#13687](https://github.com/microsoft/vscode-cpptools/issues/13687)
 * Fix changes to mergeable properties in `c_cpp_properties.json` not being used until a new configuration is requested with `"mergeConfigurations": true`. [#13688](https://github.com/microsoft/vscode-cpptools/issues/13688)
 * Update Apple clang 16.4 to LLVM clang version mappings and fix incorrect mappings for Apple clang 14.
@@ -268,13 +276,13 @@
 * Stop logging file watch events for excluded files. [#11455](https://github.com/microsoft/vscode-cpptools/issues/11455)
 * Fix a crash if the Ryzen 3000 doesn't have updated drivers. [#12201](https://github.com/microsoft/vscode-cpptools/issues/12201)
 * Fix handling of `-isystem` and `-iquote` for IntelliSense configuration. [#12207](https://github.com/microsoft/vscode-cpptools/issues/12207)
-* Fix doxygen comment generation when `/**` comments are used. [#12249](https://github.com/microsoft/vscode-cpptools/issues/12249)
+* Fix Doxygen comment generation when `/**` comments are used. [#12249](https://github.com/microsoft/vscode-cpptools/issues/12249)
 * Fix a code analysis crash on Linux if the message is too long. [#12285](https://github.com/microsoft/vscode-cpptools/issues/12285)
 * Fix relative paths in `compile_commands.json` to be relative to the `compile_commands.json`'s directory. [#12290](https://github.com/microsoft/vscode-cpptools/issues/12290)
 * Fix a tag parser performance regression. [#12292](https://github.com/microsoft/vscode-cpptools/issues/12292)
 * Fix a regression with cl.exe system include path detection. [#12293](https://github.com/microsoft/vscode-cpptools/issues/12293)
 * Fix code analysis, find all references, and rename from getting the wrong configuration for non-open files on the first run when using a configuration provider. [#12313](https://github.com/microsoft/vscode-cpptools/issues/12313)
-* Fix handling of doxygen comment blocks with `*//*` in them. [#12316](https://github.com/microsoft/vscode-cpptools/issues/12316)
+* Fix handling of Doxygen comment blocks with `*//*` in them. [#12316](https://github.com/microsoft/vscode-cpptools/issues/12316)
 * Fix potential crashes during IntelliSense process shutdown. [#12354](https://github.com/microsoft/vscode-cpptools/issues/12354)
 * Fix the language status not showing it's busy while the tag parser is initializing. [#12403](https://github.com/microsoft/vscode-cpptools/issues/12403)
 * Fix the vcpkg code action not appearing for missing headers available via vcpkg. [#12413](https://github.com/microsoft/vscode-cpptools/issues/12413)

--- a/Extension/ThirdPartyNotices.txt
+++ b/Extension/ThirdPartyNotices.txt
@@ -298,6 +298,317 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+llvm/llvm-project 0d44201451f03ba907cdb268ddddfc3fa38a0ebd - Apache-2.0 WITH LLVM-exception
+
+
+(c) ABS
+(c) (tm)
+(c) Value A
+(c) auto AS
+(c) Value Sd
+(c) auto AST
+(c) CXType PT
+(c) Type I1Ty
+(c) Value RHS
+(c) X1 ... X1
+Copy (c) Copy
+(c) Type I32Ty
+(c) Value Elt0
+(c) Type Int8Ty
+(c) Type V8x8Ty
+(c) unsigned AS
+Copy c (c) Copy
+(c) Constant One
+(c) Type FloatTy
+(c) Type Int16Ty
+(c) Type Int32Ty
+(c) Type Int64Ty
+(c) Value AllocA
+(c) Value Alloca
+Alloc1 a1 (c) R1
+Alloc1 a2 (c) R1
+copyright u'2013
+(c) FileID MainID
+(c) Lower C Upper
+(c) Stmt NumExprs
+(c) Type DoubleTy
+(c) Type I32PtrTy
+(c) Value AllocaA
+Coproc, Opc1, CRm
+(c) Align NewAlign
+(c) PointerType P2
+Copyright (c) 2012
+Exprs new (c) Stmt
+(c) DeclRefExpr Ref
+(c) ExprResult NewE
+(c) Metadata Ops MD
+(c) SelectInst SelI
+(c) SmallVector MDs
+(c) TransferBatch B
+(c) Type Int32PtrTy
+(c) Type Int64PtrTy
+(c) Value InvMaxMin
+(c) BasicBlock Entry
+(c) CXXRecordDecl CD
+(c) FunctionType FTy
+(c) Offset C- Offset
+Copyright 2010 INRIA
+Copyright 2011 INRIA
+Copyright 2012 INRIA
+Copyright 2014 INRIA
+Copyright 2015 INRIA
+Copyright 2016 INRIA
+(c) FunctionType FnTy
+(c) QualType ResultTy
+(c) SourceRange Range
+AsmToks new (c) Token
+SubExprs new (c) Stmt
+(c) BasicBlock EntryBB
+(c) FunctionType FFnTy
+(c) FunctionType IFnTy
+(c) SourceLocation Loc
+Condition (c) Branches
+Context (c) LineToUnit
+(c) ErrMsg Stream Error
+(c) SmallVector NewVars
+(c) SmallVector ToErase
+Bbb kind copyright' Bbb
+(c) Constant PosDivisorC
+CommonPtr new (c) Common
+Copyright (c) 2012 CHECK
+(c) CharUnits AlignedSize
+(c) Constant NullV2I32Ptr
+(c) Constant PosDividendC
+Copyright 2010-2011 INRIA
+Copyright 2014-2015 INRIA
+COPYRIGHT,v 1.3 2003/06/02
+Coproc, Opc1, Rt, Rt2, CRm
+Copyright 2008 Google Inc.
+Copyright 2015 Google Inc.
+Copyright 2018 Google Inc.
+Copyright The LLVM project
+coprime. APInt A HugePrime
+(c) IdentifierInfo NumExprs
+(c) VectorType Int8PtrVecTy
+Copyright (c) 1997, Phillip
+Copyright 2005, Google Inc.
+Copyright 2006, Google Inc.
+Copyright 2007, Google Inc.
+Copyright 2008, Google Inc.
+Copyright 2013, Google Inc.
+Copyright 2015, Google Inc.
+InitCache (c) TransferBatch
+Copyright 2006, Dean Edwards
+(c) CXXBaseSpecifier NumBases
+(c) Designator NumDesignators
+(c) StringLiteral NumClobbers
+Constraints new (c) StringRef
+Copyright (c) 2010 Apple Inc.
+Copyright (c) by P.J. Plauger
+Copyright 2010 Zencoder, Inc.
+Copyright 2017 Roman Lebedev.
+ParamInfo new (c) ParmVarDecl
+Copyright (c) 2009 Google Inc.
+Copyright (c) 2016 Aaron Watry
+Copyright (c) 2017 Google Inc.
+Copyright (c) 2018 Jim Ingham.
+IMPL-NEXT switch (c) IMPL-NEXT
+coprocessor. SDValue ImmCorpoc
+(c) CHECK-NEXT foo() CHECK-NEXT
+(copr0) ConstantDataVector CDV1
+(copr1) ConstantDataVector CDV2
+Copyright (c) 1994 X Consortium
+Copyright (c) 2008 Matteo Frigo
+Copyright (c) 2009 Matteo Frigo
+Copyright 2008-2010 Apple, Inc.
+Copyright 2015 Sven Verdoolaege
+Copyright 2016 Sven Verdoolaege
+Copyright 2017 Sven Verdoolaege
+Copyright 2018 Cerebras Systems
+Copyright 2018 Sven Verdoolaege
+Copyright 2019 Cerebras Systems
+Copyright, License, and Patents
+Other Coprocessor Instructions.
+(c) StringLiteral NumConstraints
+Copyright 2011 Sven Verdoolaege.
+(c) foo() pragma omp target teams
+Copyright (c) 1992 Henry Spencer.
+Copyright (c) 2004-2018 Bootstrap
+Copyright (c) 2006 Kirill Simonov
+Copyright (c) 2010-2018 Bootstrap
+Copyright 2001-2004 Unicode, Inc.
+Value0 Data.getULEB128 (c) Value1
+copyright u'2003- d, LLVM Project
+copyright u'2011- d, LLVM Project
+Copyright (c) 1999-2007 Apple Inc.
+Copyright (c) 2009-2019 Polly Team
+Copyright 2012 Universiteit Leiden
+Copyright 2016-2017 Tobias Grosser
+copyright u'2007- d, The LLDB Team
+copyright u'2013- d, Analyzer Team
+Constraint new (c) AtomicConstraint
+Copyright (c) 2015the LLVM Project.
+copyright u'2007- d, The Clang Team
+copyright u'2010- d, The Polly Team
+copyright u'2017- d, The Flang Team
+Copyright (C ) Microsoft Corporation
+Copyright (c) 2001 Alexander Peslyak
+Copyright (c) 2014, 2015 Google Inc.
+Copyright (c) 2019 The MLIR Authors.
+Copyright (c) Microsoft Corporation.
+Copyright 2015-2016 Sven Verdoolaege
+Copyright 2016, 2017 Tobias Grosser.
+Copyright 2016-2017 Sven Verdoolaege
+Copyright 2018-2019 Cerebras Systems
+(c) PointerType InitPtrType InitValue
+Copyright (c) 1999-2003 Steve Purcell
+Copyright (c) 2012-2016, Yann Collet.
+Copyright 2011,2015 Sven Verdoolaege.
+DiagStorage new (c) DiagnosticStorage
+Copyright (c) 2008 Christian Haggstrom
+Copyright (c) 2012 Avionic Design GmbH
+Copyright 2007-2010 by the Sphinx team
+(c) CHECK-NEXT T break CHECK-NEXT Preds
+Copyright (c) 2002-2004 Tim J. Robbins.
+Copyright (c) 2005 Free Standards Group
+Copyright (c) 2019, NVIDIA CORPORATION.
+Copyright 2005-2007 Universiteit Leiden
+Copyright 2006-2007 Universiteit Leiden
+Copyright 2012 Ecole Normale Superieure
+Copyright 2013 Ecole Normale Superieure
+Copyright 2014 Ecole Normale Superieure
+Copyright 2016 Ismael Jimenez Martinez.
+NameCount AS.getU32 (c) AbbrevTableSize
+in LLVM, Diploma Thesis, (c) April 2011
+(c) StringRef NumClobbers // FIXME Avoid
+Copyright (c) 1997-2019 Intel Corporation
+Copyright (c) 2010-2015 Benjamin Peterson
+Copyright 1992, 1993, 1994 Henry Spencer.
+coproc_option_imm Operand let PrintMethod
+(c) CXXCtorInitializer NumIvarInitializers
+(c), intrinsic cos !WARNING Attribute BIND
+Copyright (c) 2004 eXtensible Systems, Inc.
+Copyright (c) 2009-2014 by the contributors
+Copyright (c) 2009-2015 by the contributors
+Copyright (c) 2009-2016 by the contributors
+Copyright (c) 2009-2019 by the contributors
+Copyright (c) 2011-2014 by the contributors
+Copyright (c) 2011-2019 by the contributors
+Copyright (c) 2017-2019 by the contributors
+(c) CHECK-NEXT Preds (1) B4 CHECK-NEXT Succs
+(c) CHECK-NEXT Preds (1) B5 CHECK-NEXT Succs
+(c) CHECK-NEXT Preds (1) B7 CHECK-NEXT Succs
+CoprocNumAsmOperand AsmOperandClass let Name
+CoprocRegAsmOperand AsmOperandClass let Name
+Copyright (c) 1993 by Sun Microsystems, Inc.
+Copyright 2012,2014 Ecole Normale Superieure
+Copyright 2012-2013 Ecole Normale Superieure
+Copyright 2012-2014 Ecole Normale Superieure
+Copyright 2013-2014 Ecole Normale Superieure
+Copyright (c) 1992, 1993, 1994 Henry Spencer.
+Copyright (c) 2002-2007 Michael J. Fromberger
+Copyright 2000 Free Software Foundation, Inc.
+CompUnitCount AS.getU32 (c) LocalTypeUnitCount
+Copyright (c) 2008 Ryan McCabe <ryan@numb.org>
+ForeignTypeUnitCount AS.getU32 (c) BucketCount
+CoprocOptionAsmOperand AsmOperandClass let Name
+Copyright (c) 2014 Advanced Micro Devices, Inc.
+Copyright (c) 2015 Advanced Micro Devices, Inc.
+(c) Designator NumDesigs NumDesignators NumDesigs
+Copyright (c) 1992, 1993 UNIX International, Inc.
+Copyright (c) 2004 Free Software Foundation, Inc.
+Copyright (c) 2008 Free Software Foundation, Inc.
+Copyright (c) 2011 Free Software Foundation, Inc.
+Copyright (c) 2012 Free Software Foundation, Inc.
+Copyright (c) 2012, Noah Spurrier <noah@noah.org>
+Copyright (c) 2013-2014, Pexpect development team
+Copyright (c) 2013-2016, Pexpect development team
+Copyright (c) 2014 Free Software Foundation, Inc.
+Copyright (c) 2015 Paul Norman <penorman@mac.com>
+Copyright (c) 2016 Aaron Watry <awatry@gmail.com>
+Copyright extcopyright~ he year the LLVM Project.
+(c) CHECK-NEXT Preds (3) B3 B4 B2 CHECK-NEXT Succs
+(c) CHECK-NEXT Preds (3) B3 B5 B6 CHECK-NEXT Succs
+Copyright (c) 2003-2010 Python Software Foundation
+Copyright (c) 2008 Paolo Bonzini <bonzini@gnu.org>
+Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+Copyright 2008-2009 Katholieke Universiteit Leuven
+(c) Desc StrOffsetsContributionDescriptor C- Offset
+(c) Stmt NumExprs std::copy Exprs, Exprs + NumExprs
+Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+Copyright (c) 2008 Stepan Kasal <skasal@redhat.com>
+Copyright (c) 2012 Qualcomm Innovation Center, Inc.
+Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+Copyright (c) 2014,2015 Advanced Micro Devices, Inc.
+Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+Copyright (c) 2014, 2015 Advanced Micro Devices, Inc.
+Copyright (c) 2016 Krzesimir Nowak <qdlacz@gmail.com>
+Copyright (c) 1994-2014 Free Software Foundation, Inc.
+Copyright (c) 1996-2014 Free Software Foundation, Inc.
+Copyright (c) 1996-2018 Free Software Foundation, Inc.
+Copyright (c) 1997-2014 Free Software Foundation, Inc.
+Copyright (c) 1999-2013 Free Software Foundation, Inc.
+Copyright (c) 1999-2014 Free Software Foundation, Inc.
+Copyright (c) 2001-2014 Free Software Foundation, Inc.
+Copyright (c) 2002-2014 Free Software Foundation, Inc.
+Copyright (c) 2003-2014 Free Software Foundation, Inc.
+Copyright (c) 2004-2014 Free Software Foundation, Inc.
+Copyright (c) 2006-2014 Free Software Foundation, Inc.
+Copyright (c) 2008 Sven Verdoolaege <skimo@kotnet.org>
+Copyright (c) 2009-2014 Free Software Foundation, Inc.
+Copyright (c) 2010-2015 Free Software Foundation, Inc.
+Copyright (c) 2010-2017 Free Software Foundation, Inc.
+Copyright (c) 2011-2013 Free Software Foundation, Inc.
+Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+(c) StructType FrameTy Shape.FrameTy Instruction FramePtr
+Copyright (c) 2013 Jesse Towner <jessetowner@lavabit.com>
+Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+(c) Type AtExitFuncArgs VoidStar FunctionType AtExitFuncTy
+(c) GlobalVariable Handle new GlobalVariable M, DsoHandleTy
+(c) Type ArgTys Int32Ty, Int32Ty, Int32Ty FunctionType FnTy
+Copyright (c) 2004 Scott James Remnant <scott@netsplit.com>
+Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+Copyright (c) 2009 Steven G. Johnson <stevenj@alum.mit.edu>
+Copyright (c) 2004, 2011-2018 Free Software Foundation, Inc.
+Copyright (c) 2013 Victor Oliveira <victormatheus@gmail.com>
+(c) DeclRefExpr DR M.makeDeclRefExpr(PV) ImplicitCastExpr ICE
+(c) IdentifierInfo NumExprs std::copy Names, Names + NumExprs
+Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+(c) BranchInst BI BranchInst::Create(Exit, Exit, False, Entry)
+Copyright (c) 1994 The Regents of the University of California.
+Copyright (c) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+Copyright (c) 1996-2001, 2003-2018 Free Software Foundation, Inc.
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+Copyright (c) 2004, 2005, 2007, 2008 Free Software Foundation, Inc.
+Copyright (c) 2004, 2005, 2007, 2009 Free Software Foundation, Inc.
+Copyright (c) 2007-2018 University of Illinois at Urbana-Champaign.
+Copyright (c) 2007-2019 University of Illinois at Urbana-Champaign.
+(c) StringRef Expression Data.getBytes(C, BlockLength) DataExtractor
+Copyright (c) 2006-2009 Steven J. Bethard <steven.bethard@gmail.com>
+Copyright (c) 1992, 1993 The Regents of the University of California.
+(c) StringLiteral NumClobbers std::copy Clobbers, Clobbers + NumClobbers
+Copyright (c) 2004, 2005, 2007, 2008, 2009 Free Software Foundation, Inc.
+Copyright (c) 1992, 1993, 1994 The Regents of the University of California.
+Copyright (c) 2004-2005, 2007-2008, 2011-2018 Free Software Foundation, Inc.
+Copyright (c) 2004-2005, 2007-2009, 2011-2018 Free Software Foundation, Inc.
+Copyright (c) 2004-2005, 2007, 2009, 2011-2018 Free Software Foundation, Inc.
+(c) StringLiteral NumConstraints std::copy Constraints, Constraints + NumConstraints
+Copyright (c) 1999, 2000, 2003, 2004, 2005, 2006, 2007, 2009, 2010, 2011, 2012 Free Software Foundation, Inc.
+Copyright (c) 1996, 1997, 1999, 2000, 2002, 2003, 2004, 2005, 2006, 2008, 2009, 2010, 2011, 2012 Free Software Foundation, Inc.
+Copyright (c) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation, Inc.
+Copyright (c) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation, Inc.
+Copyright (c) 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012 Free Software Foundation, Inc.
+
+Apache-2.0 WITH LLVM-exception
+
+---------------------------------------------------------
+
 ---------------------------------------------------------
 
 webidl-conversions 3.0.1 - BSD-2-Clause
@@ -751,6 +1062,44 @@ the licensed code:
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
   DEALINGS IN THE SOFTWARE.
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+@github/copilot-language-server 1.316.0 - LicenseRef-scancode-unknown
+https://github.com/github/copilot-language-server-release
+
+COPYRIGHT Zone Model
+Copyright Deno authors
+(c) 2012 by Cedric Mesnil
+Copyright (c) 2018 Agoric
+Copyright Domenic Denicola
+Copyright (c) 2011 Google Inc.
+Copyright (c) 2012 Google Inc.
+Copyright 1995-2022 Mark Adler
+Copyright 1995-2023 Mark Adler
+Copyright Node.js contributors
+Copyright (c) 2016, Contributors
+Copyright (c) 2014, StrongLoop Inc.
+Copyright 2009 the V8 project authors
+Copyright 2011 the V8 project authors
+Copyright 2012 the V8 project authors
+Copyright 2013 the V8 project authors
+Copyright 2017 the V8 project authors
+Copyright (c) Microsoft and contributors
+Copyright (c) 2016 Unicode, Inc. and others
+Copyright (c) 2012-2018 by various contributors
+Copyright (c) 2009 Thomas Robinson <280north.com>
+Copyright Joyent, Inc. and other Node contributors
+Copyright 1995-2022 Jean-loup Gailly and Mark Adler
+Copyright 1995-2023 Jean-loup Gailly and Mark Adler
+Copyright (c) 1996-2016 Free Software Foundation, Inc.
+Copyright (c) NevWare21 Solutions LLC and contributors
+Copyright 1995-2023 Jean-loup Gailly and Mark Adler Qkkbal
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+LicenseRef-scancode-unknown
 
 ---------------------------------------------------------
 

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.26.3-main",
+    "version": "1.27.0-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
I decided to keep the buggy-looking auto-generated LLVM TPN notice since the @github/copilot-language-server license is similar in style.