### PR TITLE
Fix hang due to config provider timeout

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2284,9 +2284,12 @@ export class DefaultClient implements Client {
                     message += ` (${err})`;
                 }
 
-                if (await vscode.window.showInformationMessage(message, dismiss, disable) === disable) {
-                    settings.toggleSetting("configurationWarnings", "enabled", "disabled");
-                }
+                // Do not await here, as that would prevent the function from returning until the user dismisses the message.
+                vscode.window.showInformationMessage(message, dismiss, disable).then(result => {
+                    if (result === disable) {
+                        settings.toggleSetting("configurationWarnings", "enabled", "disabled");
+                    }
+                });
             }
         }
         return result;

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2285,7 +2285,7 @@ export class DefaultClient implements Client {
                 }
 
                 // Do not await here, as that would prevent the function from returning until the user dismisses the message.
-                vscode.window.showInformationMessage(message, dismiss, disable).then(result => {
+                void vscode.window.showInformationMessage(message, dismiss, disable).then(result => {
                     if (result === disable) {
                         settings.toggleSetting("configurationWarnings", "enabled", "disabled");
                     }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-cpptools/issues/13862

The issue appears to be that the timeout causes a `vscode.window.showInformationMessage`, which was being awaiting.  If the user does not dismiss it, the function would not return and would fail to indicate that the custom configuration request is complete.

The fix is to not await it.