### PR TITLE
Set `C_Cpp.copilotHover` to `disabled` by default.

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.32.0: March 25, 2026
+### Bug Fix
+* Set `C_Cpp.copilotHover` to `disabled` by default due to several reported VS Code (Copilot) bugs. [#14168](https://github.com/microsoft/vscode-cpptools/issues/14168), [#14211](https://github.com/microsoft/vscode-cpptools/issues/14211), [#14241](https://github.com/microsoft/vscode-cpptools/issues/14241)
+
 ## Version 1.31.3: March 24, 2026
 ### Enhancements
 * Add support for `program` in attach debug configurations. [#14046](https://github.com/microsoft/vscode-cpptools/issues/14046)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.31.3-main",
+    "version": "1.32.0-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",
@@ -3593,7 +3593,7 @@
                             "disabled",
                             "enabled"
                         ],
-                        "default": "default",
+                        "default": "disabled",
                         "markdownDescription": "%c_cpp.configuration.copilotHover.markdownDescription%",
                         "scope": "window"
                     },


### PR DESCRIPTION
The user at https://github.com/microsoft/vscode-cpptools/issues/14211#issuecomment-3963811644 reported this fixed their issue, also a couple users at https://github.com/microsoft/vscode-cpptools/issues/14168#issuecomment-4086899225 .