### PR TITLE
Add telemetry to check for potential cases of blocked activation.

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1391,6 +1391,7 @@ export class DefaultClient implements Client {
                 }
 
                 this.copilotCompletionProvider = CopilotCompletionContextProvider.Create();
+                util.setProgress(util.getProgressCopilotSuccess());
                 this.disposables.push(this.copilotCompletionProvider);
 
                 // Listen for messages from the language server.

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -247,19 +247,22 @@ export function displayExtensionNotReadyPrompt(): void {
 // Users start with a progress of 0 and it increases as they get further along in using the tool.
 // This eliminates noise/problems due to re-installs, terminated installs that don't send errors,
 // errors followed by workarounds that lead to success, etc.
-const progressInstallSuccess: number = 100;
+const progressDebuggerStarted: number = 50;
+const progressDebuggerSuccess: number = 100;
 const progressExecutableStarted: number = 150;
+const progressCopilotSuccess: number = 180;
 const progressExecutableSuccess: number = 200;
 const progressParseRootSuccess: number = 300;
+const progressLanguageServiceDisabled: number = 400;
 const progressIntelliSenseNoSquiggles: number = 1000;
 // Might add more IntelliSense progress measurements later.
-// IntelliSense progress is separate from the install progress, because parse root can occur afterwards.
+// IntelliSense progress is separate from the activation progress, because parse root can occur afterwards.
 
-const installProgressStr: string = "CPP." + packageJson.version + ".Progress";
+const activationProgressStr: string = "CPP." + packageJson.version + ".Progress";
 const intelliSenseProgressStr: string = "CPP." + packageJson.version + ".IntelliSenseProgress";
 
 export function getProgress(): number {
-    return extensionContext ? extensionContext.globalState.get<number>(installProgressStr, -1) : -1;
+    return extensionContext ? extensionContext.globalState.get<number>(activationProgressStr, -1) : -1;
 }
 
 export function getIntelliSenseProgress(): number {
@@ -268,15 +271,18 @@ export function getIntelliSenseProgress(): number {
 
 export function setProgress(progress: number): void {
     if (extensionContext && getProgress() < progress) {
-        void extensionContext.globalState.update(installProgressStr, progress);
+        void extensionContext.globalState.update(activationProgressStr, progress);
         const telemetryProperties: Record<string, string> = {};
         let progressName: string | undefined;
         switch (progress) {
-            case 0: progressName = "install started"; break;
-            case progressInstallSuccess: progressName = "install succeeded"; break;
+            case 0: progressName = "activation started"; break;
+            case progressDebuggerStarted: progressName = "debugger started"; break;
+            case progressDebuggerSuccess: progressName = "debugger succeeded"; break;
             case progressExecutableStarted: progressName = "executable started"; break;
+            case progressCopilotSuccess: progressName = "copilot succeeded"; break;
             case progressExecutableSuccess: progressName = "executable succeeded"; break;
             case progressParseRootSuccess: progressName = "parse root succeeded"; break;
+            case progressLanguageServiceDisabled: progressName = "language service disabled"; break;
         }
         if (progressName) {
             telemetryProperties.progress = progressName;
@@ -300,10 +306,13 @@ export function setIntelliSenseProgress(progress: number): void {
     }
 }
 
-export function getProgressInstallSuccess(): number { return progressInstallSuccess; } // Download/install was successful (i.e. not blocked by component acquisition).
+export function getProgressDebuggerStarted(): number { return progressDebuggerStarted; } // Debugger was successfully initialized.
+export function getProgressDebuggerSuccess(): number { return progressDebuggerSuccess; } // Debugger was successfully initialized.
 export function getProgressExecutableStarted(): number { return progressExecutableStarted; } // The extension was activated and starting the executable was attempted.
+export function getProgressCopilotSuccess(): number { return progressCopilotSuccess; } // Copilot activation was successful.
 export function getProgressExecutableSuccess(): number { return progressExecutableSuccess; } // Starting the exe was successful (i.e. not blocked by 32-bit or glibc < 2.18 on Linux)
 export function getProgressParseRootSuccess(): number { return progressParseRootSuccess; } // Parse root was successful (i.e. not blocked by processing taking too long).
+export function getProgressLanguageServiceDisabled(): number { return progressLanguageServiceDisabled; } // The user disabled the language service.
 export function getProgressIntelliSenseNoSquiggles(): number { return progressIntelliSenseNoSquiggles; } // IntelliSense was successful and the user got no squiggles.
 
 export function isUri(input: any): input is vscode.Uri {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -306,7 +306,7 @@ export function setIntelliSenseProgress(progress: number): void {
     }
 }
 
-export function getProgressDebuggerStarted(): number { return progressDebuggerStarted; } // Debugger was successfully initialized.
+export function getProgressDebuggerStarted(): number { return progressDebuggerStarted; } // Debugger initialization was started.
 export function getProgressDebuggerSuccess(): number { return progressDebuggerSuccess; } // Debugger was successfully initialized.
 export function getProgressExecutableStarted(): number { return progressExecutableStarted; } // The extension was activated and starting the executable was attempted.
 export function getProgressCopilotSuccess(): number { return progressCopilotSuccess; } // Copilot activation was successful.

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -42,8 +42,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     });
 
     util.setExtensionContext(context);
-    Telemetry.activate();
     util.setProgress(0);
+    Telemetry.activate();
 
     // Register a protocol handler to serve localized versions of the schema for c_cpp_properties.json
     class SchemaProvider implements vscode.TextDocumentContentProvider {
@@ -63,7 +63,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
     vscode.workspace.registerTextDocumentContentProvider('cpptools-schema', instrument(new SchemaProvider()));
 
     // Initialize the DebuggerExtension and register the related commands and providers.
+    util.setProgress(util.getProgressDebuggerStarted());
     await DebuggerExtension.initialize(context);
+    util.setProgress(util.getProgressDebuggerSuccess());
 
     const info: PlatformInformation = await PlatformInformation.GetPlatformInformation();
     sendTelemetry(info);
@@ -161,6 +163,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CppToo
         // The check here for isIntelliSenseEngineDisabled avoids logging
         // the message on old Macs that we've already displayed a warning for.
         log(localize("intellisense.disabled", "intelliSenseEngine is disabled"));
+        util.setProgress(util.getProgressLanguageServiceDisabled());
     }
 
     // Send an instrumentation message upon completing activation.


### PR DESCRIPTION
The progressDebuggerSuccess won't be reported if it's stuck on the SSH processing: https://github.com/microsoft/vscode-cpptools/issues/13966 .

FYI, this telemetry only tracks if a user is completely blocked and never becomes unblocked since the status is saved to persistent state. So it wouldn't catch cases where users are temporarily blocked or only blocked in certain scenarios.