### PR TITLE
Fallback to GPT-5.4-mini and cache the model used.

### DIFF
--- a/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
@@ -43,7 +43,7 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
         if (vscodelm) {
             try {
                 let model: vscode.LanguageModelChat | undefined;
-                if (this.chatModelId == undefined) {
+                if (this.chatModelId === undefined) {
                     // First look for GPT-4o which should be available to all
                     // users and have a 0x multiplier on paid plans.
                     // GPT-4o is faster than the x0 GPT-5-mini (which seems too slow for hover, e.g. 10+ seconds).

--- a/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
+++ b/Extension/src/LanguageServer/Providers/CopilotHoverProvider.ts
@@ -27,6 +27,7 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
     private cancelledPosition: vscode.Position | undefined;
     private content: string | undefined;
     private chatModel: vscode.LanguageModelChat | undefined;
+    private chatModelId: string | undefined; // Save the selected model ID to avoid trying the same unavailable model repeatedly.
     // Flag to avoid querying the LanguageModelChat repeatedly if no model is found
     private checkedChatModel: boolean = false;
     constructor(client: DefaultClient) {
@@ -41,13 +42,29 @@ export class CopilotHoverProvider implements vscode.HoverProvider {
         const vscodelm = getVSCodeLanguageModel();
         if (vscodelm) {
             try {
-                // First look for GPT-4o which should be available to all
-                // users and have a 0x multiplier on paid plans.
-                // GTP-4o is faster than GPT-5-mini (which seems too slow for hover, e.g. 10+ seconds).
-                let [model] = await vscodelm.selectChatModels({ ...modelSelector, id: 'gpt-4o' });
-                if (!model) {
-                    // If GPT-4o is not available, fall back to the first available model.
-                    [model] = await vscodelm.selectChatModels(modelSelector);
+                let model: vscode.LanguageModelChat | undefined;
+                if (this.chatModelId == undefined) {
+                    // First look for GPT-4o which should be available to all
+                    // users and have a 0x multiplier on paid plans.
+                    // GPT-4o is faster than the x0 GPT-5-mini (which seems too slow for hover, e.g. 10+ seconds).
+                    this.chatModelId = 'gpt-4o';
+                    [model] = await vscodelm.selectChatModels({ ...modelSelector, id: this.chatModelId });
+                    if (!model) {
+                        // If GPT-4o is not available, fallback to GPT-5.4-mini (x0.33 and fast).
+                        this.chatModelId = 'gpt-5.4-mini';
+                        [model] = await vscodelm.selectChatModels({ ...modelSelector, id: this.chatModelId });
+                    }
+                    if (!model) {
+                        // If GPT-5.4-mini is not available, fallback to the first available model.
+                        this.chatModelId = 'default';
+                        [model] = await vscodelm.selectChatModels(modelSelector);
+                    }
+                } else {
+                    if (this.chatModelId === 'default') {
+                        [model] = await vscodelm.selectChatModels(modelSelector);
+                    } else {
+                        [model] = await vscodelm.selectChatModels({ ...modelSelector, id: this.chatModelId });
+                    }
                 }
                 if (!model) {
                     telemetry.logLanguageServerEvent('CopilotHoverNoModelSelected', { remoteName: vscode.env.remoteName || 'local' });


### PR DESCRIPTION
Follow up to https://github.com/microsoft/vscode-cpptools/pull/14364 .

Fallback to GPT-5.4-mini for when GPT-4o is no longer available, and also cache the model selected to avoid repeatedly trying to use an unavailable model.
