### PR TITLE
Enable signing for Themes and ExtensionPack

### DIFF
--- a/Build/package/jobs_package_vsix.yml
+++ b/Build/package/jobs_package_vsix.yml
@@ -5,6 +5,9 @@ parameters:
 - name: srcDir
   type: string
   default: ''
+- name: signType
+  type: string
+  default: 'real'
 
 jobs:
 - job: package
@@ -12,6 +15,15 @@ jobs:
   timeoutInMinutes: 30
   cancelTimeoutInMinutes: 1
   templateContext:
+    mb: # Enable the MicroBuild Signing toolset
+      signing:
+        enabled: true
+        signType: ${{ parameters.signType }}
+        zipSources: false
+        ${{ if eq(parameters.signType, 'real') }}:
+          signWithProd: true
+    featureFlags:
+      autoBaseline: false
     outputs:
     - output: pipelineArtifact
       displayName: '${{ parameters.vsixName }}'

--- a/Extension/.vscodeignore
+++ b/Extension/.vscodeignore
@@ -29,25 +29,25 @@ jobs/**
 cgmanifest.json
 
 # ignore development files
-tsconfig.json
-test.tsconfig.json
-ui.tsconfig.json
-tslint.json
+.eslintignore
 .eslintrc.js
-webpack.config.js
-tscCompileList.txt
-gulpfile.js
 .gitattributes
 .gitignore
+gulpfile.js
+localized_string_ids.h
+readme.developer.md
+Reinstalling the Extension.md
+test.tsconfig.json
+translations_auto_pr.js
+tsconfig.json
+tslint.json
+tscCompileList.txt
+ui.tsconfig.json
+webpack.config.js
 CMakeLists.txt
 debugAdapters/install.lock*
 typings/**
 **/*.map
-import_edge_strings.js
-localized_string_ids.h
-translations_auto_pr.js
-readme.developer.md
-Reinstalling the Extension.md
 *.d.ts
 
 # ignore i18n language files

--- a/ExtensionPack/CHANGELOG.md
+++ b/ExtensionPack/CHANGELOG.md
@@ -1,7 +1,0 @@
-# C/C++ Extension Pack for Visual Studio Code Change Log
-
-## Version 1.3.0
-### List of extensions:
-* C/C++
-* C/C++ Themes
-* CMake Tools

--- a/ExtensionPack/package-lock.json
+++ b/ExtensionPack/package-lock.json
@@ -1,0 +1,16 @@
+{
+    "name": "cpptools-extension-pack",
+    "version": "1.4.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "cpptools-extension-pack",
+            "version": "1.4.0",
+            "license": "SEE LICENSE IN LICENSE.txt",
+            "engines": {
+                "vscode": "^1.48.0"
+            }
+        }
+    }
+}

--- a/ExtensionPack/package.json
+++ b/ExtensionPack/package.json
@@ -9,7 +9,7 @@
       "name": "Microsoft Corporation"
     },
     "license": "SEE LICENSE IN LICENSE.txt",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "engines": {
         "vscode": "^1.48.0"
     },

--- a/Themes/.gitignore
+++ b/Themes/.gitignore
@@ -1,1 +1,0 @@
-package-lock.json

--- a/Themes/package-lock.json
+++ b/Themes/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "cpptools-themes",
+  "version": "2.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cpptools-themes",
+      "version": "2.1.0",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "engines": {
+        "vscode": "^1.30.0"
+      }
+    }
+  }
+}

--- a/Themes/package.json
+++ b/Themes/package.json
@@ -2,7 +2,7 @@
   "name": "cpptools-themes",
   "displayName": "C/C++ Themes",
   "description": "UI Themes for C/C++ extension.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "publisher": "ms-vscode",
   "preview": false,
   "icon": "assets/LanguageCCPP_color_128x.png",


### PR DESCRIPTION
I don't believe we rebuilt these other extensions after enabling signing on the main extension.