### PR TITLE
Remove some redundant code related to `revealIfOpen` setting

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -478,21 +478,7 @@ async function onSwitchHeaderSource(): Promise<void> {
         }
     });
     const document: vscode.TextDocument = await vscode.workspace.openTextDocument(targetFileName);
-    const workbenchConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("workbench");
-    let foundEditor: boolean = false;
-    if (workbenchConfig.get("editor.revealIfOpen")) {
-        // If the document is already visible in another column, open it there.
-        vscode.window.visibleTextEditors.forEach(editor => {
-            if (editor.document === document && !foundEditor) {
-                foundEditor = true;
-                void vscode.window.showTextDocument(document, editor.viewColumn).then(undefined, logAndReturn.undefined);
-            }
-        });
-    }
-
-    if (!foundEditor) {
-        void vscode.window.showTextDocument(document).then(undefined, logAndReturn.undefined);
-    }
+    void vscode.window.showTextDocument(document).then(undefined, logAndReturn.undefined);
 }
 
 /**


### PR DESCRIPTION
Originally, the code involved was attempting to reveal the document if already open in another tab group (which is not the default behavior of VS Code), as that seemed more correct.  A user then contributed a change to cause it to properly adhere to the `revealIfOpen` setting: https://github.com/microsoft/vscode-cpptools/pull/8857/files

However, `showTextDocument` will honor the `revealIfOpen` setting by default, making a lot of that code unnecessary.  This change removes unnecessary code and does not change the current behavior.

Related:
https://github.com/microsoft/vscode-cpptools/discussions/13867
https://github.com/microsoft/vscode/issues/263012
