### PR TITLE
Fix custom comment continuation for multiple follow-up lines

### DIFF
--- a/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
@@ -94,7 +94,7 @@ suite("multiline comment setting tests", function(): void {
     });
 
     test("Check the OnEnterRules for C++ with an additional option", () => {
-        const rules = getLanguageConfigFromPatterns('cpp', ["/**", "/*!"]).onEnterRules;
+        const rules = getLanguageConfigFromPatterns('cpp', [ "/**", "/*!" ]).onEnterRules;
         assert.deepStrictEqual(rules, multipleMLRules);
     });
 
@@ -200,7 +200,7 @@ suite("extensibility tests v3", function(): void {
             configurations: [ {name: "test3", configurationProvider: provider.extensionId} ],
             version: 4
         },
-            disposables);
+        disposables);
     });
 
     suiteTeardown(function(): void {
@@ -296,7 +296,7 @@ suite("extensibility tests v2", function(): void {
             configurations: [ {name: "test2", configurationProvider: provider.extensionId} ],
             version: 4
         },
-            disposables);
+        disposables);
     });
 
     suiteTeardown(function(): void {
@@ -378,7 +378,7 @@ suite("extensibility tests v1", function(): void {
             configurations: [ {name: "test1", configurationProvider: provider.extensionId} ],
             version: 4
         },
-            disposables);
+        disposables);
     });
 
     suiteTeardown(function(): void {
@@ -454,7 +454,7 @@ suite("extensibility tests v0", function(): void {
             configurations: [ { name: "test0", configurationProvider: provider.name } ],
             version: 4
         },
-            disposables);
+        disposables);
     });
 
     suiteTeardown(async function(): Promise<void> {

--- a/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
@@ -45,6 +45,27 @@ suite("multiline comment setting tests", function(): void {
             action: { indentAction: vscode.IndentAction.None, removeText: 1 }
         }
     ];
+    const multipleMLRules: vscode.OnEnterRule[] = [
+        defaultMLRules[0], // e.g. /** | */
+        defaultMLRules[1], // e.g. /** ...|
+        { // e.g. /*! | */
+            beforeText: /^\s*\/\*\!(?!\/)([^\*]|\*(?!\/))*$/,
+            afterText: /^\s*\*\/$/,
+            action: { indentAction: vscode.IndentAction.IndentOutdent, appendText: ' * ' }
+        },
+        { // e.g. /*! ...|
+            beforeText: /^\s*\/\*\!(?!\/)([^\*]|\*(?!\/))*$/,
+            action: { indentAction: vscode.IndentAction.None, appendText: ' * ' }
+        },
+        defaultMLRules[2], // e.g.  * ...|
+        { // e.g.  * ...|
+            beforeText: /^(\t|[ ])*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+            previousLineText: /(?=^(\s*(\/\*\!|\*)).*)(?=(?!(\s*\*\/)))/,
+            action: { indentAction: vscode.IndentAction.None, appendText: '* ' }
+        },
+        defaultMLRules[3], // e.g.  */|
+        defaultMLRules[4] // e.g.  *-----*/|
+    ];
     const defaultSLRules: vscode.OnEnterRule[] = [
         {
             beforeText: /^\s*\/\/\/.+$/,
@@ -70,6 +91,11 @@ suite("multiline comment setting tests", function(): void {
     test("Check the default OnEnterRules for C++", () => {
         const rules = getLanguageConfigFromPatterns('cpp', [ "/**" ]).onEnterRules;
         assert.deepStrictEqual(rules, defaultMLRules);
+    });
+
+    test("Check the OnEnterRules for C++ with an additional option", () => {
+        const rules = getLanguageConfigFromPatterns('cpp', ["/**", "/*!"]).onEnterRules;
+        assert.deepStrictEqual(rules, multipleMLRules);
     });
 
     test("Make sure duplicate rules are removed", () => {
@@ -174,7 +200,7 @@ suite("extensibility tests v3", function(): void {
             configurations: [ {name: "test3", configurationProvider: provider.extensionId} ],
             version: 4
         },
-        disposables);
+            disposables);
     });
 
     suiteTeardown(function(): void {
@@ -270,7 +296,7 @@ suite("extensibility tests v2", function(): void {
             configurations: [ {name: "test2", configurationProvider: provider.extensionId} ],
             version: 4
         },
-        disposables);
+            disposables);
     });
 
     suiteTeardown(function(): void {
@@ -352,7 +378,7 @@ suite("extensibility tests v1", function(): void {
             configurations: [ {name: "test1", configurationProvider: provider.extensionId} ],
             version: 4
         },
-        disposables);
+            disposables);
     });
 
     suiteTeardown(function(): void {
@@ -428,7 +454,7 @@ suite("extensibility tests v0", function(): void {
             configurations: [ { name: "test0", configurationProvider: provider.name } ],
             version: 4
         },
-        disposables);
+            disposables);
     });
 
     suiteTeardown(async function(): Promise<void> {


### PR DESCRIPTION
Fixes: #8998

Cherry-picks the original change from the release branch. It should have gone to main first.
Also adds a unit test.