### PR TITLE
Set context flag for when C++ language server is activated

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -275,6 +275,7 @@ export async function activate(): Promise<void> {
     }
 
     await registerRelatedFilesProvider();
+    await vscode.commands.executeCommand('setContext', 'cpptools.languageServerActivated', true);
 }
 
 export function updateLanguageConfigurations(): void {


### PR DESCRIPTION
The primary purpose of this is for this flag to be consumed by the C++ devtools extensions. This way the C++ specific Copilot tools will only appear in tools list and register when the C++ language server is actually activated.