### PR TITLE
UCRTVersion is not required for a developer environment

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -1549,7 +1549,6 @@ export function hasMsvcEnvironment(): boolean {
         'INCLUDE',
         'LIB',
         'LIBPATH',
-        'UCRTVersion',
         'UniversalCRTSdkDir',
         'VCIDEInstallDir',
         'VCINSTALLDIR',


### PR DESCRIPTION
Fixes: #14352

The Windows 8.1 SDK does not set this variable, so it is not strictly required.