### PR TITLE
Fix typo "no_suitable_complier" in nativeStrings.json

### DIFF
--- a/Extension/i18n/chs/src/nativeStrings.i18n.json
+++ b/Extension/i18n/chs/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "正在终止根位置的标记分析",
 	"unable_to_retrieve_to_reset_timestamps": "无法检索数据库记录以重置时间戳: 错误 = {0}",
 	"failed_to_reset_timestamps_for": "未能为 {0} 重置时间戳: 错误 = {1}",
-	"no_suitable_complier": "未找到合适的编译器。请在 c_cpp_properties.json 中设置 \"compilerPath\"。",
+	"no_suitable_compiler": "未找到合适的编译器。请在 c_cpp_properties.json 中设置 \"compilerPath\"。",
 	"compiler_include_not_found": "未找到编译器包含路径: {0}",
 	"intellisense_not_responding": "IntelliSense 引擎未响应。改为使用标记分析器。",
 	"tag_parser_will_be_used": "标记分析器将用于以下项中的 IntelliSense 操作: {0}",

--- a/Extension/i18n/cht/src/nativeStrings.i18n.json
+++ b/Extension/i18n/cht/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "正在中止根目錄處的標籤剖析",
 	"unable_to_retrieve_to_reset_timestamps": "無法取得 DB 記錄以重設時間戳記: 錯誤 = {0}",
 	"failed_to_reset_timestamps_for": "無法重設 {0} 的時間戳記: 錯誤 = {1}",
-	"no_suitable_complier": "找不到任何適合的編譯器。請設定 c_cpp_properties.json 中的 \"compilerPath\"。",
+	"no_suitable_compiler": "找不到任何適合的編譯器。請設定 c_cpp_properties.json 中的 \"compilerPath\"。",
 	"compiler_include_not_found": "找不到編譯器包含路徑: {0}",
 	"intellisense_not_responding": "IntelliSense 引擎未回應。改為使用標籤剖析器。",
 	"tag_parser_will_be_used": "標籤剖析器將用於 {0} 中的 IntelliSense 作業",

--- a/Extension/i18n/csy/src/nativeStrings.i18n.json
+++ b/Extension/i18n/csy/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Parsování značek v kořenu se přerušuje.",
 	"unable_to_retrieve_to_reset_timestamps": "Nepovedlo se načíst záznamy databáze pro resetování časových razítek: chyba = {0}",
 	"failed_to_reset_timestamps_for": "Nepovedlo se resetovat časové razítko pro {0}: chyba = {1}",
-	"no_suitable_complier": "Nenašel se žádný vhodný kompilátor. Nastavte prosím compilerPath v souboru c_cpp_properties.json.",
+	"no_suitable_compiler": "Nenašel se žádný vhodný kompilátor. Nastavte prosím compilerPath v souboru c_cpp_properties.json.",
 	"compiler_include_not_found": "Nenašla se cesta kompilátoru pro vložené soubory: {0}",
 	"intellisense_not_responding": "Modul IntelliSense neodpovídá. Používá se místo něj analyzátor značek.",
 	"tag_parser_will_be_used": "Analyzátor značek se bude používat pro operace IntelliSense v: {0}",

--- a/Extension/i18n/deu/src/nativeStrings.i18n.json
+++ b/Extension/i18n/deu/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Die Taganalyse wird am Stamm abgebrochen.",
 	"unable_to_retrieve_to_reset_timestamps": "Datenbankdatensätze können nicht abgerufen werden, um Zeitstempel zurückzusetzen: Fehler = {0}",
 	"failed_to_reset_timestamps_for": "Fehler beim Zurücksetzen des Zeitstempels für \"{0}\": Fehler = {1}",
