### PR TITLE
Update brace-expansion v5.

### DIFF
--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1761,10 +1761,10 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-brace-expansion@^5.0.2:
-  version "5.0.3"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.3.tgz#6a9c6c268f85b53959ec527aeafe0f7300258eef"
-  integrity sha1-apxsJo+FtTlZ7FJ66v4PcwAlju8=
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha1-3MOjcRa3nz4bRtuZTO1dVw6TD9s=
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Backports for version 1 and 2 are still in progress.
