### PR TITLE
Fix Copilot hover model selection

### DIFF
--- a/Extension/src/constants.ts
+++ b/Extension/src/constants.ts
@@ -15,4 +15,4 @@ export const isLinux = OperatingSystem === 'linux';
 export const verboseEnabled = false;
 
 // Model selector for Copilot features
-export const modelSelector = { vendor: 'copilot', family: 'gpt-4' };
+export const modelSelector = { vendor: 'copilot' };


### PR DESCRIPTION
GPT-4 is no longer supported by the underlying API. To avoid issues like this in the future, I removed the exact model restriction, so we'll instead take the first "Copilot" model offered by the API.

Fixes https://github.com/microsoft/vscode/issues/284337