-	"no_suitable_complier": "Es wurde kein geeigneter Compiler gefunden. Legen Sie \"compilerPath\" in \"c_cpp_properties.json\" fest.",
+	"no_suitable_compiler": "Es wurde kein geeigneter Compiler gefunden. Legen Sie \"compilerPath\" in \"c_cpp_properties.json\" fest.",
 	"compiler_include_not_found": "Compilerincludepfad nicht gefunden: {0}",
 	"intellisense_not_responding": "Die IntelliSense-Engine reagiert nicht. Stattdessen wird der Tagparser verwendet.",
 	"tag_parser_will_be_used": "Der Tagparser wird für IntelliSense-Vorgänge in \"{0}\" verwendet.",

--- a/Extension/i18n/esn/src/nativeStrings.i18n.json
+++ b/Extension/i18n/esn/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Anulando el análisis de etiquetas en el directorio raíz",
 	"unable_to_retrieve_to_reset_timestamps": "No se pueden recuperar los registros de la base de datos para restablecer las marcas de tiempo. Error = {0}",
 	"failed_to_reset_timestamps_for": "No se pudo restablecer la marca de tiempo de {0}. Error = {1}",
-	"no_suitable_complier": "No se encontró ningún compilador adecuado. Establezca \"compilerPath\" en c_cpp_properties.json.",
+	"no_suitable_compiler": "No se encontró ningún compilador adecuado. Establezca \"compilerPath\" en c_cpp_properties.json.",
 	"compiler_include_not_found": "No se encontró la ruta de acceso de inclusión del compilador: {0}",
 	"intellisense_not_responding": "El motor de IntelliSense no responde. Se usará el analizador de etiquetas en su lugar.",
 	"tag_parser_will_be_used": "Se usará el analizador de etiquetas para las operaciones de IntelliSense en {0}",

--- a/Extension/i18n/fra/src/nativeStrings.i18n.json
+++ b/Extension/i18n/fra/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Annulation de l'analyse des balises à la racine",
 	"unable_to_retrieve_to_reset_timestamps": "Impossible de récupérer les enregistrements de base de données pour réinitialiser les horodatages : erreur = {0}",
 	"failed_to_reset_timestamps_for": "La réinitialisation de l'horodatage a échoué pour {0} : erreur = {1}",
-	"no_suitable_complier": "Aucun compilateur approprié. Définissez \"compilerPath\" dans c_cpp_properties.json.",
+	"no_suitable_compiler": "Aucun compilateur approprié. Définissez \"compilerPath\" dans c_cpp_properties.json.",
 	"compiler_include_not_found": "Le chemin d'inclusion du compilateur est introuvable : {0}",
 	"intellisense_not_responding": "Le moteur IntelliSense ne répond pas. Utilisation de l'analyseur de balises à la place.",
 	"tag_parser_will_be_used": "L'analyseur de balises est utilisé pour les opérations IntelliSense dans {0}",

--- a/Extension/i18n/ita/src/nativeStrings.i18n.json
+++ b/Extension/i18n/ita/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Interruzione dell'analisi dei tag in corrispondenza della radice",
 	"unable_to_retrieve_to_reset_timestamps": "Non è possibile recuperare i record del database per reimpostare i timestamp. Errore = {0}",
 	"failed_to_reset_timestamps_for": "Non è stato possibile reimpostare il timestamp per {0}. Errore = {1}",
-	"no_suitable_complier": "Non sono stati trovati compilatore appropriati. Impostare \"compilerPath\" in c_cpp_properties.json.",
+	"no_suitable_compiler": "Non sono stati trovati compilatore appropriati. Impostare \"compilerPath\" in c_cpp_properties.json.",
 	"compiler_include_not_found": "Il percorso di inclusione del compilatore non è stato trovato: {0}",
 	"intellisense_not_responding": "Il motore IntelliSense non risponde. Verrà usato il parser di tag.",
 	"tag_parser_will_be_used": "Il parser di tag verrà usato per le operazioni IntelliSense in: {0}",

