### PR TITLE
Revert didOpen changes in favor of adding encoding to didChangeVisibleTextEditors

### DIFF
--- a/Extension/src/LanguageServer/protocolFilter.ts
+++ b/Extension/src/LanguageServer/protocolFilter.ts
@@ -19,7 +19,7 @@ export const ServerCancelled: number = -32802;
 
 export function createProtocolFilter(): Middleware {
     return {
-        didOpen: async (document, _sendMessage) => {
+        didOpen: async (document, sendMessage) => {
             if (!util.isCpp(document)) {
                 return;
             }
@@ -44,8 +44,8 @@ export function createProtocolFilter(): Middleware {
                     }
                     // client.takeOwnership() will call client.TrackedDocuments.add() again, but that's ok. It's a Set.
                     client.takeOwnership(document);
+                    void sendMessage(document);
                     client.ready.then(() => {
-                        client.sendDidOpen(document).catch(logAndReturn.undefined);
                         const cppEditors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => util.isCpp(e.document));
                         client.onDidChangeVisibleTextEditors(cppEditors).catch(logAndReturn.undefined);
                     }).catch(logAndReturn.undefined);


### PR DESCRIPTION
Fixes an issue related to:
https://github.com/microsoft/vscode-cpptools/pull/13769

... where the change to didOpen resulted in race conditions between the new didOpen message and other messages.

This change restores the original didOpen and instead piggy-backs the encoding on the didChangeVisibleTextEditors message (which must be received before we start language services for a file).

There is also a native-side PR.