### PR TITLE
Warn users about too many files processed in the workspace

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2772,7 +2772,7 @@ export class DefaultClient implements Client {
 
                 const message = localize(
                     "parsing.stats.large.project",
-                    'Enumerated {0} files with {1} source files detected. You may want to consider excluding some files for better performance.',
+                    'Enumerated {0} files with {1} C/C++ source files detected. You may want to consider excluding some files for better performance.',
                     filesDiscovered,
                     parsableFiles);
                 const learnMore = localize('learn.more', 'Learn More');
@@ -2780,7 +2780,7 @@ export class DefaultClient implements Client {
 
                 // We only want to show this once per session.
                 this.excessiveFilesWarningShown = true;
-                const response = await vscode.window.showWarningMessage(message, learnMore, dontShowAgain);
+                const response = await vscode.window.showInformationMessage(message, learnMore, dontShowAgain);
 
                 if (response === dontShowAgain) {
                     showExcessiveFilesWarning.Value = false;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2764,7 +2764,7 @@ export class DefaultClient implements Client {
         }
 
         const showExcessiveFilesWarning = new PersistentWorkspaceState<boolean>('CPP.showExcessiveFilesWarning', true);
-        if (!this.excessiveFilesWarningShown && notificationBody.event === 'ParsingStats' && showExcessiveFilesWarning.Value) {
+        if (!this.excessiveFilesWarningShown && showExcessiveFilesWarning.Value && notificationBody.event === 'ParsingStats') {
             const filesDiscovered = notificationBody.metrics?.filesDiscovered ?? 0;
             const parsableFiles = notificationBody.metrics?.parsableFiles ?? 0;
             if (filesDiscovered > 250000 || parsableFiles > 100000) {

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1723,7 +1723,7 @@ export class DefaultClient implements Client {
         languageClient = new LanguageClient(`cpptools`, serverOptions, clientOptions);
         languageClient.onNotification(DebugProtocolNotification, logDebugProtocol);
         languageClient.onNotification(DebugLogNotification, logLocalized);
-        languageClient.onNotification(LogTelemetryNotification, (e) => this.logTelemetry(e));
+        languageClient.onNotification(LogTelemetryNotification, (e) => void this.logTelemetry(e));
         languageClient.onNotification(ShowMessageWindowNotification, showMessageWindow);
         languageClient.registerProposedFeatures();
         await languageClient.start();
@@ -2757,9 +2757,37 @@ export class DefaultClient implements Client {
         }
     }
 
-    private logTelemetry(notificationBody: TelemetryPayload): void {
+    private excessiveFilesWarningShown: boolean = false;
+    private async logTelemetry(notificationBody: TelemetryPayload): Promise<void> {
         if (notificationBody.event === "includeSquiggles" && this.configurationProvider && notificationBody.properties) {
             notificationBody.properties["providerId"] = this.configurationProvider;
+        }
+
+        const showExcessiveFilesWarning = new PersistentWorkspaceState<boolean>('CPP.showExcessiveFilesWarning', true);
+        if (!this.excessiveFilesWarningShown && notificationBody.event === 'ParsingStats' && showExcessiveFilesWarning.Value) {
+            const filesDiscovered = notificationBody.metrics?.filesDiscovered ?? 0;
+            const parsableFiles = notificationBody.metrics?.parsableFiles ?? 0;
+            if (filesDiscovered > 250000 || parsableFiles > 100000) {
+                // According to telemetry, less than 3% of workspaces have this many files so it seems like a reasonable threshold.
+
+                const message = localize(
+                    "parsing.stats.large.project",
+                    'Enumerated {0} files with {1} source files detected. You may want to consider excluding some files for better performance.',
+                    filesDiscovered,
+                    parsableFiles);
+                const learnMore = localize('learn.more', 'Learn More');
+                const dontShowAgain = localize('dont.show.again', 'Don\'t Show Again');
+
+                // We only want to show this once per session.
+                this.excessiveFilesWarningShown = true;
+                const response = await vscode.window.showWarningMessage(message, learnMore, dontShowAgain);
+
+                if (response === dontShowAgain) {
+                    showExcessiveFilesWarning.Value = false;
+                } else if (response === learnMore) {
+                    void vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://go.microsoft.com/fwlink/?linkid=2333292'));
+                }
+            }
         }
         telemetry.logLanguageServerEvent(notificationBody.event, notificationBody.properties, notificationBody.metrics);
     }


### PR DESCRIPTION
Fixes: #10828

For consideration. Telemetry suggests that less than 3% of workspaces have more than 100,000 source files (with 250,000 total files).  That seems like a reasonable threshold, but we could raise it if we think that's too many customers to notify.

The notification can be disabled for the workspace. The "learn more" button links to a page I wrote in the Wiki about improving the configuration (which should also be reviewed).  https://github.com/microsoft/vscode-cpptools/wiki/Optimizing-your-configuration