### PR TITLE
Run without debugging

### DIFF
--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -66,6 +66,11 @@ jobs:
       #   run: yarn test --scenario=MultirootDeadlockTest
       #   working-directory: Extension
 
+      # - name: Run E2E IntelliSense features tests
+      #   if: ${{ inputs.platform == 'windows' }}
+      #   run: yarn test --scenario=RunWithoutDebugging
+      #   working-directory: Extension
+
       # NOTE: For mac/linux run the tests with xvfb-action for UI support.
       # Another way to start xvfb https://github.com/microsoft/vscode-test/blob/master/sample/azure-pipelines.yml
 
@@ -81,5 +86,12 @@ jobs:
       #   uses: coactions/setup-xvfb@v1
       #   with:
       #     run: yarn test --scenario=MultirootDeadlockTest
+      #     working-directory: Extension
+
+      # - name: Run E2E IntelliSense features tests (xvfb)
+      #   if: ${{ inputs.platform == 'mac' || inputs.platform == 'linux' }}
+      #   uses: coactions/setup-xvfb@v1
+      #   with:
+      #     run: yarn test --scenario=RunWithoutDebugging
       #     working-directory: Extension
 

--- a/Extension/.vscode/launch.json
+++ b/Extension/.vscode/launch.json
@@ -98,6 +98,10 @@
                     "value": "${workspaceFolder}/test/scenarios/MultirootDeadlockTest/assets/test.code-workspace"
                 },
                 {
+                    "label": "RunWithoutDebugging   ",
+                    "value": "${workspaceFolder}/test/scenarios/RunWithoutDebugging/assets/"
+                },
+                {
                     "label": "SimpleCppProject   ",
                     "value": "${workspaceFolder}/test/scenarios/SimpleCppProject/assets/simpleCppProject.code-workspace"
                 },

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -147,7 +147,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 Telemetry.logDebuggerEvent(DebuggerEvent.debugPanel, { "debugType": DebugType.debug, "configSource": folder ? ConfigSource.workspaceFolder : ConfigSource.singleFile, "configMode": ConfigMode.noLaunchConfig, "cancelled": "true", "succeeded": "true" });
                 return undefined; // aborts debugging silently
             } else {
-                const noDebug = config.noDebug ?? false; // preserve the noDebug value from the config if it exists.
+                const noDebug = config.noDebug ?? false; // Preserve the noDebug value from the config if it exists.
                 // Currently, we expect only one debug config to be selected.
                 console.assert(configs.length === 1, "More than one debug config is selected.");
                 config = configs[0];

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -147,12 +147,14 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
                 Telemetry.logDebuggerEvent(DebuggerEvent.debugPanel, { "debugType": DebugType.debug, "configSource": folder ? ConfigSource.workspaceFolder : ConfigSource.singleFile, "configMode": ConfigMode.noLaunchConfig, "cancelled": "true", "succeeded": "true" });
                 return undefined; // aborts debugging silently
             } else {
+                const noDebug = config.noDebug ?? false; // preserve the noDebug value from the config if it exists.
                 // Currently, we expect only one debug config to be selected.
                 console.assert(configs.length === 1, "More than one debug config is selected.");
                 config = configs[0];
                 // Keep track of the entry point where the debug config has been selected, for telemetry purposes.
                 config.debuggerEvent = DebuggerEvent.debugPanel;
                 config.configSource = folder ? ConfigSource.workspaceFolder : ConfigSource.singleFile;
+                config.noDebug = noDebug;
             }
         }
 

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -97,7 +97,7 @@ function createLaunchString(name: string, type: string, executable: string): str
 "stopAtEntry": false,
 "cwd": "$\{fileDirname\}",
 "environment": [],
-${ type === "cppdbg" ? `"externalConsole": false` : `"console": "externalTerminal"` }
+${ type === "cppdbg" ? `"externalConsole": false` : `"console": "integratedTerminal"` }
 `;
 }
 

--- a/Extension/src/Debugger/configurations.ts
+++ b/Extension/src/Debugger/configurations.ts
@@ -97,7 +97,7 @@ function createLaunchString(name: string, type: string, executable: string): str
 "stopAtEntry": false,
 "cwd": "$\{fileDirname\}",
 "environment": [],
-${ type === "cppdbg" ? `"externalConsole": false` : `"console": "integratedTerminal"` }
+${type === "cppdbg" ? `"externalConsole": false` : `"console": "internalConsole"`}
 `;
 }
 