--- a/Extension/i18n/jpn/src/nativeStrings.i18n.json
+++ b/Extension/i18n/jpn/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "ルートでのタグ解析を中止しています",
 	"unable_to_retrieve_to_reset_timestamps": "タイムスタンプをリセットするための DB レコードを取得できません。エラー = {0}",
 	"failed_to_reset_timestamps_for": "{0} のタイムスタンプをリセットできませんでした: エラー = {1}",
-	"no_suitable_complier": "適切なコンパイラが見つかりませんでした。c_cpp_properties.json の \"compilerPath\" を設定してください。",
+	"no_suitable_compiler": "適切なコンパイラが見つかりませんでした。c_cpp_properties.json の \"compilerPath\" を設定してください。",
 	"compiler_include_not_found": "コンパイラのインクルード パスが見つかりませんでした: {0}",
 	"intellisense_not_responding": "IntelliSense エンジンが応答していません。代わりにタグ パーサーを使用します。",
 	"tag_parser_will_be_used": "タグ パーサーは {0} で IntelliSense 操作に使用されます",

--- a/Extension/i18n/kor/src/nativeStrings.i18n.json
+++ b/Extension/i18n/kor/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "루트에서 태그 구문 분석을 중단합니다.",
 	"unable_to_retrieve_to_reset_timestamps": "타임스탬프를 다시 설정할 DB 레코드를 검색할 수 없습니다. 오류 = {0}",
 	"failed_to_reset_timestamps_for": "{0} 에 대한 타임스탬프를 다시 설정하지 못했습니다. 오류 = {1}",
-	"no_suitable_complier": "적합한 컴파일러를 찾을 수 없습니다. c_cpp_properties.json에서 \"compilerPath\"를 설정하세요.",
+	"no_suitable_compiler": "적합한 컴파일러를 찾을 수 없습니다. c_cpp_properties.json에서 \"compilerPath\"를 설정하세요.",
 	"compiler_include_not_found": "컴파일러 포함 경로를 찾을 수 없음: {0}",
 	"intellisense_not_responding": "IntelliSense 엔진이 응답하지 않습니다. 태그 파서를 대신 사용합니다.",
 	"tag_parser_will_be_used": "태그 파서가 다음의 IntelliSense 작업에서 사용됨: {0}",

--- a/Extension/i18n/plk/src/nativeStrings.i18n.json
+++ b/Extension/i18n/plk/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Przerywanie analizowania tagów w elemencie głównym",
 	"unable_to_retrieve_to_reset_timestamps": "Nie można pobrać rekordów bazy danych w celu zresetowania znaczników czasu: błąd = {0}",
 	"failed_to_reset_timestamps_for": "Nie można zresetować znacznika czasu dla elementu {0}: błąd = {1}",
-	"no_suitable_complier": "Nie znaleziono odpowiedniego kompilatora. Ustaw element „compilerPath” w pliku c_cpp_properties.json.",
+	"no_suitable_compiler": "Nie znaleziono odpowiedniego kompilatora. Ustaw element „compilerPath” w pliku c_cpp_properties.json.",
 	"compiler_include_not_found": "Nie znaleziono ścieżki dołączania kompilatora: {0}",
 	"intellisense_not_responding": "Aparat funkcji IntelliSense nie odpowiada. W zamian użyj analizatora tagów.",
 	"tag_parser_will_be_used": "Analizator tagów będzie używany na potrzeby operacji funkcji IntelliSense w: {0}",

--- a/Extension/i18n/ptb/src/nativeStrings.i18n.json
+++ b/Extension/i18n/ptb/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Anulando análise de marca na raiz",
 	"unable_to_retrieve_to_reset_timestamps": "Não é possível recuperar os registros do BD para redefinir os carimbos de data/hora: erro = {0}",
 	"failed_to_reset_timestamps_for": "Falha ao redefinir o carimbo de data/hora para {0}: erro = {1}",
