### PR TITLE
Don't require NETFXSDKDir for msvc environment test

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1551,7 +1551,6 @@ export function hasMsvcEnvironment(): boolean {
         'INCLUDE',
         'LIB',
         'LIBPATH',
-        'NETFXSDKDir',
         'UCRTVersion',
         'UniversalCRTSdkDir',
         'VCIDEInstallDir',


### PR DESCRIPTION
Fixes: #14084