### PR TITLE
Remove `/` from the message since it seems to cause it to be dropped.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1706,9 +1706,10 @@ export class DefaultClient implements Client {
 
                     // Wait 1 second to allow time for the file watcher to signal a crash call stack write has occurred.
                     setTimeout(() => {
+                        const sanitizedLspMessage = this.lastInvokedLspMessage.replace('/', '.');
                         telemetry.logLanguageServerEvent("languageClientCrash",
                             {
-                                lastInvokedLspMessage: this.lastInvokedLspMessage
+                                lastInvokedLspMessage: sanitizedLspMessage
                             },
                             {
                                 restarting: Number(restart),


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-cpptools/pull/13888