### PR TITLE
Fix commentContinuationPatterns if they're a prefix of a later one.

### DIFF
--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -386,6 +386,13 @@ export class CppSettings extends Settings {
     public get commentContinuationPatterns(): (string | CommentPattern)[] {
         const value: any = super.Section.get<any>("commentContinuationPatterns");
         if (this.isArrayOfCommentContinuationPatterns(value)) {
+            // Needs to be sorted with longer patterns first so it takes precedence and
+            // doesn't apply the shorter pattern if it's a prefix (e.g. // matching ///).
+            value.sort((a: string | CommentPattern, b: string | CommentPattern) => {
+                const aStr: string = (isString(a)) ? a : a.begin;
+                const bStr: string = (isString(b)) ? b : b.begin;
+                return bStr.length - aStr.length;
+            });
             return value;
         }
         const setting = getRawSetting("C_Cpp.commentContinuationPatterns", true);

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -389,8 +389,8 @@ export class CppSettings extends Settings {
             // Needs to be sorted with longer patterns first so it takes precedence and
             // doesn't apply the shorter pattern if it's a prefix (e.g. // matching ///).
             value.sort((a: string | CommentPattern, b: string | CommentPattern) => {
-                const aStr: string = (isString(a)) ? a : a.begin;
-                const bStr: string = (isString(b)) ? b : b.begin;
+                const aStr: string = isString(a) ? a : a.begin;
+                const bStr: string = isString(b) ? b : b.begin;
                 return bStr.length - aStr.length;
             });
             return value;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-cpptools/issues/14081