### PR TITLE
Register the CPP context provider with Copilot Chat as well. 

### DIFF
--- a/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
@@ -11,7 +11,7 @@ import { getOutputChannelLogger, Logger } from '../logger';
 import * as telemetry from '../telemetry';
 import { CopilotCompletionContextResult } from './client';
 import { CopilotCompletionContextTelemetry } from './copilotCompletionContextTelemetry';
-import { getCopilotApi, getCopilotChatApi, type CopilotChatApi } from './copilotProviders';
+import { getCopilotChatApi, getCopilotClientApi, type CopilotContextProviderAPI } from './copilotProviders';
 import { clients } from './extension';
 import { CppSettings } from './settings';
 
@@ -449,7 +449,7 @@ ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}
         const properties: Record<string, string> = {};
         const registerCopilotContextProvider = 'registerCopilotContextProvider';
         try {
-            const copilotApi = await getCopilotApi();
+            const copilotApi = await getCopilotClientApi();
             const copilotChatApi = await getCopilotChatApi();
             if (!copilotApi && !copilotChatApi) { throw new CopilotContextProviderException("getCopilotApi() returned null, Copilot is missing or inactive."); }
             const contextProvider = {
@@ -486,8 +486,8 @@ ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}
         }
     }
 
-    private async installContextProvider(copilotAPI: CopilotChatApi, contextProvider: ContextProvider<SupportedContextItem>): Promise<{ hasGetContextProviderAPI: boolean; hasAPI: boolean }> {
-        const hasGetContextProviderAPI = "getContextProviderAPI" in copilotAPI;
+    private async installContextProvider(copilotAPI: CopilotContextProviderAPI, contextProvider: ContextProvider<SupportedContextItem>): Promise<{ hasGetContextProviderAPI: boolean; hasAPI: boolean }> {
+        const hasGetContextProviderAPI = typeof copilotAPI.getContextProviderAPI === 'function';
         if (hasGetContextProviderAPI) {
             const contextAPI = await copilotAPI.getContextProviderAPI("v1");
             if (contextAPI) {

--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -24,11 +24,11 @@ export interface CopilotTrait {
     promptTextOverride?: string;
 }
 
-export interface CopilotChatApi {
+export interface CopilotContextProviderAPI {
     getContextProviderAPI(version: string): Promise<ContextProviderApiV1 | undefined>;
 }
 
-export interface CopilotApi extends CopilotChatApi {
+export interface CopilotApi extends CopilotContextProviderAPI {
     registerRelatedFilesProvider(
         providerId: { extensionId: string; languageId: string },
         callback: (
@@ -40,7 +40,7 @@ export interface CopilotApi extends CopilotChatApi {
 }
 
 export async function registerRelatedFilesProvider(): Promise<void> {
-    const api = await getCopilotApi();
+    const api = await getCopilotClientApi();
     if (util.extensionContext && api) {
         try {
             for (const languageId of ['c', 'cpp', 'cuda-cpp']) {
@@ -132,7 +132,7 @@ async function getIncludes(uri: vscode.Uri, maxDepth: number): Promise<GetInclud
     return includes;
 }
 
-export async function getCopilotApi(): Promise<CopilotApi | undefined> {
+export async function getCopilotClientApi(): Promise<CopilotApi | undefined> {
     const copilotExtension = vscode.extensions.getExtension<CopilotApi>('github.copilot');
     if (!copilotExtension) {
         return undefined;
@@ -149,19 +149,30 @@ export async function getCopilotApi(): Promise<CopilotApi | undefined> {
     }
 }
 
-export async function getCopilotChatApi(): Promise<CopilotChatApi | undefined> {
+export async function getCopilotChatApi(): Promise<CopilotContextProviderAPI | undefined> {
+    type CopilotChatApi = { getAPI?(version: number): CopilotContextProviderAPI | undefined };
     const copilotExtension = vscode.extensions.getExtension<CopilotChatApi>('github.copilot-chat');
     if (!copilotExtension) {
         return undefined;
     }
 
+    let exports: CopilotChatApi | undefined;
     if (!copilotExtension.isActive) {
         try {
-            return await copilotExtension.activate();
+            exports = await copilotExtension.activate();
         } catch {
             return undefined;
         }
     } else {
-        return copilotExtension.exports;
+        exports = copilotExtension.exports;
     }
+    if (!exports || typeof exports.getAPI !== 'function') {
+        return undefined;
+    }
+    const result = exports.getAPI(1);
+    return result;
+}
+
+interface Disposable {
+    dispose(): void;
 }


### PR DESCRIPTION
We are in the process of moving Inline completions from Copilot client to Copilot chat. For a certain time we therefore need to register the context provider with both Copilot client and Copilot chat. Which path is exercised will be determined by VS Code. So for the same [document,position] pair only one resolve request will occurr.

Registering with Copilot Chat has also the advantage that context is resolved during NES. If you want to enable this you can use the setting `"github.copilot.chat.advanced.inlineEdits.xtabProvider.languageContext.enabled"`