### PR TITLE
Fix stuck "Find All References" progress notifications on overlapping requests

### DIFF
--- a/Extension/src/LanguageServer/references.ts
+++ b/Extension/src/LanguageServer/references.ts
@@ -346,6 +346,7 @@ export class ReferencesManager {
     }
 
     private handleProgressStarted(referencesProgress: ReferencesProgress): void {
+        this.resetProgressBar();
         this.referencesStartedWhileTagParsing = this.client.IsTagParsing;
 
         let mode: ReferencesCommandMode = ReferencesCommandMode.None;
@@ -436,18 +437,18 @@ export class ReferencesManager {
     public resetProgressBar(): void {
         if (this.referencesDelayProgress) {
             clearInterval(this.referencesDelayProgress);
+            this.referencesDelayProgress = undefined;
         }
         if (this.currentUpdateProgressTimer) {
-            if (this.currentUpdateProgressTimer) {
-                clearInterval(this.currentUpdateProgressTimer);
-            }
-            if (this.currentUpdateProgressResolve) {
-                this.currentUpdateProgressResolve(undefined);
-            }
-            this.currentUpdateProgressResolve = undefined;
+            clearInterval(this.currentUpdateProgressTimer);
             this.currentUpdateProgressTimer = undefined;
         }
+        if (this.currentUpdateProgressResolve) {
+            this.currentUpdateProgressResolve(undefined);
+            this.currentUpdateProgressResolve = undefined;
+        }
         this.referencesProgressBarStartTime = 0;
+        this.referencesCurrentProgress = undefined;
     }
 
     public startRename(): void {


### PR DESCRIPTION
Closes #14381

Fixed a regression where overlapping "Find All References" requests (e.g., from DevTools) caused notifications to get stuck.
The fix ensures ReferencesManager properly clears previous timers and resolves active promises before starting a new request, preventing orphaned background loops. Verified via simulation.