### PR TITLE
Remove "exceptions" from quoteArgs.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4055,11 +4055,9 @@
                                         "default": {}
                                     },
                                     "quoteArgs": {
-                                        "exceptions": {
-                                            "type": "boolean",
-                                            "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
-                                            "default": true
-                                        }
+                                        "type": "boolean",
+                                        "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
+                                        "default": true
                                     }
                                 }
                             },
@@ -4841,11 +4839,9 @@
                                         "default": {}
                                     },
                                     "quoteArgs": {
-                                        "exceptions": {
-                                            "type": "boolean",
-                                            "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
-                                            "default": true
-                                        }
+                                        "type": "boolean",
+                                        "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
+                                        "default": true
                                     }
                                 }
                             },

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -47,11 +47,9 @@
           "default": {}
         },
         "quoteArgs": {
-          "exceptions": {
-            "type": "boolean",
-            "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
-            "default": true
-          }
+          "type": "boolean",
+          "description": "%c_cpp.debuggers.pipeTransport.quoteArgs.description%",
+          "default": true
         }
       }
     },


### PR DESCRIPTION
The "exceptions" appears incorrect. I noticed this while reviewing https://github.com/microsoft/vscode-cpptools/pull/13794