-	"no_suitable_complier": "Nenhum compilador adequado encontrado. Defina \"compilerPath\" em c_cpp_properties.json.",
+	"no_suitable_compiler": "Nenhum compilador adequado encontrado. Defina \"compilerPath\" em c_cpp_properties.json.",
 	"compiler_include_not_found": "O compilador inclui o caminho não encontrado: {0}",
 	"intellisense_not_responding": "O mecanismo IntelliSense não está respondendo. Usando o Analisador de Marca em seu lugar.",
 	"tag_parser_will_be_used": "O Analisador de Marca será usado para operações do IntelliSense em: {0}",

--- a/Extension/i18n/rus/src/nativeStrings.i18n.json
+++ b/Extension/i18n/rus/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Прерывание анализа тегов в корне",
 	"unable_to_retrieve_to_reset_timestamps": "Не удалось получить записи базы данных для сброса меток времени: ошибка — {0}",
 	"failed_to_reset_timestamps_for": "Не удалось сбросить метку времени для {0}: ошибка — {1}",
-	"no_suitable_complier": "Подходящий компилятор не найден. Укажите \"compilerPath\" в c_cpp_properties.json.",
+	"no_suitable_compiler": "Подходящий компилятор не найден. Укажите \"compilerPath\" в c_cpp_properties.json.",
 	"compiler_include_not_found": "Путь включения компилятора не найден: {0}",
 	"intellisense_not_responding": "Подсистема IntelliSense не отвечает. Используйте вместо этого анализатор тегов.",
 	"tag_parser_will_be_used": "Анализатор тегов будет использоваться для операций IntelliSense в: {0}",

--- a/Extension/i18n/trk/src/nativeStrings.i18n.json
+++ b/Extension/i18n/trk/src/nativeStrings.i18n.json
@@ -46,7 +46,7 @@
 	"aborting_tag_parse_at_root": "Kökte etiket ayrıştırma durduruluyor",
 	"unable_to_retrieve_to_reset_timestamps": "Zaman damgalarını sıfırlamak için veritabanı kayıtları alınamıyor: hata = {0}",
 	"failed_to_reset_timestamps_for": "{0} için zaman damgası sıfırlanamadı: hata = {1}",
-	"no_suitable_complier": "Uygun derleyici bulunamadı. Lütfen c_cpp_properties.json dosyasında \"compilerPath\" öğesini ayarlayın.",
+	"no_suitable_compiler": "Uygun derleyici bulunamadı. Lütfen c_cpp_properties.json dosyasında \"compilerPath\" öğesini ayarlayın.",
 	"compiler_include_not_found": "Derleyici ekleme yolu bulunamadı: {0}",
 	"intellisense_not_responding": "IntelliSense altyapısı yanıt vermiyor. Bunun yerine Etiket Ayrıştırıcısı kullanılıyor.",
 	"tag_parser_will_be_used": "Etiket Ayrıştırıcısı, şurada IntelliSense işlemleri için kullanılacak: {0}",

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -44,7 +44,7 @@
     "aborting_tag_parse_at_root": "Aborting tag parse at root",
     "unable_to_retrieve_to_reset_timestamps": "Unable to retrieve DB records to reset timestamps: error = {0}",
     "failed_to_reset_timestamps_for": "Failed to reset timestamp for {0}: error = {1}",
-    "no_suitable_complier": "No suitable compiler found. Please set the \"compilerPath\" in c_cpp_properties.json.",
+    "no_suitable_compiler": "No suitable compiler found. Please set the \"compilerPath\" in c_cpp_properties.json.",
     "compiler_include_not_found": "Compiler include path not found: {0}",
     "intellisense_not_responding": "IntelliSense engine is not responding. Using the Tag Parser instead.",
     "tag_parser_will_be_used": "Tag Parser will be used for IntelliSense operations in: {0}",


### PR DESCRIPTION
- Rename `no_suitable_complier` to `no_suitable_compiler` in [Extension/src/nativeStrings.json]
- Update all referencing i18n files to match the new key.
- This change ensures the generated C++ header and TypeScript code will use the correct spelling.