### PR TITLE
Fix/external include handling

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -3214,6 +3214,38 @@ export class DefaultClient implements Client {
             const compilerPathAndArgs: util.CompilerPathAndArgs =
                 util.extractCompilerPathAndArgs(!!settings.legacyCompilerArgsBehavior, c.compilerPath, c.compilerArgs);
             modifiedConfig.compilerPath = compilerPathAndArgs.compilerPath;
+
+            // Handle external includes
+            const externalIncludePaths: string[] = [];
+            if (c.compilerArgs) {
+                const extracted = util.extractIncludePathsFromArgs(c.compilerArgs);
+                externalIncludePaths.push(...extracted.externalIncludePaths);
+
+                // Resolve external include variables
+                for (const varName of extracted.externalIncludeVars) {
+                    const resolved = this.AdditionalEnvironment ? this.AdditionalEnvironment[varName] : process.env[varName];
+                    if (util.isString(resolved)) {
+                        externalIncludePaths.push(...resolved.split(path.delimiter).filter(p => !!p));
+                    } else if (util.isArrayOfString(resolved)) {
+                        externalIncludePaths.push(...resolved);
+                    }
+                }
+            }
+
+            // Handle EXTERNAL_INCLUDE environment variable
+            const externalIncludeEnv = this.AdditionalEnvironment ? this.AdditionalEnvironment["EXTERNAL_INCLUDE"] : process.env["EXTERNAL_INCLUDE"];
+            if (util.isString(externalIncludeEnv)) {
+                externalIncludePaths.push(...externalIncludeEnv.split(path.delimiter).filter(p => !!p));
+            } else if (util.isArrayOfString(externalIncludeEnv)) {
+                externalIncludePaths.push(...externalIncludeEnv);
+            }
+
+            if (externalIncludePaths.length > 0) {
+                const currentIncludePath = modifiedConfig.includePath || [];
+                const uniqueNewIncludes = externalIncludePaths.filter(p => !currentIncludePath.includes(p));
+                modifiedConfig.includePath = currentIncludePath.concat(uniqueNewIncludes);
+            }
+
             if (settings.legacyCompilerArgsBehavior) {
                 modifiedConfig.compilerArgsLegacy = compilerPathAndArgs.allCompilerArgs;
                 modifiedConfig.compilerArgs = undefined;

--- a/Extension/src/Utility/msvcFlags.ts
+++ b/Extension/src/Utility/msvcFlags.ts
@@ -1,0 +1,69 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export interface IncludePathsFromArgs {
+    includePaths: string[];
+    externalIncludePaths: string[];
+    externalIncludeVars: string[];
+}
+
+/**
+ * Parses compiler arguments for include-related flags (MSVC/clang-cl style).
+ * Supports /I, /imsvc, /external:I, /external:var.
+ */
+export function extractIncludePathsFromArgs(args: string[]): IncludePathsFromArgs {
+    const result: IncludePathsFromArgs = {
+        includePaths: [],
+        externalIncludePaths: [],
+        externalIncludeVars: []
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg.startsWith("/I") || arg.startsWith("-I")) {
+            let path = arg.substring(2);
+            if (path === "" && i + 1 < args.length) {
+                const nextArg = args[i + 1];
+                if (!nextArg.startsWith("/") && !nextArg.startsWith("-")) {
+                    path = args[++i];
+                }
+            }
+            if (path !== "") {
+                result.includePaths.push(path);
+            }
+        } else if (arg.startsWith("/imsvc") || arg.startsWith("-imsvc")) {
+            let path = arg.substring(6);
+            if (path === "" && i + 1 < args.length) {
+                const nextArg = args[i + 1];
+                if (!nextArg.startsWith("/") && !nextArg.startsWith("-")) {
+                    path = args[++i];
+                }
+            }
+            if (path !== "") {
+                // imsvc is treated as a system include, so we put it in externalIncludePaths
+                result.externalIncludePaths.push(path);
+            }
+        } else if (arg.startsWith("/external:I") || arg.startsWith("-external:I")) {
+            let path = arg.substring(11);
+            if (path === "" && i + 1 < args.length) {
+                const nextArg = args[i + 1];
+                if (!nextArg.startsWith("/") && !nextArg.startsWith("-")) {
+                    path = args[++i];
+                }
+            }
+            if (path !== "") {
+                result.externalIncludePaths.push(path);
+            }
+        } else if (arg.startsWith("/external:var:") || arg.startsWith("-external:var:")) {
+
+            const varName = arg.substring(14);
+            if (varName !== "") {
+                result.externalIncludeVars.push(varName);
+            }
+        }
+    }
+
+    return result;
+}

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1850,3 +1850,7 @@ export function getVSCodeLanguageModel(): any | undefined {
     }
     return vscodelm;
 }
+
+export * from './Utility/msvcFlags';
+
+

--- a/Extension/test/unit/msvcArgumentParsing.test.ts
+++ b/Extension/test/unit/msvcArgumentParsing.test.ts
@@ -1,0 +1,51 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { deepEqual } from 'assert';
+import { describe, it } from 'mocha';
+import { extractIncludePathsFromArgs } from '../../src/Utility/msvcFlags';
+
+
+describe('MSVC Argument Parsing', () => {
+    it('extracts /I paths', () => {
+        const args = ['/I', 'C:\\path1', '/IC:\\path2', '-I', 'C:\\path3', '-IC:\\path4'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.includePaths, ['C:\\path1', 'C:\\path2', 'C:\\path3', 'C:\\path4']);
+    });
+
+    it('extracts /imsvc paths', () => {
+        const args = ['/imsvc', 'C:\\sys1', '/imsvcC:\\sys2', '-imsvc', 'C:\\sys3', '-imsvcC:\\sys4'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.externalIncludePaths, ['C:\\sys1', 'C:\\sys2', 'C:\\sys3', 'C:\\sys4']);
+    });
+
+    it('extracts /external:I paths', () => {
+        const args = ['/external:I', 'C:\\ext1', '/external:IC:\\ext2', '-external:I', 'C:\\ext3', '-external:IC:\\ext4'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.externalIncludePaths, ['C:\\ext1', 'C:\\ext2', 'C:\\ext3', 'C:\\ext4']);
+    });
+
+    it('extracts /external:var variables', () => {
+        const args = ['/external:var:MYVAR', '-external:var:OTHERVAR'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.externalIncludeVars, ['MYVAR', 'OTHERVAR']);
+    });
+
+    it('handles mixed flags', () => {
+        const args = ['/I', 'p1', '/external:I', 'p2', '/external:var:v1', '/imsvc', 'p3'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.includePaths, ['p1']);
+        deepEqual(result.externalIncludePaths, ['p2', 'p3']);
+        deepEqual(result.externalIncludeVars, ['v1']);
+    });
+
+    it('handles empty/incomplete flags', () => {
+        const args = ['/I', '/external:I', '/external:var:'];
+        const result = extractIncludePathsFromArgs(args);
+        deepEqual(result.includePaths, []);
+        deepEqual(result.externalIncludePaths, []);
+        deepEqual(result.externalIncludeVars, []);
+    });
+});


### PR DESCRIPTION
Fixes #14205

MSVC External Includes: Implemented parsing for /external:I, /external:var, and /imsvc compiler flags.

Environment Support: Added automatic resolution for the EXTERNAL_INCLUDE environment variable.

Robust Utility: Created 
msvcFlags.ts to accurately extract and deduplicate paths from compilerArgs.

Verification: Added 6 unit tests to ensure stability and correct handling of edge cases.