### PR TITLE
bump xmldom version by updating plist dependency

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6876,7 +6876,7 @@
         "node-stream-zip": "^1.15.0",
         "node-vcvarsall": "^1.2.0",
         "node-vswhere": "^1.0.2",
-        "plist": "^3.1.0",
+        "plist": "^5.0.0",
         "posix-getopt": "^1.2.1",
         "shell-quote": "1.8.2",
         "ssh-config": "^4.4.4",

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -6876,7 +6876,7 @@
         "node-stream-zip": "^1.15.0",
         "node-vcvarsall": "^1.2.0",
         "node-vswhere": "^1.0.2",
-        "plist": "^5.0.0",
+        "plist": "^3.1.1",
         "posix-getopt": "^1.2.1",
         "shell-quote": "1.8.2",
         "ssh-config": "^4.4.4",

--- a/Extension/src/platform.ts
+++ b/Extension/src/platform.ts
@@ -71,11 +71,15 @@ export class PlatformInformation {
 
         if (util.checkFileExistsSync(DARWIN_SYSTEM_VERSION_PLIST)) {
             const systemVersionPListBuffer: Buffer = fs.readFileSync(DARWIN_SYSTEM_VERSION_PLIST);
-            const systemVersionData: any = plist.parse(systemVersionPListBuffer.toString());
-            if (systemVersionData) {
-                productDarwinVersion = systemVersionData.ProductVersion;
-            } else {
-                errorMessage = localize("missing.plist.productversion", "Could not get ProduceVersion from SystemVersion.plist");
+            try {
+                const systemVersionData: any = plist.parse(systemVersionPListBuffer.toString());
+                if (systemVersionData) {
+                    productDarwinVersion = systemVersionData.ProductVersion;
+                } else {
+                    errorMessage = localize("missing.plist.productversion", "Could not get ProduceVersion from SystemVersion.plist");
+                }
+            } catch (error) {
+                errorMessage = localize("plist.parse.error", "Failed to parse SystemVersion.plist: {0}", (error as Error).message);
             }
         } else {
             errorMessage = localize("missing.darwin.systemversion.file", "Failed to find SystemVersion.plist in {0}.", DARWIN_SYSTEM_VERSION_PLIST);

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1686,7 +1686,7 @@ bare-events@^2.7.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
   integrity sha1-ez4QvY4fyA2vOLtRaSFnj1ZquJ8=
 
-base64-js@^1.3.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
@@ -4990,12 +4990,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-plist@^5.0.0:
-  version "5.0.0"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/plist/-/plist-5.0.0.tgz#a0a0db9d31667d43e11a4b8e3795af4d76bc0804"
-  integrity sha1-oKDbnTFmfUPhGkuON5WvTXa8CAQ=
+plist@^3.1.1:
+  version "3.1.1"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/plist/-/plist-3.1.1.tgz#fa6099e1e3cf6ea180258ebe6378ea3878c2c841"
+  integrity sha1-+mCZ4ePPbqGAJY6+Y3jqOHjCyEE=
   dependencies:
     "@xmldom/xmldom" "^0.9.10"
+    base64-js "^1.5.1"
     xmlbuilder "^15.1.1"
 
 plugin-error@^1.0.1:

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1309,10 +1309,10 @@
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha1-Ml20I5XNSf5sFAV/mpAOQn34gQ4=
 
-"@xmldom/xmldom@^0.8.8":
-  version "0.8.13"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
-  integrity sha1-ANHdlAshjf8uSTCdQQ2LshIVkiU=
+"@xmldom/xmldom@^0.9.10":
+  version "0.9.10"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@xmldom/xmldom/-/xmldom-0.9.10.tgz#a0ad5a26fe8aa996310870726e1704977f769dee"
+  integrity sha1-oK1aJv6KqZYxCHBybhcEl392ne4=
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -1686,7 +1686,7 @@ bare-events@^2.7.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
   integrity sha1-ez4QvY4fyA2vOLtRaSFnj1ZquJ8=
 
-base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=
@@ -4990,13 +4990,12 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-plist@^3.1.0:
-  version "3.1.0"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/plist/-/plist-3.1.0.tgz#797a516a93e62f5bde55e0b9cc9c967f860893c9"
-  integrity sha1-eXpRapPmL1veVeC5zJyWf4YIk8k=
+plist@^5.0.0:
+  version "5.0.0"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/plist/-/plist-5.0.0.tgz#a0a0db9d31667d43e11a4b8e3795af4d76bc0804"
+  integrity sha1-oKDbnTFmfUPhGkuON5WvTXa8CAQ=
   dependencies:
-    "@xmldom/xmldom" "^0.8.8"
-    base64-js "^1.5.1"
+    "@xmldom/xmldom" "^0.9.10"
     xmlbuilder "^15.1.1"
 
 plugin-error@^1.0.1:


### PR DESCRIPTION
CVE-2026-41675 wants us to update `xmldom`. It is only used by `plist` and updating that module updates the other one.

Also adding a try/catch in the code because `plist.parse` can throw.