@@ -164,7 +164,7 @@ export class MIConfigurations extends Configuration {
 \t${indentJsonString(createLaunchString(name, this.miDebugger, this.executable))},
 \t"MIMode": "${this.MIMode}"{0}{1}
 }`, [this.miDebugger === "cppdbg" && os.platform() === "win32" ? `,${os.EOL}\t"miDebuggerPath": "/path/to/gdb"` : "",
-            this.additionalProperties ? `,${os.EOL}\t${indentJsonString(this.additionalProperties)}` : ""]);
+        this.additionalProperties ? `,${os.EOL}\t${indentJsonString(this.additionalProperties)}` : ""]);
 
         return {
             "label": configPrefix + name,
@@ -182,7 +182,7 @@ export class MIConfigurations extends Configuration {
 \t${indentJsonString(createAttachString(name, this.miDebugger, this.executable))}
 \t"MIMode": "${this.MIMode}"{0}{1}
 }`, [this.miDebugger === "cppdbg" && os.platform() === "win32" ? `,${os.EOL}\t"miDebuggerPath": "/path/to/gdb"` : "",
-            this.additionalProperties ? `,${os.EOL}\t${indentJsonString(this.additionalProperties)}` : ""]);
+        this.additionalProperties ? `,${os.EOL}\t${indentJsonString(this.additionalProperties)}` : ""]);
 
         return {
             "label": configPrefix + name,

--- a/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
+++ b/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
@@ -7,11 +7,12 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from "vscode";
 import * as nls from 'vscode-nls';
+import { RunWithoutDebuggingAdapter } from './runWithoutDebuggingAdapter';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
-// Registers DebugAdapterDescriptorFactory for `cppdbg` and `cppvsdbg`. If it is not ready, it will prompt a wait for the download dialog.
+// Registers DebugAdapterDescriptorFactory for `cppdbg` and `cppvsdbg`.
 // NOTE: This file is not automatically tested.
 
 abstract class AbstractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
@@ -27,7 +28,11 @@ abstract class AbstractDebugAdapterDescriptorFactory implements vscode.DebugAdap
 
 export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
 
-    async createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor> {
+    async createDebugAdapterDescriptor(session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor> {
+        if (session.configuration.noDebug) {
+            return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+        }
+
         const adapter: string = "./debugAdapters/bin/OpenDebugAD7" + (os.platform() === 'win32' ? ".exe" : "");
 
         const command: string = path.join(this.context.extensionPath, adapter);
@@ -38,7 +43,11 @@ export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDes
 
 export class CppvsdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
 
-    async createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor | null> {
+    async createDebugAdapterDescriptor(session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor | null> {
+        if (session.configuration.noDebug) {
+            return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+        }
+
         if (os.platform() !== 'win32') {
             void vscode.window.showErrorMessage(localize("debugger.not.available", "Debugger type '{0}' is not available for non-Windows machines.", "cppvsdbg"));
             return null;

--- a/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
+++ b/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
@@ -7,6 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from "vscode";
 import * as nls from 'vscode-nls';
+import { getOutputChannel } from '../logger';
 import { RunWithoutDebuggingAdapter } from './runWithoutDebuggingAdapter';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -27,10 +28,13 @@ abstract class AbstractDebugAdapterDescriptorFactory implements vscode.DebugAdap
 }
 
 export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-
     async createDebugAdapterDescriptor(session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor> {
         if (session.configuration.noDebug) {
-            return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+            if (noDebugSupported(session.configuration)) {
+                return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+            }
+            // If the configuration is not supported, gracefully fall back to a regular debug session and log a message to the user.
+            logReasonForNoDebugNotSupported(session.configuration);
         }
 
         const adapter: string = "./debugAdapters/bin/OpenDebugAD7" + (os.platform() === 'win32' ? ".exe" : "");
@@ -42,10 +46,13 @@ export class CppdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDes
 }
 
 export class CppvsdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterDescriptorFactory {
-
     async createDebugAdapterDescriptor(session: vscode.DebugSession, _executable?: vscode.DebugAdapterExecutable): Promise<vscode.DebugAdapterDescriptor | null> {
         if (session.configuration.noDebug) {
-            return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+            if (noDebugSupported(session.configuration)) {
+                return new vscode.DebugAdapterInlineImplementation(new RunWithoutDebuggingAdapter());
+            }
+            // If the configuration is not supported, gracefully fall back to a regular debug session and log a message to the user.
+            logReasonForNoDebugNotSupported(session.configuration);
         }
 
         if (os.platform() !== 'win32') {
@@ -58,4 +65,29 @@ export class CppvsdbgDebugAdapterDescriptorFactory extends AbstractDebugAdapterD
             );
         }
     }
+}
+
+function noDebugSupported(configuration: vscode.DebugConfiguration): boolean {
+    // Don't attempt to start a noDebug session if the configuration has any of these properties, which require a debug adapter to function.
+    return configuration.request === 'launch' && !configuration.pipeTransport && !configuration.debugServerPath && !configuration.miDebuggerServerAddress && !configuration.coreDumpPath;
+}
+
+function logReasonForNoDebugNotSupported(configuration: vscode.DebugConfiguration): void {
+    const outputChannel = getOutputChannel();
+    if (configuration.request !== 'launch') {
+        outputChannel.appendLine(localize("debugger.noDebug.requestType.not.supported", "Run Without Debugging is only supported for launch configurations."));
+    }
+    if (configuration.pipeTransport) {
+        outputChannel.appendLine(localize("debugger.noDebug.pipeTransport.not.supported", "Run Without Debugging is not supported for configurations with 'pipeTransport' set."));
+    }
+    if (configuration.debugServerPath) {
+        outputChannel.appendLine(localize("debugger.noDebug.debugServerPath.not.supported", "Run Without Debugging is not supported for configurations with 'debugServerPath' set."));
+    }
+    if (configuration.miDebuggerServerAddress) {
+        outputChannel.appendLine(localize("debugger.noDebug.miDebuggerServerAddress.not.supported", "Run Without Debugging is not supported for configurations with 'miDebuggerServerAddress' set."));
+    }
+    if (configuration.coreDumpPath) {
+        outputChannel.appendLine(localize("debugger.noDebug.coreDumpPath.not.supported", "Run Without Debugging is not supported for configurations with 'coreDumpPath' set."));
+    }
+    outputChannel.show(true);
 }

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -7,7 +7,11 @@ import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
 import { sessionIsWsl } from '../common';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize = nls.loadMessageBundle();
 
 /**
  * A minimal inline Debug Adapter that runs the target program directly without a debug adapter
@@ -117,9 +121,46 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         } else if (platform === 'linux' && sessionIsWsl()) {
             cp.spawn('/mnt/c/Windows/System32/cmd.exe', ['/c', 'start', 'bash', '-c', `${cmdLine};read -p 'Press enter to continue...'`], { env, detached: true, stdio: 'ignore' }).unref();
         } else { // platform === 'linux'
-            cp.spawn('bash', ['-c', `${cmdLine};read -p 'Press enter to continue...'`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+            this.launchLinuxExternalTerminal(cmdLine, cwd, env);
         }
         this.sendEvent('terminated');
+    }
+
+    /**
+     * On Linux, find and launch an available terminal emulator to run the command.
+     */
+    private launchLinuxExternalTerminal(cmdLine: string, cwd: string | undefined, env: NodeJS.ProcessEnv): void {
+        const bashCmd = `${cmdLine}; echo; read -p 'Press enter to continue...'`;
+        const bashArgs = ['bash', '-c', bashCmd];
+
+        // Terminal emulators in order of preference, with the correct flag style for each.
+        const candidates: { cmd: string; buildArgs: () => string[] }[] = [
+            { cmd: 'x-terminal-emulator', buildArgs: () => ['-e', ...bashArgs] },
+            { cmd: 'gnome-terminal', buildArgs: () => ['-e', ...bashArgs] },
+            { cmd: 'konsole', buildArgs: () => ['-e', ...bashArgs] },
+            { cmd: 'xterm', buildArgs: () => ['-e', ...bashArgs] }
+        ];
+
+        // Honor the $TERMINAL environment variable if set.
+        const terminalEnv = process.env['TERMINAL'];
+        if (terminalEnv) {
+            candidates.unshift({ cmd: terminalEnv, buildArgs: () => ['-e', ...bashArgs] });
+        }
+
+        for (const candidate of candidates) {
+            try {
+                const result = cp.spawnSync('which', [candidate.cmd], { stdio: 'pipe' });
+                if (result.status === 0) {
+                    cp.spawn(candidate.cmd, candidate.buildArgs(), { cwd, env, detached: true, stdio: 'ignore' }).unref();
+                    return;
+                }
+            } catch {
+                continue;
+            }
+        }
+
+        const message = localize('no.terminal.emulator', 'No terminal emulator found. Please set the $TERMINAL environment variable to your terminal emulator of choice, or install one of the following: x-terminal-emulator, gnome-terminal, konsole, xterm.');
+        vscode.window.showErrorMessage(message);
     }
 
     /**

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -7,6 +7,7 @@ import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { sessionIsWsl } from '../common';
 
 /**
  * A minimal inline Debug Adapter that runs the target program directly without a debug adapter
@@ -56,13 +57,14 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
             cwd?: string;
             environment?: { name: string; value: string; }[];
             console?: string;
+            externalConsole?: boolean;
         };
 
         const program: string = config.program ?? '';
         const args: string[] = config.args ?? [];
         const cwd: string | undefined = config.cwd;
         const environment: { name: string; value: string; }[] = config.environment ?? [];
-        const consoleMode: string = config.console ?? 'integratedTerminal';
+        const consoleMode: string = config.console ?? (config.externalConsole ? 'externalTerminal' : 'integratedTerminal');
 
         // Merge the launch config's environment variables on top of the inherited process environment.
         const env: NodeJS.ProcessEnv = { ...process.env };
@@ -112,8 +114,10 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
             cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
         } else if (platform === 'darwin') {
             cp.spawn('osascript', ['-e', `tell application "Terminal" to do script "${cmdLine.replace(/"/g, '\\"')}"`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
-        } else {
-            cp.spawn('x-terminal-emulator', ['-e', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+        } else if (platform === 'linux' && sessionIsWsl()) {
+            cp.spawn('/mnt/c/Windows/System32/cmd.exe', ['/c', 'start', 'bash', '-c', `${cmdLine};read -p 'Press enter to continue...'`], { env, detached: true, stdio: 'ignore' }).unref();
+        } else { // platform === 'linux'
+            cp.spawn('bash', ['-c', `${cmdLine};read -p 'Press enter to continue...'`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
         }
         this.sendEvent('terminated');
     }

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -134,7 +134,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         const bashArgs = ['bash', '-c', bashCmd];
 
         // Terminal emulators in order of preference, with the correct flag style for each.
-        const candidates: { cmd: string; buildArgs: () => string[] }[] = [
+        const candidates: { cmd: string; buildArgs(): string[] }[] = [
             { cmd: 'x-terminal-emulator', buildArgs: () => ['-e', ...bashArgs] },
             { cmd: 'gnome-terminal', buildArgs: () => ['-e', ...bashArgs] },
             { cmd: 'konsole', buildArgs: () => ['-e', ...bashArgs] },

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { sessionIsWsl } from '../common';
+import { buildShellCommandLine, sessionIsWsl } from '../common';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize = nls.loadMessageBundle();
@@ -112,8 +112,8 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
             this.monitorIntegratedTerminal(this.terminal);
             this.terminalExecution = shellIntegration.executeCommand(program, args);
         } else {
-            const shellArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
-            this.terminal.sendText(shellArgs.join(' '));
+            const cmdLine: string = buildShellCommandLine('', program, args);
+            this.terminal.sendText(cmdLine);
 
             // The terminal manages its own lifecycle; notify VS Code the "debug" session is done.
             this.sendEvent('terminated');
@@ -124,8 +124,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
      * Launch the program in an external terminal. We do not keep track of this terminal or the spawned process.
      */
     private launchExternalTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv): void {
-        const quotedArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
-        const cmdLine: string = quotedArgs.join(' ');
+        const cmdLine: string = buildShellCommandLine('', program, args);
         const platform: string = os.platform();
         if (platform === 'win32') {
             cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
@@ -201,10 +200,6 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
 
     private escapeQuotes(arg: string): string {
         return arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    }
-
-    private quoteArg(arg: string): string {
-        return /\s/.test(arg) ? `"${this.escapeQuotes(arg)}"` : arg;
     }
 
     private waitForShellIntegration(terminal: vscode.Terminal, timeoutMs: number): Promise<vscode.TerminalShellIntegration | undefined> {

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -81,12 +81,10 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
 
         this.sendResponse(request, {});
 
-        if (consoleMode === 'integratedTerminal') {
+        if (consoleMode === 'integratedTerminal' || consoleMode === 'internalConsole') {
             await this.launchIntegratedTerminal(program, args, cwd, env);
         } else if (consoleMode === 'externalTerminal') {
             this.launchExternalTerminal(program, args, cwd, env);
-        } else {
-            this.launchInternalConsole(program, args, cwd, env);
         }
     }
 
@@ -173,29 +171,6 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
 
         const message = localize('no.terminal.emulator', 'No terminal emulator found. Please set the $TERMINAL environment variable to your terminal emulator of choice, or install one of the following: x-terminal-emulator, gnome-terminal, konsole, xterm.');
         vscode.window.showErrorMessage(message);
-    }
-
-    /**
-     * Spawn the process and forward stdout/stderr as DAP output events.
-     */
-    private launchInternalConsole(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv) {
-        this.childProcess = cp.spawn(program, args, { cwd, env });
-
-        this.childProcess.stdout?.on('data', (data: Buffer) => {
-            this.sendEvent('output', { category: 'stdout', output: data.toString() });
-        });
-        this.childProcess.stderr?.on('data', (data: Buffer) => {
-            this.sendEvent('output', { category: 'stderr', output: data.toString() });
-        });
-        this.childProcess.on('error', (err: Error) => {
-            this.sendEvent('output', { category: 'stderr', output: `${err.message}\n` });
-            this.sendEvent('exited', { exitCode: 1 });
-            this.sendEvent('terminated');
-        });
-        this.childProcess.on('exit', (code: number | null) => {
-            this.sendEvent('exited', { exitCode: code ?? 0 });
-            this.sendEvent('terminated');
-        });
     }
 
     private escapeQuotes(arg: string): string {

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -108,13 +108,32 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         // Not all terminals support shell integration. If it's not available, we'll just send the command as text though we won't be able to monitor its execution.
         if (shellIntegration) {
             this.monitorIntegratedTerminal(this.terminal);
-            if (program.includes(' ')) {
+            let executable: string = program;
+            let executableArgs: string[] = args;
+            if (!program.match(/["']/) && program.match(/\s/)) {
                 // VS Code does not automatically quote the program path if it has spaces.
-                program = `"${program}"`;
+                const shellPath: string | undefined = 'shellPath' in this.terminal.creationOptions
+                    ? this.terminal.creationOptions.shellPath?.toLowerCase()
+                    : undefined;
+                const terminalShell: string | undefined = this.terminal.state.shell?.toLowerCase();
+                const defaultTerminalProfile: string | undefined = os.platform() === 'win32'
+                    ? vscode.workspace.getConfiguration('terminal.integrated').get<string>('defaultProfile.windows')?.toLowerCase()
+                    : undefined;
+                const isPowerShell: boolean | undefined =
+                    shellPath?.endsWith('pwsh.exe') || shellPath?.endsWith('powershell.exe') || shellPath?.endsWith('pwsh') ||
+                    terminalShell?.includes('powershell') || terminalShell?.includes('pwsh') ||
+                    defaultTerminalProfile?.includes('powershell') || defaultTerminalProfile?.includes('pwsh');
+
+                if (isPowerShell) {
+                    executable = '&';
+                    executableArgs = [program, ...args];
+                } else {
+                    executable = `"${program}"`;
+                }
             }
-            this.terminalExecution = shellIntegration.executeCommand(program, args);
+            this.terminalExecution = shellIntegration.executeCommand(executable, executableArgs);
         } else {
-            const cmdLine: string = buildShellCommandLine('', program, args);
+            const cmdLine: string = buildShellCommandLine('', program, args, true);
             this.terminal.sendText(cmdLine);
 
             // The terminal manages its own lifecycle; notify VS Code the "debug" session is done.
@@ -126,10 +145,10 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
      * Launch the program in an external terminal. We do not keep track of this terminal or the spawned process.
      */
     private launchExternalTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv): void {
-        const cmdLine: string = buildShellCommandLine('', program, args);
+        const cmdLine: string = buildShellCommandLine('', program, args, true);
         const platform: string = os.platform();
         if (platform === 'win32') {
-            cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+            cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', `"${cmdLine}"`], { cwd, env, windowsVerbatimArguments: true, detached: true, stdio: 'ignore' }).unref();
         } else if (platform === 'darwin') {
             cp.spawn('osascript', ['-e', `tell application "Terminal" to do script "${this.escapeQuotes(cmdLine)}"`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
         } else if (platform === 'linux' && sessionIsWsl()) {

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -20,10 +20,13 @@ const localize = nls.loadMessageBundle();
 export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
     private readonly sendMessageEmitter = new vscode.EventEmitter<vscode.DebugProtocolMessage>();
     public readonly onDidSendMessage: vscode.Event<vscode.DebugProtocolMessage> = this.sendMessageEmitter.event;
+    private readonly terminalListeners: vscode.Disposable[] = [];
 
     private seq: number = 1;
     private childProcess?: cp.ChildProcess;
     private terminal?: vscode.Terminal;
+    private terminalExecution?: vscode.TerminalShellExecution;
+    private hasTerminated: boolean = false;
 
     public handleMessage(message: vscode.DebugProtocolMessage): void {
         const msg = message as { type: string; command: string; seq: number; arguments?: any; };
@@ -79,7 +82,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         this.sendResponse(request, {});
 
         if (consoleMode === 'integratedTerminal') {
-            this.launchIntegratedTerminal(program, args, cwd, env);
+            await this.launchIntegratedTerminal(program, args, cwd, env);
         } else if (consoleMode === 'externalTerminal') {
             this.launchExternalTerminal(program, args, cwd, env);
         } else {
@@ -91,8 +94,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
      * Launch the program in a VS Code integrated terminal.
      * The terminal will remain open after the program exits and be reused for the next session, if applicable.
      */
-    private launchIntegratedTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv) {
-        const shellArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
+    private async launchIntegratedTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv): Promise<void> {
         const terminalName = path.normalize(program);
         const existingTerminal = vscode.window.terminals.find(t => t.name === terminalName);
         this.terminal = existingTerminal ?? vscode.window.createTerminal({
@@ -101,10 +103,21 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
             env: env as Record<string, string>
         });
         this.terminal.show(true);
-        this.terminal.sendText(shellArgs.join(' '));
 
-        // The terminal manages its own lifecycle; notify VS Code the "debug" session is done.
-        this.sendEvent('terminated');
+        const shellIntegration: vscode.TerminalShellIntegration | undefined =
+            this.terminal.shellIntegration ?? await this.waitForShellIntegration(this.terminal, 3000);
+
+        // Not all terminals support shell integration. If it's not available, we'll just send the command as text though we won't be able to monitor its execution.
+        if (shellIntegration) {
+            this.monitorIntegratedTerminal(this.terminal);
+            this.terminalExecution = shellIntegration.executeCommand(program, args);
+        } else {
+            const shellArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
+            this.terminal.sendText(shellArgs.join(' '));
+
+            // The terminal manages its own lifecycle; notify VS Code the "debug" session is done.
+            this.sendEvent('terminated');
+        }
     }
 
     /**
@@ -194,6 +207,65 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         return /\s/.test(arg) ? `"${this.escapeQuotes(arg)}"` : arg;
     }
 
+    private waitForShellIntegration(terminal: vscode.Terminal, timeoutMs: number): Promise<vscode.TerminalShellIntegration | undefined> {
+        return new Promise(resolve => {
+            let resolved: boolean = false;
+            const done = (shellIntegration: vscode.TerminalShellIntegration | undefined): void => {
+                if (resolved) {
+                    return;
+                }
+
+                resolved = true;
+                clearTimeout(timeout);
+                shellIntegrationChanged.dispose();
+                terminalClosed.dispose();
+                resolve(shellIntegration);
+            };
+
+            const timeout = setTimeout(() => done(undefined), timeoutMs);
+            const shellIntegrationChanged = vscode.window.onDidChangeTerminalShellIntegration(event => {
+                if (event.terminal === terminal) {
+                    done(event.shellIntegration);
+                }
+            });
+            const terminalClosed = vscode.window.onDidCloseTerminal(closedTerminal => {
+                if (closedTerminal === terminal) {
+                    done(undefined);
+                }
+            });
+        });
+    }
+
+    private monitorIntegratedTerminal(terminal: vscode.Terminal): void {
+        this.disposeTerminalListeners();
+        this.terminalListeners.push(
+            vscode.window.onDidEndTerminalShellExecution(event => {
+                if (event.terminal !== terminal || event.execution !== this.terminalExecution || this.hasTerminated) {
+                    return;
+                }
+
+                if (event.exitCode !== undefined) {
+                    this.sendEvent('exited', { exitCode: event.exitCode });
+                }
+
+                this.sendEvent('terminated');
+            }),
+            vscode.window.onDidCloseTerminal(closedTerminal => {
+                if (closedTerminal !== terminal || this.hasTerminated) {
+                    return;
+                }
+
+                this.sendEvent('terminated');
+            })
+        );
+    }
+
+    private disposeTerminalListeners(): void {
+        while (this.terminalListeners.length > 0) {
+            this.terminalListeners.pop()?.dispose();
+        }
+    }
+
     private sendResponse(request: { command: string; seq: number; }, body: object): void {
         this.sendMessageEmitter.fire({
             type: 'response',
@@ -206,6 +278,15 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
     }
 
     private sendEvent(event: string, body?: object): void {
+        if (event === 'terminated') {
+            if (this.hasTerminated) {
+                return;
+            }
+
+            this.hasTerminated = true;
+            this.disposeTerminalListeners();
+        }
+
         this.sendMessageEmitter.fire({
             type: 'event',
             seq: this.seq++,
@@ -216,6 +297,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
 
     public dispose(): void {
         this.terminateProcess();
+        this.disposeTerminalListeners();
         this.sendMessageEmitter.dispose();
     }
 

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -108,6 +108,10 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         // Not all terminals support shell integration. If it's not available, we'll just send the command as text though we won't be able to monitor its execution.
         if (shellIntegration) {
             this.monitorIntegratedTerminal(this.terminal);
+            if (program.includes(' ')) {
+                // VS Code does not automatically quote the program path if it has spaces.
+                program = `"${program}"`;
+            }
             this.terminalExecution = shellIntegration.executeCommand(program, args);
         } else {
             const cmdLine: string = buildShellCommandLine('', program, args);

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -117,7 +117,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         if (platform === 'win32') {
             cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
         } else if (platform === 'darwin') {
-            cp.spawn('osascript', ['-e', `tell application "Terminal" to do script "${cmdLine.replace(/"/g, '\\"')}"`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+            cp.spawn('osascript', ['-e', `tell application "Terminal" to do script "${this.escapeQuotes(cmdLine)}"`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
         } else if (platform === 'linux' && sessionIsWsl()) {
             cp.spawn('/mnt/c/Windows/System32/cmd.exe', ['/c', 'start', 'bash', '-c', `${cmdLine};read -p 'Press enter to continue...'`], { env, detached: true, stdio: 'ignore' }).unref();
         } else { // platform === 'linux'
@@ -186,8 +186,12 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
         });
     }
 
+    private escapeQuotes(arg: string): string {
+        return arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    }
+
     private quoteArg(arg: string): string {
-        return /\s/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg;
+        return /\s/.test(arg) ? `"${this.escapeQuotes(arg)}"` : arg;
     }
 
     private sendResponse(request: { command: string; seq: number; }, body: object): void {

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { buildShellCommandLine, sessionIsWsl } from '../common';
+import { isWindows } from '../constants';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize = nls.loadMessageBundle();
@@ -116,7 +117,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
                     ? this.terminal.creationOptions.shellPath?.toLowerCase()
                     : undefined;
                 const terminalShell: string | undefined = this.terminal.state.shell?.toLowerCase();
-                const defaultTerminalProfile: string | undefined = os.platform() === 'win32'
+                const defaultTerminalProfile: string | undefined = isWindows
                     ? vscode.workspace.getConfiguration('terminal.integrated').get<string>('defaultProfile.windows')?.toLowerCase()
                     : undefined;
                 const isPowerShell: boolean | undefined =
@@ -124,7 +125,7 @@ export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
                     terminalShell?.includes('powershell') || terminalShell?.includes('pwsh') ||
                     defaultTerminalProfile?.includes('powershell') || defaultTerminalProfile?.includes('pwsh');
 
-                if (isPowerShell) {
+                if (isPowerShell || (isWindows && isPowerShell === undefined)) { // PowerShell is the default on Windows if we can't determine the shell.
                     executable = '&';
                     executableArgs = [program, ...args];
                 } else {

--- a/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
+++ b/Extension/src/Debugger/runWithoutDebuggingAdapter.ts
@@ -1,0 +1,177 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * A minimal inline Debug Adapter that runs the target program directly without a debug adapter
+ * when the user invokes "Run Without Debugging".
+ */
+export class RunWithoutDebuggingAdapter implements vscode.DebugAdapter {
+    private readonly sendMessageEmitter = new vscode.EventEmitter<vscode.DebugProtocolMessage>();
+    public readonly onDidSendMessage: vscode.Event<vscode.DebugProtocolMessage> = this.sendMessageEmitter.event;
+
+    private seq: number = 1;
+    private childProcess?: cp.ChildProcess;
+    private terminal?: vscode.Terminal;
+
+    public handleMessage(message: vscode.DebugProtocolMessage): void {
+        const msg = message as { type: string; command: string; seq: number; arguments?: any; };
+        if (msg.type === 'request') {
+            void this.handleRequest(msg);
+        }
+    }
+
+    private async handleRequest(request: { command: string; seq: number; arguments?: any; }): Promise<void> {
+        switch (request.command) {
+            case 'initialize':
+                this.sendResponse(request, {});
+                this.sendEvent('initialized');
+                break;
+            case 'launch':
+                await this.launch(request);
+                break;
+            case 'configurationDone':
+                this.sendResponse(request, {});
+                break;
+            case 'disconnect':
+            case 'terminate':
+                this.sendResponse(request, {});
+                break;
+            default:
+                this.sendResponse(request, {});
+                break;
+        }
+    }
+
+    private async launch(request: { command: string; seq: number; arguments?: any; }): Promise<void> {
+        const config = request.arguments as {
+            program?: string;
+            args?: string[];
+            cwd?: string;
+            environment?: { name: string; value: string; }[];
+            console?: string;
+        };
+
+        const program: string = config.program ?? '';
+        const args: string[] = config.args ?? [];
+        const cwd: string | undefined = config.cwd;
+        const environment: { name: string; value: string; }[] = config.environment ?? [];
+        const consoleMode: string = config.console ?? 'integratedTerminal';
+
+        // Merge the launch config's environment variables on top of the inherited process environment.
+        const env: NodeJS.ProcessEnv = { ...process.env };
+        for (const e of environment) {
+            env[e.name] = e.value;
+        }
+
+        this.sendResponse(request, {});
+
+        if (consoleMode === 'integratedTerminal') {
+            this.launchIntegratedTerminal(program, args, cwd, env);
+        } else if (consoleMode === 'externalTerminal') {
+            this.launchExternalTerminal(program, args, cwd, env);
+        } else {
+            this.launchInternalConsole(program, args, cwd, env);
+        }
+    }
+
+    /**
+     * Launch the program in a VS Code integrated terminal.
+     * The terminal will remain open after the program exits and be reused for the next session, if applicable.
+     */
+    private launchIntegratedTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv) {
+        const shellArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
+        const terminalName = path.normalize(program);
+        const existingTerminal = vscode.window.terminals.find(t => t.name === terminalName);
+        this.terminal = existingTerminal ?? vscode.window.createTerminal({
+            name: terminalName,
+            cwd,
+            env: env as Record<string, string>
+        });
+        this.terminal.show(true);
+        this.terminal.sendText(shellArgs.join(' '));
+
+        // The terminal manages its own lifecycle; notify VS Code the "debug" session is done.
+        this.sendEvent('terminated');
+    }
+
+    /**
+     * Launch the program in an external terminal. We do not keep track of this terminal or the spawned process.
+     */
+    private launchExternalTerminal(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv): void {
+        const quotedArgs: string[] = [program, ...args].map(a => this.quoteArg(a));
+        const cmdLine: string = quotedArgs.join(' ');
+        const platform: string = os.platform();
+        if (platform === 'win32') {
+            cp.spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/K', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+        } else if (platform === 'darwin') {
+            cp.spawn('osascript', ['-e', `tell application "Terminal" to do script "${cmdLine.replace(/"/g, '\\"')}"`], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+        } else {
+            cp.spawn('x-terminal-emulator', ['-e', cmdLine], { cwd, env, detached: true, stdio: 'ignore' }).unref();
+        }
+        this.sendEvent('terminated');
+    }
+
+    /**
+     * Spawn the process and forward stdout/stderr as DAP output events.
+     */
+    private launchInternalConsole(program: string, args: string[], cwd: string | undefined, env: NodeJS.ProcessEnv) {
+        this.childProcess = cp.spawn(program, args, { cwd, env });
+
+        this.childProcess.stdout?.on('data', (data: Buffer) => {
+            this.sendEvent('output', { category: 'stdout', output: data.toString() });
+        });
+        this.childProcess.stderr?.on('data', (data: Buffer) => {
+            this.sendEvent('output', { category: 'stderr', output: data.toString() });
+        });
+        this.childProcess.on('error', (err: Error) => {
+            this.sendEvent('output', { category: 'stderr', output: `${err.message}\n` });
+            this.sendEvent('exited', { exitCode: 1 });
+            this.sendEvent('terminated');
+        });
+        this.childProcess.on('exit', (code: number | null) => {
+            this.sendEvent('exited', { exitCode: code ?? 0 });
+            this.sendEvent('terminated');
+        });
+    }
+
+    private quoteArg(arg: string): string {
+        return /\s/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg;
+    }
+
+    private sendResponse(request: { command: string; seq: number; }, body: object): void {
+        this.sendMessageEmitter.fire({
+            type: 'response',
+            seq: this.seq++,
+            request_seq: request.seq,
+            success: true,
+            command: request.command,
+            body
+        } as vscode.DebugProtocolMessage);
+    }
+
+    private sendEvent(event: string, body?: object): void {
+        this.sendMessageEmitter.fire({
+            type: 'event',
+            seq: this.seq++,
+            event,
+            body
+        } as vscode.DebugProtocolMessage);
+    }
+
+    public dispose(): void {
+        this.terminateProcess();
+        this.sendMessageEmitter.dispose();
+    }
+
+    private terminateProcess(): void {
+        this.childProcess?.kill();
+        this.childProcess = undefined;
+    }
+}

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1850,3 +1850,14 @@ export function getVSCodeLanguageModel(): any | undefined {
     }
     return vscodelm;
 }
+
+export function sessionIsWsl(): boolean {
+    if (process.env.WSL_DISTRO_NAME) {
+        return true;
+    }
+    try {
+        return fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+    } catch {
+        return false;
+    }
+}

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1568,6 +1568,34 @@ export function hasMsvcEnvironment(): boolean {
     );
 }
 
+export function getMissingMsvcEnvironmentVariables(): string[] {
+    const msvcEnvVars: string[] = [
+        'DevEnvDir',
+        'Framework40Version',
+        'FrameworkDir',
+        'FrameworkVersion',
+        'INCLUDE',
+        'LIB',
+        'LIBPATH',
+        'UCRTVersion',
+        'UniversalCRTSdkDir',
+        'VCIDEInstallDir',
+        'VCINSTALLDIR',
+        'VCToolsRedistDir',
+        'VisualStudioVersion',
+        'VSINSTALLDIR',
+        'WindowsLibPath',
+        'WindowsSdkBinPath',
+        'WindowsSdkDir',
+        'WindowsSDKLibVersion',
+        'WindowsSDKVersion'
+    ];
+    return msvcEnvVars.filter(envVarName =>
+        (process.env[envVarName] === undefined || process.env[envVarName] === '') &&
+        extensionContext?.environmentVariableCollection?.get(envVarName) === undefined
+    );
+}
+
 function isIntegral(str: string): boolean {
     const regex = /^-?\d+$/;
     return regex.test(str);

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1695,7 +1695,7 @@ export interface IQuotedString {
 
 export type CommandString = string | IQuotedString;
 
-export function buildShellCommandLine(originalCommand: CommandString, command: CommandString, args: CommandString[]): string {
+export function buildShellCommandLine(originalCommand: CommandString, command: CommandString, args: CommandString[], singleCommandOnly: boolean = false): string {
 
     let shellQuoteOptions: IShellQuotingOptions;
     const isWindows: boolean = os.platform() === 'win32';
@@ -1809,7 +1809,7 @@ export function buildShellCommandLine(originalCommand: CommandString, command: C
 
     let commandLine = result.join(' ');
     // There are special rules quoted command line in cmd.exe
-    if (isWindows) {
+    if (isWindows && !singleCommandOnly) {
         commandLine = `chcp 65001>nul && ${commandLine}`;
         if (commandQuoted && argQuoted) {
             commandLine = '"' + commandLine + '"';

--- a/Extension/test/scenarios/RunWithoutDebugging/assets/argsTest.cpp
+++ b/Extension/test/scenarios/RunWithoutDebugging/assets/argsTest.cpp
@@ -1,0 +1,21 @@
+#include <fstream>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        return 1;
+    }
+
+    std::ofstream resultFile(argv[1]);
+    if (!resultFile) {
+        return 2;
+    }
+
+    for (int i = 2; i < argc; ++i) {
+        resultFile << argv[i];
+        if (i + 1 < argc) {
+            resultFile << '\n';
+        }
+    }
+
+    return 0;
+}

--- a/Extension/test/scenarios/RunWithoutDebugging/assets/debugTest.cpp
+++ b/Extension/test/scenarios/RunWithoutDebugging/assets/debugTest.cpp
@@ -1,0 +1,11 @@
+#include <fstream>
+
+int main() {
+    std::ofstream resultFile("runWithoutDebuggingResult.txt");
+    if (!resultFile) {
+        return 1;
+    }
+
+    resultFile << 37;
+    return 0;
+}

--- a/Extension/test/scenarios/RunWithoutDebugging/assets/exitCode.cpp
+++ b/Extension/test/scenarios/RunWithoutDebugging/assets/exitCode.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 37;
+}

--- a/Extension/test/scenarios/RunWithoutDebugging/assets/exitCode.cpp
+++ b/Extension/test/scenarios/RunWithoutDebugging/assets/exitCode.cpp
@@ -1,3 +1,0 @@
-int main() {
-    return 37;
-}

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/compileProgram.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/compileProgram.ts
@@ -1,0 +1,72 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../../vscode.d.ts" />
+import * as assert from 'assert';
+import * as cp from 'child_process';
+import * as vscode from 'vscode';
+import * as util from '../../../../src/common';
+import { isLinux, isMacOS, isWindows } from '../../../../src/constants';
+import { getEffectiveEnvironment } from '../../../../src/LanguageServer/devcmd';
+
+interface ProcessResult {
+    code: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+function runProcess(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<ProcessResult> {
+    return new Promise((resolve, reject) => {
+        const child = cp.spawn(command, args, { cwd, env });
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (data: Buffer) => {
+            stdout += data.toString();
+        });
+
+        child.stderr.on('data', (data: Buffer) => {
+            stderr += data.toString();
+        });
+
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+}
+
+async function setWindowsBuildEnvironment(): Promise<void> {
+    const promise = vscode.commands.executeCommand('C_Cpp.SetVsDeveloperEnvironment', 'test');
+    const timer = setInterval(() => {
+        void vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+    }, 1000);
+    await promise;
+    clearInterval(timer);
+    const missingVars = util.getMissingMsvcEnvironmentVariables();
+    assert.strictEqual(missingVars.length, 0, `MSVC environment missing: ${missingVars.join(', ')}`);
+}
+
+export async function compileProgram(workspacePath: string, sourcePath: string, outputPath: string): Promise<void> {
+    if (isWindows) {
+        await setWindowsBuildEnvironment();
+        const env = getEffectiveEnvironment();
+        const result = await runProcess('cl.exe', ['/nologo', '/EHsc', '/Zi', '/std:c++17', `/Fe:${outputPath}`, sourcePath], workspacePath, env);
+        assert.strictEqual(result.code, 0, `MSVC compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    if (isMacOS) {
+        const result = await runProcess('clang++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
+        assert.strictEqual(result.code, 0, `clang++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    if (isLinux) {
+        const result = await runProcess('g++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
+        assert.strictEqual(result.code, 0, `g++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    assert.fail(`Unsupported test platform: ${process.platform}`);
+}

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -252,6 +252,7 @@ suite('Run Without Debugging Integration Test', function (): void {
         const executablePath = path.join(workspacePath, executableName);
         const sessionName = 'Debug Launch Breakpoint Stop';
         const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
+        const miMode = isMacOS ? 'lldb' : 'gdb';
 
         await compileProgram(workspacePath, sourceFile, executablePath);
 
@@ -278,6 +279,7 @@ suite('Run Without Debugging Integration Test', function (): void {
                     program: executablePath,
                     args: [],
                     cwd: workspacePath,
+                    MIMode: debugType === 'cppdbg' ? miMode : undefined,
                     externalConsole: debugType === 'cppdbg' ? false : undefined,
                     console: debugType === 'cppvsdbg' ? 'internalConsole' : undefined
                 },

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -24,7 +24,6 @@ interface TrackerState {
     stoppedEventReceived: boolean;
     exitedEventReceived: boolean;
     exitedBeforeStop: boolean;
-    actualExitCode?: number;
 }
 
 interface TrackerController {
@@ -59,7 +58,8 @@ async function setWindowsBuildEnvironment(): Promise<void> {
     }, 1000);
     await promise;
     clearInterval(timer);
-    assert.strictEqual(util.hasMsvcEnvironment(), true, 'MSVC environment not set correctly.');
+    const missingVars = util.getMissingMsvcEnvironmentVariables();
+    assert.strictEqual(missingVars.length, 0, `MSVC environment missing: ${missingVars.join(', ')}`);
 }
 
 async function compileProgram(workspacePath: string, sourcePath: string, outputPath: string): Promise<void> {
@@ -86,11 +86,11 @@ async function compileProgram(workspacePath: string, sourcePath: string, outputP
     assert.fail(`Unsupported test platform: ${process.platform}`);
 }
 
-async function createBreakpointAtReturnStatement(sourceUri: vscode.Uri): Promise<vscode.SourceBreakpoint> {
+async function createBreakpointAtResultWriteStatement(sourceUri: vscode.Uri): Promise<vscode.SourceBreakpoint> {
     const document = await vscode.workspace.openTextDocument(sourceUri);
-    const returnLine = document.getText().split(/\r?\n/).findIndex((line) => line.includes('return 37;'));
-    assert.notStrictEqual(returnLine, -1, 'Unable to find expected return statement for breakpoint placement.');
-    const breakpoint = new vscode.SourceBreakpoint(new vscode.Location(sourceUri, new vscode.Position(returnLine, 0)), true);
+    const resultWriteLine = document.getText().split(/\r?\n/).findIndex((line) => line.includes('resultFile << 37;'));
+    assert.notStrictEqual(resultWriteLine, -1, 'Unable to find expected result-write statement for breakpoint placement.');
+    const breakpoint = new vscode.SourceBreakpoint(new vscode.Location(sourceUri, new vscode.Position(resultWriteLine, 0)), true);
     vscode.debug.addBreakpoints([breakpoint]);
     return breakpoint;
 }
@@ -106,7 +106,7 @@ function createSessionTerminatedPromise(sessionName: string): Promise<void> {
     });
 }
 
-function createTracker(debugType: string, sessionName: string, programName: string, timeoutMs: number, timeoutMessage: string): TrackerController {
+function createTracker(debugType: string, sessionName: string, timeoutMs: number, timeoutMessage: string): TrackerController {
     const state: TrackerState = {
         setBreakpointsRequestReceived: false,
         stoppedEventReceived: false,
@@ -150,37 +150,8 @@ function createTracker(debugType: string, sessionName: string, programName: stri
                             resolve('stopped');
                         }
 
-                        // integratedTerminal scenarios may not send an 'exited' event if the terminal does not support shell integration.
-                        // We have to close the terminal with the exit code to get the result.
-                        if (message.event === 'terminated' && !state.exitedEventReceived) {
+                        if ((message.event === 'terminated' || message.event === 'exited') && !state.exitedEventReceived) {
                             state.exitedEventReceived = true;
-                            const disp = vscode.window.onDidCloseTerminal((terminal) => {
-                                if (terminal.name === programName) {
-                                    state.exitedEventReceived = true;
-                                    state.actualExitCode = terminal.exitStatus?.code;
-                                    if (!state.stoppedEventReceived) {
-                                        state.exitedBeforeStop = true;
-                                    }
-                                    if (timeoutHandle) {
-                                        clearTimeout(timeoutHandle);
-                                        timeoutHandle = undefined;
-                                    }
-                                    disp.dispose();
-                                    resolve('exited');
-                                }
-                            });
-
-                            vscode.window.terminals.forEach((terminal) => {
-                                if (terminal.name === programName) {
-                                    const exitCommand = isWindows ? 'exit /b %ErrorLevel%' : 'exit $?';
-                                    terminal.sendText(exitCommand);
-                                }
-                            });
-                        }
-
-                        if (message.event === 'exited') {
-                            state.exitedEventReceived = true;
-                            state.actualExitCode = message.body?.exitCode;
                             if (!state.stoppedEventReceived) {
                                 state.exitedBeforeStop = true;
                             }
@@ -210,6 +181,32 @@ function createTracker(debugType: string, sessionName: string, programName: stri
     };
 }
 
+async function waitForResultFileValue(filePath: string, timeoutMs: number): Promise<number> {
+    const deadline = Date.now() + timeoutMs;
+    let lastContents = '';
+
+    while (Date.now() < deadline) {
+        try {
+            lastContents = await util.readFileText(filePath, 'utf8');
+            const trimmedContents = lastContents.trim();
+            if (trimmedContents.length > 0) {
+                const value = Number.parseInt(trimmedContents, 10);
+                if (!Number.isNaN(value)) {
+                    return value;
+                }
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+        }
+
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+    }
+
+    assert.fail(`Timed out waiting for numeric result in ${filePath}. Last contents: ${lastContents}`);
+}
+
 suite('Run Without Debugging Integration Test', function (): void {
     suiteSetup(async function (): Promise<void> {
         const extension: vscode.Extension<any> = vscode.extensions.getExtension('ms-vscode.cpptools') || assert.fail('Extension not found');
@@ -224,21 +221,23 @@ suite('Run Without Debugging Integration Test', function (): void {
         }
     });
 
-    test('Run Without Debugging should not break on breakpoints and emit expected exit code', async () => {
-        const expectedExitCode = 37;
+    test('Run Without Debugging should not break on breakpoints and write the expected result file', async () => {
+        const expectedResultValue = 37;
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
         const workspacePath = workspaceFolder.uri.fsPath;
-        const sourceFile = path.join(workspacePath, 'exitCode.cpp');
+        const sourceFile = path.join(workspacePath, 'debugTest.cpp');
         const sourceUri = vscode.Uri.file(sourceFile);
-        const executableName = isWindows ? 'exitCodeProgram.exe' : 'exitCodeProgram';
+        const resultFilePath = path.join(workspacePath, 'runWithoutDebuggingResult.txt');
+        const executableName = isWindows ? 'debugTestProgram.exe' : 'debugTestProgram';
         const executablePath = path.join(workspacePath, executableName);
-        const sessionName = 'Run Without Debugging Exit Code';
+        const sessionName = 'Run Without Debugging Result File';
         const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
 
+        await util.deleteFile(resultFilePath);
         await compileProgram(workspacePath, sourceFile, executablePath);
 
-        const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
-        const tracker = createTracker(debugType, sessionName, executablePath, 30000, 'Timed out waiting for debugger event.');
+        const breakpoint = await createBreakpointAtResultWriteStatement(sourceUri);
+        const tracker = createTracker(debugType, sessionName, 30000, 'Timed out waiting for debugger event.');
         const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
 
         try {
@@ -260,23 +259,26 @@ suite('Run Without Debugging Integration Test', function (): void {
 
             const lastEvent = await tracker.lastEvent;
             await debugSessionTerminated;
+            const actualResultValue = await waitForResultFileValue(resultFilePath, 10000);
 
             assert.strictEqual(lastEvent, 'exited', 'No-debug launch should exit rather than stop on a breakpoint.');
             assert.strictEqual(tracker.state.setBreakpointsRequestReceived, false, 'a "no debug" session should not send setBreakpoints requests.');
             assert.strictEqual(tracker.state.stoppedEventReceived, false, 'a "no debug" session should not emit stopped events.');
-            assert.strictEqual(tracker.state.actualExitCode, expectedExitCode, 'Unexpected exit code from run without debugging launch.');
+            assert.strictEqual(actualResultValue, expectedResultValue, 'Unexpected result value from run without debugging launch.');
         } finally {
             tracker.dispose();
             vscode.debug.removeBreakpoints([breakpoint]);
+            await util.deleteFile(resultFilePath);
         }
     });
 
     test('Debug launch should bind and stop at the breakpoint', async () => {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
         const workspacePath = workspaceFolder.uri.fsPath;
-        const sourceFile = path.join(workspacePath, 'exitCode.cpp');
+        const sourceFile = path.join(workspacePath, 'debugTest.cpp');
         const sourceUri = vscode.Uri.file(sourceFile);
-        const executableName = isWindows ? 'exitCodeProgram.exe' : 'exitCodeProgram';
+        const resultFilePath = path.join(workspacePath, 'runWithoutDebuggingResult.txt');
+        const executableName = isWindows ? 'debugTestProgram.exe' : 'debugTestProgram';
         const executablePath = path.join(workspacePath, executableName);
         const sessionName = 'Debug Launch Breakpoint Stop';
         const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
@@ -284,10 +286,10 @@ suite('Run Without Debugging Integration Test', function (): void {
 
         await compileProgram(workspacePath, sourceFile, executablePath);
 
-        const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
+        const breakpoint = await createBreakpointAtResultWriteStatement(sourceUri);
 
         let launchedSession: vscode.DebugSession | undefined;
-        const tracker = createTracker(debugType, sessionName, executablePath, 45000, 'Timed out waiting for debugger event in normal debug mode.');
+        const tracker = createTracker(debugType, sessionName, 45000, 'Timed out waiting for debugger event in normal debug mode.');
 
         const startedSubscription = vscode.debug.onDidStartDebugSession((session) => {
             if (session.name === sessionName) {
@@ -331,6 +333,7 @@ suite('Run Without Debugging Integration Test', function (): void {
             startedSubscription.dispose();
             tracker.dispose();
             vscode.debug.removeBreakpoints([breakpoint]);
+            await util.deleteFile(resultFilePath);
         }
     });
 });

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -1,0 +1,305 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../../vscode.d.ts" />
+import * as assert from 'assert';
+import * as cp from 'child_process';
+import { suite } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as util from '../../../../src/common';
+import { isLinux, isMacOS, isWindows } from '../../../../src/constants';
+import { getEffectiveEnvironment } from '../../../../src/LanguageServer/devcmd';
+
+interface ProcessResult {
+    code: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+interface TrackerState {
+    setBreakpointsRequestReceived: boolean;
+    stoppedEventReceived: boolean;
+    exitedEventReceived: boolean;
+    exitedBeforeStop: boolean;
+    actualExitCode?: number;
+}
+
+interface TrackerController {
+    state: TrackerState;
+    lastEvent: Promise<'stopped' | 'exited'>;
+    dispose(): void;
+}
+
+function runProcess(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<ProcessResult> {
+    return new Promise((resolve, reject) => {
+        const child = cp.spawn(command, args, { cwd, env });
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (data: Buffer) => {
+            stdout += data.toString();
+        });
+
+        child.stderr.on('data', (data: Buffer) => {
+            stderr += data.toString();
+        });
+
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+}
+
+async function setWindowsBuildEnvironment(): Promise<void> {
+    const promise = vscode.commands.executeCommand('C_Cpp.SetVsDeveloperEnvironment', 'test');
+    const timer = setInterval(() => {
+        void vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+    }, 1000);
+    await promise;
+    clearInterval(timer);
+    assert.strictEqual(util.hasMsvcEnvironment(), true, 'MSVC environment not set correctly.');
+}
+
+async function compileProgram(workspacePath: string, sourcePath: string, outputPath: string): Promise<void> {
+    if (isWindows) {
+        await setWindowsBuildEnvironment();
+        const env = getEffectiveEnvironment();
+        const result = await runProcess('cl.exe', ['/nologo', '/EHsc', '/Zi', '/std:c++17', `/Fe:${outputPath}`, sourcePath], workspacePath, env);
+        assert.strictEqual(result.code, 0, `MSVC compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    if (isMacOS) {
+        const result = await runProcess('clang++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
+        assert.strictEqual(result.code, 0, `clang++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    if (isLinux) {
+        const result = await runProcess('g++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
+        assert.strictEqual(result.code, 0, `g++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+        return;
+    }
+
+    assert.fail(`Unsupported test platform: ${process.platform}`);
+}
+
+async function createBreakpointAtReturnStatement(sourceUri: vscode.Uri): Promise<vscode.SourceBreakpoint> {
+    const document = await vscode.workspace.openTextDocument(sourceUri);
+    const returnLine = document.getText().split(/\r?\n/).findIndex((line) => line.includes('return 37;'));
+    assert.notStrictEqual(returnLine, -1, 'Unable to find expected return statement for breakpoint placement.');
+    const breakpoint = new vscode.SourceBreakpoint(new vscode.Location(sourceUri, new vscode.Position(returnLine, 0)), true);
+    vscode.debug.addBreakpoints([breakpoint]);
+    return breakpoint;
+}
+
+function createSessionTerminatedPromise(sessionName: string): Promise<void> {
+    return new Promise<void>((resolve) => {
+        const terminateSubscription = vscode.debug.onDidTerminateDebugSession((session) => {
+            if (session.name === sessionName) {
+                terminateSubscription.dispose();
+                resolve();
+            }
+        });
+    });
+}
+
+function createTracker(debugType: string, sessionName: string, timeoutMs: number, timeoutMessage: string): TrackerController {
+    const state: TrackerState = {
+        setBreakpointsRequestReceived: false,
+        stoppedEventReceived: false,
+        exitedEventReceived: false,
+        exitedBeforeStop: false
+    };
+
+    let trackerRegistration: vscode.Disposable | undefined;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+
+    const lastEvent = new Promise<'stopped' | 'exited'>((resolve, reject) => {
+        timeoutHandle = setTimeout(() => {
+            trackerRegistration?.dispose();
+            trackerRegistration = undefined;
+            reject(new Error(timeoutMessage));
+        }, timeoutMs);
+
+        trackerRegistration = vscode.debug.registerDebugAdapterTrackerFactory(debugType, {
+            createDebugAdapterTracker: (session: vscode.DebugSession): vscode.DebugAdapterTracker | undefined => {
+                if (session.name !== sessionName) {
+                    return undefined;
+                }
+
+                return {
+                    onWillReceiveMessage: (message: any): void => {
+                        if (message?.type === 'request' && message?.command === 'setBreakpoints') {
+                            state.setBreakpointsRequestReceived = true;
+                        }
+                    },
+                    onDidSendMessage: (message: any): void => {
+                        if (message?.type !== 'event') {
+                            return;
+                        }
+
+                        if (message.event === 'stopped') {
+                            state.stoppedEventReceived = true;
+                            if (timeoutHandle) {
+                                clearTimeout(timeoutHandle);
+                                timeoutHandle = undefined;
+                            }
+                            resolve('stopped');
+                        }
+
+                        if (message.event === 'exited') {
+                            state.exitedEventReceived = true;
+                            state.actualExitCode = message.body?.exitCode;
+                            if (!state.stoppedEventReceived) {
+                                state.exitedBeforeStop = true;
+                            }
+                            if (timeoutHandle) {
+                                clearTimeout(timeoutHandle);
+                                timeoutHandle = undefined;
+                            }
+                            resolve('exited');
+                        }
+                    }
+                };
+            }
+        });
+    });
+
+    return {
+        state,
+        lastEvent,
+        dispose(): void {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle);
+                timeoutHandle = undefined;
+            }
+            trackerRegistration?.dispose();
+            trackerRegistration = undefined;
+        }
+    };
+}
+
+suite('Run Without Debugging Integration Test', function (): void {
+
+    suiteSetup(async function (): Promise<void> {
+        const extension: vscode.Extension<any> = vscode.extensions.getExtension('ms-vscode.cpptools') || assert.fail('Extension not found');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    suiteTeardown(async function (): Promise<void> {
+        if (isWindows) {
+            await vscode.commands.executeCommand('C_Cpp.ClearVsDeveloperEnvironment');
+        }
+    });
+
+    test('Run Without Debugging should not break on breakpoints and emit expected exit code', async () => {
+        const expectedExitCode = 37;
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
+        const workspacePath = workspaceFolder.uri.fsPath;
+        const sourceFile = path.join(workspacePath, 'exitCode.cpp');
+        const sourceUri = vscode.Uri.file(sourceFile);
+        const executableName = isWindows ? 'exitCodeProgram.exe' : 'exitCodeProgram';
+        const executablePath = path.join(workspacePath, executableName);
+        const sessionName = 'Run Without Debugging Exit Code';
+        const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
+
+        await compileProgram(workspacePath, sourceFile, executablePath);
+
+        const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
+        const tracker = createTracker(debugType, sessionName, 30000, 'Timed out waiting for debugger event.');
+        const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
+
+        try {
+            const started = await vscode.debug.startDebugging(
+                workspaceFolder,
+                {
+                    name: sessionName,
+                    type: debugType,
+                    request: 'launch',
+                    program: executablePath,
+                    args: [],
+                    cwd: workspacePath,
+                    console: 'internalConsole'
+                },
+                { noDebug: true });
+
+            assert.strictEqual(started, true, 'The noDebug launch did not start successfully.');
+
+            const lastEvent = await tracker.lastEvent;
+            await debugSessionTerminated;
+
+            assert.strictEqual(lastEvent, 'exited', 'No-debug launch should exit rather than stop on a breakpoint.');
+            assert.strictEqual(tracker.state.setBreakpointsRequestReceived, false, 'a "no debug" session should not send setBreakpoints requests.');
+            assert.strictEqual(tracker.state.stoppedEventReceived, false, 'a "no debug" session should not emit stopped events.');
+            assert.strictEqual(tracker.state.actualExitCode, expectedExitCode, 'Unexpected exit code from run without debugging launch.');
+        } finally {
+            tracker.dispose();
+            vscode.debug.removeBreakpoints([breakpoint]);
+        }
+    });
+
+    test('Debug launch should bind and stop at the breakpoint', async () => {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
+        const workspacePath = workspaceFolder.uri.fsPath;
+        const sourceFile = path.join(workspacePath, 'exitCode.cpp');
+        const sourceUri = vscode.Uri.file(sourceFile);
+        const executableName = isWindows ? 'exitCodeProgram.exe' : 'exitCodeProgram';
+        const executablePath = path.join(workspacePath, executableName);
+        const sessionName = 'Debug Launch Breakpoint Stop';
+        const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
+
+        await compileProgram(workspacePath, sourceFile, executablePath);
+
+        const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
+
+        let launchedSession: vscode.DebugSession | undefined;
+        const tracker = createTracker(debugType, sessionName, 45000, 'Timed out waiting for debugger event in normal debug mode.');
+
+        const startedSubscription = vscode.debug.onDidStartDebugSession((session) => {
+            if (session.name === sessionName) {
+                launchedSession = session;
+            }
+        });
+
+        const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
+
+        try {
+            const started = await vscode.debug.startDebugging(
+                workspaceFolder,
+                {
+                    name: sessionName,
+                    type: debugType,
+                    request: 'launch',
+                    program: executablePath,
+                    args: [],
+                    cwd: workspacePath,
+                    console: 'internalConsole'
+                },
+                { noDebug: false });
+
+            assert.strictEqual(started, true, 'The debug launch did not start successfully.');
+
+            const lastEvent = await tracker.lastEvent;
+
+            assert.strictEqual(lastEvent, 'stopped', 'Debug launch should stop at the breakpoint before exit.');
+            assert.strictEqual(tracker.state.setBreakpointsRequestReceived, true, 'Debug mode should send setBreakpoints requests.');
+            assert.strictEqual(tracker.state.stoppedEventReceived, true, 'Debug mode should emit a stopped event at the breakpoint.');
+            assert.strictEqual(tracker.state.exitedBeforeStop, false, 'Program exited before stopping at breakpoint in debug mode.');
+            assert.strictEqual(vscode.debug.activeDebugSession?.name, sessionName, 'Debug session should still be active at breakpoint.');
+
+            const stoppedSession = launchedSession ?? vscode.debug.activeDebugSession;
+            assert.ok(stoppedSession, 'Unable to identify the running debug session for termination.');
+            await vscode.debug.stopDebugging(stoppedSession);
+            await debugSessionTerminated;
+        } finally {
+            startedSubscription.dispose();
+            tracker.dispose();
+            vscode.debug.removeBreakpoints([breakpoint]);
+        }
+    });
+});

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -106,7 +106,7 @@ function createSessionTerminatedPromise(sessionName: string): Promise<void> {
     });
 }
 
-function createTracker(debugType: string, sessionName: string, timeoutMs: number, timeoutMessage: string): TrackerController {
+function createTracker(debugType: string, sessionName: string, programName: string, timeoutMs: number, timeoutMessage: string): TrackerController {
     const state: TrackerState = {
         setBreakpointsRequestReceived: false,
         stoppedEventReceived: false,
@@ -148,6 +148,34 @@ function createTracker(debugType: string, sessionName: string, timeoutMs: number
                                 timeoutHandle = undefined;
                             }
                             resolve('stopped');
+                        }
+
+                        // integratedTerminal scenarios may not send an 'exited' event if the terminal does not support shell integration.
+                        // We have to close the terminal with the exit code to get the result.
+                        if (message.event === 'terminated' && !state.exitedEventReceived) {
+                            state.exitedEventReceived = true;
+                            const disp = vscode.window.onDidCloseTerminal((terminal) => {
+                                if (terminal.name === programName) {
+                                    state.exitedEventReceived = true;
+                                    state.actualExitCode = terminal.exitStatus?.code;
+                                    if (!state.stoppedEventReceived) {
+                                        state.exitedBeforeStop = true;
+                                    }
+                                    if (timeoutHandle) {
+                                        clearTimeout(timeoutHandle);
+                                        timeoutHandle = undefined;
+                                    }
+                                    disp.dispose();
+                                    resolve('exited');
+                                }
+                            });
+
+                            vscode.window.terminals.forEach((terminal) => {
+                                if (terminal.name === programName) {
+                                    const exitCommand = isWindows ? 'exit /b %ErrorLevel%' : 'exit $?';
+                                    terminal.sendText(exitCommand);
+                                }
+                            });
                         }
 
                         if (message.event === 'exited') {
@@ -210,7 +238,7 @@ suite('Run Without Debugging Integration Test', function (): void {
         await compileProgram(workspacePath, sourceFile, executablePath);
 
         const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
-        const tracker = createTracker(debugType, sessionName, 30000, 'Timed out waiting for debugger event.');
+        const tracker = createTracker(debugType, sessionName, executablePath, 30000, 'Timed out waiting for debugger event.');
         const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
 
         try {
@@ -259,7 +287,7 @@ suite('Run Without Debugging Integration Test', function (): void {
         const breakpoint = await createBreakpointAtReturnStatement(sourceUri);
 
         let launchedSession: vscode.DebugSession | undefined;
-        const tracker = createTracker(debugType, sessionName, 45000, 'Timed out waiting for debugger event in normal debug mode.');
+        const tracker = createTracker(debugType, sessionName, executablePath, 45000, 'Timed out waiting for debugger event in normal debug mode.');
 
         const startedSubscription = vscode.debug.onDidStartDebugSession((session) => {
             if (session.name === sessionName) {

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -183,7 +183,6 @@ function createTracker(debugType: string, sessionName: string, timeoutMs: number
 }
 
 suite('Run Without Debugging Integration Test', function (): void {
-
     suiteSetup(async function (): Promise<void> {
         const extension: vscode.Extension<any> = vscode.extensions.getExtension('ms-vscode.cpptools') || assert.fail('Extension not found');
         if (!extension.isActive) {
@@ -224,7 +223,8 @@ suite('Run Without Debugging Integration Test', function (): void {
                     program: executablePath,
                     args: [],
                     cwd: workspacePath,
-                    console: 'internalConsole'
+                    externalConsole: debugType === 'cppdbg' ? false : undefined,
+                    console: debugType === 'cppvsdbg' ? 'internalConsole' : undefined
                 },
                 { noDebug: true });
 
@@ -278,7 +278,8 @@ suite('Run Without Debugging Integration Test', function (): void {
                     program: executablePath,
                     args: [],
                     cwd: workspacePath,
-                    console: 'internalConsole'
+                    externalConsole: debugType === 'cppdbg' ? false : undefined,
+                    console: debugType === 'cppvsdbg' ? 'internalConsole' : undefined
                 },
                 { noDebug: false });
 

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.integration.test.ts
@@ -5,19 +5,12 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../../../../vscode.d.ts" />
 import * as assert from 'assert';
-import * as cp from 'child_process';
 import { suite } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as util from '../../../../src/common';
-import { isLinux, isMacOS, isWindows } from '../../../../src/constants';
-import { getEffectiveEnvironment } from '../../../../src/LanguageServer/devcmd';
-
-interface ProcessResult {
-    code: number | null;
-    stdout: string;
-    stderr: string;
-}
+import { isMacOS, isWindows } from '../../../../src/constants';
+import { compileProgram } from './compileProgram';
 
 interface TrackerState {
     setBreakpointsRequestReceived: boolean;
@@ -30,60 +23,6 @@ interface TrackerController {
     state: TrackerState;
     lastEvent: Promise<'stopped' | 'exited'>;
     dispose(): void;
-}
-
-function runProcess(command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<ProcessResult> {
-    return new Promise((resolve, reject) => {
-        const child = cp.spawn(command, args, { cwd, env });
-        let stdout = '';
-        let stderr = '';
-
-        child.stdout.on('data', (data: Buffer) => {
-            stdout += data.toString();
-        });
-
-        child.stderr.on('data', (data: Buffer) => {
-            stderr += data.toString();
-        });
-
-        child.on('error', reject);
-        child.on('close', (code) => resolve({ code, stdout, stderr }));
-    });
-}
-
-async function setWindowsBuildEnvironment(): Promise<void> {
-    const promise = vscode.commands.executeCommand('C_Cpp.SetVsDeveloperEnvironment', 'test');
-    const timer = setInterval(() => {
-        void vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
-    }, 1000);
-    await promise;
-    clearInterval(timer);
-    const missingVars = util.getMissingMsvcEnvironmentVariables();
-    assert.strictEqual(missingVars.length, 0, `MSVC environment missing: ${missingVars.join(', ')}`);
-}
-
-async function compileProgram(workspacePath: string, sourcePath: string, outputPath: string): Promise<void> {
-    if (isWindows) {
-        await setWindowsBuildEnvironment();
-        const env = getEffectiveEnvironment();
-        const result = await runProcess('cl.exe', ['/nologo', '/EHsc', '/Zi', '/std:c++17', `/Fe:${outputPath}`, sourcePath], workspacePath, env);
-        assert.strictEqual(result.code, 0, `MSVC compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
-        return;
-    }
-
-    if (isMacOS) {
-        const result = await runProcess('clang++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
-        assert.strictEqual(result.code, 0, `clang++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
-        return;
-    }
-
-    if (isLinux) {
-        const result = await runProcess('g++', ['-std=c++17', '-g', sourcePath, '-o', outputPath], workspacePath);
-        assert.strictEqual(result.code, 0, `g++ compilation failed. stdout: ${result.stdout}\nstderr: ${result.stderr}`);
-        return;
-    }
-
-    assert.fail(`Unsupported test platform: ${process.platform}`);
 }
 
 async function createBreakpointAtResultWriteStatement(sourceUri: vscode.Uri): Promise<vscode.SourceBreakpoint> {
@@ -207,12 +146,25 @@ async function waitForResultFileValue(filePath: string, timeoutMs: number): Prom
     assert.fail(`Timed out waiting for numeric result in ${filePath}. Last contents: ${lastContents}`);
 }
 
-suite('Run Without Debugging Integration Test', function (): void {
+suite('Run Without Debugging Test', function (): void {
+    const expectedResultValue = 37;
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
+    const workspacePath = workspaceFolder.uri.fsPath;
+    const sourceFile = path.join(workspacePath, 'debugTest.cpp');
+    const sourceUri = vscode.Uri.file(sourceFile);
+    const resultFilePath = path.join(workspacePath, 'runWithoutDebuggingResult.txt');
+    const executableName = isWindows ? 'debugTestProgram.exe' : 'debugTestProgram';
+    const executablePath = path.join(workspacePath, executableName);
+    const sessionName = 'Run Without Debugging Result File';
+    const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
+    const miMode = isMacOS ? 'lldb' : 'gdb';
+
     suiteSetup(async function (): Promise<void> {
         const extension: vscode.Extension<any> = vscode.extensions.getExtension('ms-vscode.cpptools') || assert.fail('Extension not found');
         if (!extension.isActive) {
             await extension.activate();
         }
+        await compileProgram(workspacePath, sourceFile, executablePath);
     });
 
     suiteTeardown(async function (): Promise<void> {
@@ -221,21 +173,11 @@ suite('Run Without Debugging Integration Test', function (): void {
         }
     });
 
-    test('Run Without Debugging should not break on breakpoints and write the expected result file', async () => {
-        const expectedResultValue = 37;
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
-        const workspacePath = workspaceFolder.uri.fsPath;
-        const sourceFile = path.join(workspacePath, 'debugTest.cpp');
-        const sourceUri = vscode.Uri.file(sourceFile);
-        const resultFilePath = path.join(workspacePath, 'runWithoutDebuggingResult.txt');
-        const executableName = isWindows ? 'debugTestProgram.exe' : 'debugTestProgram';
-        const executablePath = path.join(workspacePath, executableName);
-        const sessionName = 'Run Without Debugging Result File';
-        const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
-
+    setup(async function (): Promise<void> {
         await util.deleteFile(resultFilePath);
-        await compileProgram(workspacePath, sourceFile, executablePath);
+    });
 
+    test('Run Without Debugging should not break on breakpoints and write the expected result file', async () => {
         const breakpoint = await createBreakpointAtResultWriteStatement(sourceUri);
         const tracker = createTracker(debugType, sessionName, 30000, 'Timed out waiting for debugger event.');
         const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
@@ -273,31 +215,16 @@ suite('Run Without Debugging Integration Test', function (): void {
     });
 
     test('Debug launch should bind and stop at the breakpoint', async () => {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
-        const workspacePath = workspaceFolder.uri.fsPath;
-        const sourceFile = path.join(workspacePath, 'debugTest.cpp');
-        const sourceUri = vscode.Uri.file(sourceFile);
-        const resultFilePath = path.join(workspacePath, 'runWithoutDebuggingResult.txt');
-        const executableName = isWindows ? 'debugTestProgram.exe' : 'debugTestProgram';
-        const executablePath = path.join(workspacePath, executableName);
-        const sessionName = 'Debug Launch Breakpoint Stop';
-        const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
-        const miMode = isMacOS ? 'lldb' : 'gdb';
-
-        await compileProgram(workspacePath, sourceFile, executablePath);
-
         const breakpoint = await createBreakpointAtResultWriteStatement(sourceUri);
+        const tracker = createTracker(debugType, sessionName, 30000, 'Timed out waiting for debugger event in normal debug mode.');
+        const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
 
         let launchedSession: vscode.DebugSession | undefined;
-        const tracker = createTracker(debugType, sessionName, 45000, 'Timed out waiting for debugger event in normal debug mode.');
-
         const startedSubscription = vscode.debug.onDidStartDebugSession((session) => {
             if (session.name === sessionName) {
                 launchedSession = session;
             }
         });
-
-        const debugSessionTerminated = createSessionTerminatedPromise(sessionName);
 
         try {
             const started = await vscode.debug.startDebugging(
@@ -336,4 +263,5 @@ suite('Run Without Debugging Integration Test', function (): void {
             await util.deleteFile(resultFilePath);
         }
     });
+
 });

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.terminals.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.terminals.test.ts
@@ -1,0 +1,188 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="../../../../vscode.d.ts" />
+import * as assert from 'assert';
+import { suite } from 'mocha';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as util from '../../../../src/common';
+import { isWindows } from '../../../../src/constants';
+import { compileProgram } from './compileProgram';
+
+type ConsoleMode = 'integratedTerminal' | 'externalTerminal';
+type WindowsTerminalProfile = 'Command Prompt' | 'PowerShell';
+
+/**
+ * Waits for the output of a program to be written to a file and returns the lines of output.
+ * @param filePath The path to the file containing the program output.
+ * @param timeoutMs The maximum time to wait for the output, in milliseconds.
+ * @returns A promise that resolves to an array of output lines.
+ * @throws An error if the output is not available within the specified timeout.
+ */
+async function waitForOutput(filePath: string, timeoutMs: number): Promise<string[]> {
+    const deadline = Date.now() + timeoutMs;
+    let lastContents = '';
+
+    while (Date.now() < deadline) {
+        try {
+            lastContents = await util.readFileText(filePath, 'utf8');
+            const trimmedContents = lastContents.trimEnd();
+            if (trimmedContents.length > 0) {
+                return trimmedContents.split(/\r?\n/);
+            }
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw error;
+            }
+        }
+
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+    }
+
+    assert.fail(`Timed out waiting for argument output in ${filePath}. Last contents: ${lastContents}`);
+}
+
+/**
+ * Disposes of any terminals whose names match the given program paths. These are the terminals that were created to run the specified programs.
+ * @param programs An array of program paths whose corresponding terminals should be disposed.
+ */
+function disposeTerminals(programs: string[]): void {
+    const terminalNames = new Set(programs.map(program => path.normalize(program)));
+    for (const terminal of vscode.window.terminals) {
+        if (terminalNames.has(terminal.name)) {
+            terminal.dispose();
+        }
+    }
+}
+
+async function setWindowsDefaultTerminalProfile(profile?: WindowsTerminalProfile): Promise<void> {
+    if (!isWindows) {
+        return;
+    }
+
+    const config = vscode.workspace.getConfiguration('terminal.integrated');
+    await config.update('defaultProfile.windows', profile, vscode.ConfigurationTarget.Workspace);
+}
+
+async function runNoDebugLaunch(workspaceFolder: vscode.WorkspaceFolder, sessionName: string, program: string, consoleMode: ConsoleMode, resultFilePath: string, args: string[]): Promise<string[]> {
+    const debugType = isWindows ? 'cppvsdbg' : 'cppdbg';
+    const launchConfig: vscode.DebugConfiguration = {
+        name: sessionName,
+        type: debugType,
+        request: 'launch',
+        program: program,
+        args: [resultFilePath, ...args],
+        cwd: workspaceFolder.uri.fsPath
+    };
+
+    if (debugType === 'cppvsdbg') {
+        launchConfig.console = consoleMode;
+    } else {
+        launchConfig.externalConsole = consoleMode === 'externalTerminal';
+    }
+
+    const started = await vscode.debug.startDebugging(workspaceFolder, launchConfig, { noDebug: true });
+    assert.strictEqual(started, true, `The ${consoleMode} noDebug launch did not start successfully.`);
+    return waitForOutput(resultFilePath, 15000);
+}
+
+suite('Run Without Debugging Terminal and Arguments Test', function (this: Mocha.Suite): void {
+    this.timeout(120000);
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? assert.fail('No workspace folder available');
+    const workspacePath = workspaceFolder.uri.fsPath;
+    const sourceFile = path.join(workspacePath, 'argsTest.cpp');
+    const resultFilePath = path.join(workspacePath, 'test_output.txt');
+    const executablePath = path.join(workspacePath, isWindows ? 'argsTestProgram.exe' : 'argsTestProgram');
+    const spacedExecutablePath = path.join(workspacePath, isWindows ? 'args Test Program.exe' : 'args Test Program');
+    const executablePaths = [executablePath, spacedExecutablePath];
+    const expectedArgs = [
+        'alpha',
+        'two words',
+        path.join(workspacePath, 'input folder', 'three words.txt')
+    ];
+
+    suiteSetup(async function (): Promise<void> {
+        const extension: vscode.Extension<any> = vscode.extensions.getExtension('ms-vscode.cpptools') || assert.fail('Extension not found');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+
+        await compileProgram(workspacePath, sourceFile, executablePath);
+        await compileProgram(workspacePath, sourceFile, spacedExecutablePath);
+    });
+
+    teardown(async function (): Promise<void> {
+        await util.deleteFile(resultFilePath);
+        disposeTerminals(executablePaths);
+    });
+
+    setup(async function (): Promise<void> {
+        if (await util.checkFileExists(resultFilePath)) {
+            await util.deleteFile(resultFilePath);
+        }
+    });
+
+    suiteTeardown(async function (): Promise<void> {
+        await util.deleteFile(resultFilePath);
+        disposeTerminals(executablePaths);
+
+        if (isWindows) {
+            await vscode.commands.executeCommand('C_Cpp.ClearVsDeveloperEnvironment');
+            await util.deleteFile(path.join(workspacePath, '.vscode', 'settings.json'));
+        }
+    });
+
+    const consoleCases: { label: string; consoleMode: ConsoleMode; windowsProfiles?: WindowsTerminalProfile[] }[] = [
+        {
+            label: 'integrated terminal',
+            consoleMode: 'integratedTerminal',
+            windowsProfiles: ['Command Prompt', 'PowerShell']
+        },
+        {
+            label: 'external terminal',
+            consoleMode: 'externalTerminal'
+        }
+    ];
+
+    const programCases = [
+        {
+            label: 'a program name without spaces',
+            programPath: executablePath
+        },
+        {
+            label: 'a program name with spaces',
+            programPath: spacedExecutablePath
+        }
+    ];
+
+    for (const consoleCase of consoleCases) {
+        for (const programCase of programCases) {
+            const profiles: (WindowsTerminalProfile | undefined)[] = isWindows && consoleCase.consoleMode === 'integratedTerminal' ? consoleCase.windowsProfiles ?? [undefined] : [undefined];
+
+            for (const profile of profiles) {
+                const profileSuffix = profile ? ` with ${profile} as the default terminal` : '';
+                test(`No-debug launch via ${consoleCase.label} handles ${programCase.label}${profileSuffix}`, async () => {
+                    if (profile) {
+                        await setWindowsDefaultTerminalProfile(profile);
+                    }
+
+                    disposeTerminals(executablePaths);
+                    const sessionName = `Run Without Debugging Args (${consoleCase.consoleMode}, ${path.basename(programCase.programPath)}${profile ? `, ${profile}` : ''})`;
+                    const actualArgs = await runNoDebugLaunch(
+                        workspaceFolder,
+                        sessionName,
+                        programCase.programPath,
+                        consoleCase.consoleMode,
+                        resultFilePath,
+                        expectedArgs);
+
+                    assert.deepStrictEqual(actualArgs, expectedArgs, `Unexpected arguments received for ${consoleCase.label} using ${programCase.label}${profileSuffix}.`);
+                });
+            }
+        }
+    }
+});

--- a/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.terminals.test.ts
+++ b/Extension/test/scenarios/RunWithoutDebugging/tests/runWithoutDebugging.terminals.test.ts
@@ -58,6 +58,10 @@ function disposeTerminals(programs: string[]): void {
     }
 }
 
+/**
+ * Sets or clears the setting for the default Windows terminal profile.
+ * @param profile The terminal profile to set as the default, or undefined to clear the setting.
+ */
 async function setWindowsDefaultTerminalProfile(profile?: WindowsTerminalProfile): Promise<void> {
     if (!isWindows) {
         return;
@@ -136,11 +140,11 @@ suite('Run Without Debugging Terminal and Arguments Test', function (this: Mocha
         }
     });
 
-    const consoleCases: { label: string; consoleMode: ConsoleMode; windowsProfiles?: WindowsTerminalProfile[] }[] = [
+    const consoleCases: { label: string; consoleMode: ConsoleMode; windowsProfiles?: (WindowsTerminalProfile | undefined)[] }[] = [
         {
             label: 'integrated terminal',
             consoleMode: 'integratedTerminal',
-            windowsProfiles: ['Command Prompt', 'PowerShell']
+            windowsProfiles: [undefined, 'Command Prompt', 'PowerShell']
         },
         {
             label: 'external terminal',
@@ -164,11 +168,9 @@ suite('Run Without Debugging Terminal and Arguments Test', function (this: Mocha
             const profiles: (WindowsTerminalProfile | undefined)[] = isWindows && consoleCase.consoleMode === 'integratedTerminal' ? consoleCase.windowsProfiles ?? [undefined] : [undefined];
 
             for (const profile of profiles) {
-                const profileSuffix = profile ? ` with ${profile} as the default terminal` : '';
+                const profileSuffix = profile ? ` with ${profile} as the default terminal` : consoleCase.consoleMode === 'integratedTerminal' ? ' with default terminal' : '';
                 test(`No-debug launch via ${consoleCase.label} handles ${programCase.label}${profileSuffix}`, async () => {
-                    if (profile) {
-                        await setWindowsDefaultTerminalProfile(profile);
-                    }
+                    await setWindowsDefaultTerminalProfile(profile);
 
                     disposeTerminals(executablePaths);
                     const sessionName = `Run Without Debugging Args (${consoleCase.consoleMode}, ${path.basename(programCase.programPath)}${profile ? `, ${profile}` : ''})`;


### PR DESCRIPTION
Fixes: #1201

Supports both the Play button in the editor (run active file) and configurations specified in launch.json.  macOS support needs to be tested - I don't currently have access to a machine.

*Co-authored by GitHub Copilot*