### PR TITLE
Fix/symbol search scope

### DIFF
--- a/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
+++ b/Extension/src/LanguageServer/Providers/workspaceSymbolProvider.ts
@@ -22,7 +22,8 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
         }
 
         const params: WorkspaceSymbolParams = {
-            query: query
+            query: query,
+            experimentEnabled: true
         };
 
         let symbols: LocalizeSymbolInformation[];

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -311,6 +311,7 @@ export interface GetDocumentSymbolRequestParams {
 
 export interface WorkspaceSymbolParams extends WorkspaceFolderParams {
     query: string;
+    experimentEnabled?: boolean;
 }
 
 export enum SymbolScope {


### PR DESCRIPTION
Workspace symbol search with scope::variable (e.g., std::vector) fails after Typing . This regression occurred when the experimentEnabled flag was removed, causing the language server to revert to a legacy path that handles scoped queries incorrectly.
Solution Restores the modern "fast symbol search" path by unconditionally passing experimentEnabled: true. This path correctly parses and filters scoped symbol queries.

Impact
Fixes #14200
Restores proper C++ symbol filtering for users and AI tools like Copilot.
