### PR TITLE
Wait maximum 3 seconds for the Copilot chat extension to activate.

### DIFF
--- a/Extension/src/LanguageServer/copilotProviders.ts
+++ b/Extension/src/LanguageServer/copilotProviders.ts
@@ -159,7 +159,14 @@ export async function getCopilotChatApi(): Promise<CopilotContextProviderAPI | u
     let exports: CopilotChatApi | undefined;
     if (!copilotExtension.isActive) {
         try {
-            exports = await copilotExtension.activate();
+            exports = await Promise.race([
+                copilotExtension.activate(),
+                new Promise<undefined>(resolve => {
+                    setTimeout(() => {
+                        resolve(undefined);
+                    }, 3000);
+                })
+            ]);
         } catch {
             return undefined;
         }


### PR DESCRIPTION
To avoid that the CPP extension doesn't activate wait a maximum of 3 seconds for their activation. After the timeout no context provider will be registered with the Copilot Chat extension.