### PR TITLE
Fix cg.yml.

### DIFF
--- a/Build/cg/cg.yml
+++ b/Build/cg/cg.yml
@@ -107,12 +107,8 @@ extends:
               fi
           retryCountOnTaskFailure: 3
 
-        - script: npm install --no-save --ignore-scripts=false --include=optional --force @vscode/vsce@3.7.1
-          displayName: Install vsce
-          workingDirectory: $(Build.SourcesDirectory)\Extension
-
-        - script: npm rebuild @vscode/vsce-sign --ignore-scripts=false
-          displayName: Rebuild vsce-sign binary
+        - script: yarn install --frozen-lockfile
+          displayName: Install dependencies with yarn
           workingDirectory: $(Build.SourcesDirectory)\Extension
 
         - script: if not exist node_modules\@vscode\vsce-sign\bin\vsce-sign.exe (echo Missing vsce-sign.exe && exit 1)


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-cpptools/pull/14354 .

It was bypassing the yarn.lock (package.json dependency overrides)l.