### PR TITLE
Enable string length encoding fix in cpptools

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -44,8 +44,8 @@ export function createProtocolFilter(): Middleware {
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
-                    void sendMessage(document);
                     client.ready.then(() => {
+                        client.sendDidOpen(document);
                         const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
                         client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
                     }).catch(logAndReturn.undefined);

--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -19,7 +19,7 @@ export const ServerCancelled: number = -32802;
 
 export function createProtocolFilter(): Middleware {
     return {
-        didOpen: async (document, sendMessage) => {
+        didOpen: async (document, _sendMessage) => {
             if (!util.isCpp(document)) {
                 return;
             }
@@ -45,7 +45,7 @@ export function createProtocolFilter(): Middleware {
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
                     client.ready.then(() => {
-                        client.sendDidOpen(document);
+                        client.sendDidOpen(document).catch(logAndReturn.undefined);
                         const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
                         client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
                     }).catch(logAndReturn.undefined);


### PR DESCRIPTION
There is related native side PR as well.

Switches to our own version of didOpen in order to include an encoding var which was added as part of: https://github.com/microsoft/vscode/issues/209503