### PR TITLE
pre-release check crashes when response is not properly formed.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1383,7 +1383,7 @@ export async function preReleaseCheck(): Promise<void> {
 
         const data: any = await response?.json().catch(logAndReturn.undefined);
 
-        const preReleaseAvailable = data?.results[0]?.extensions[0]?.versions[0]?.properties?.some((e: object) => Object.values(e).includes("Microsoft.VisualStudio.Code.PreRelease"));
+        const preReleaseAvailable = data?.results?.[0]?.extensions?.[0]?.versions?.[0]?.properties?.some((e: object) => Object.values(e).includes("Microsoft.VisualStudio.Code.PreRelease"));
 
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1383,7 +1383,7 @@ export async function preReleaseCheck(): Promise<void> {
 
         const data: any = await response?.json().catch(logAndReturn.undefined);
 
-        const preReleaseAvailable = data?.results[0].extensions[0].versions[0].properties.some((e: object) => Object.values(e).includes("Microsoft.VisualStudio.Code.PreRelease"));
+        const preReleaseAvailable = data?.results[0]?.extensions[0]?.versions[0]?.properties?.some((e: object) => Object.values(e).includes("Microsoft.VisualStudio.Code.PreRelease"));
 
         // If the user isn't on the pre-release version, but one is available, prompt them to install it.
         if (preReleaseAvailable) {


### PR DESCRIPTION
Fixes: #13953

The pre-release check assumes that if we get a json response it will be properly formatted. Fixing it to deal with missing data.