### PR TITLE
Set debuginfod.enable to false

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -4372,7 +4372,7 @@
                                     "enabled": {
                                         "type": "boolean",
                                         "description": "%c_cpp.debuggers.debuginfod.enabled.description%",
-                                        "default": true
+                                        "default": false
                                     },
                                     "timeout": {
                                         "type": "integer",
@@ -4990,7 +4990,7 @@
                                     "enabled": {
                                         "type": "boolean",
                                         "description": "%c_cpp.debuggers.debuginfod.enabled.description%",
-                                        "default": true
+                                        "default": false
                                     },
                                     "timeout": {
                                         "type": "integer",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -1012,7 +1012,7 @@
     "c_cpp.debuggers.symbolOptions.description": "Options to control how symbols (.pdb files) are found and loaded.",
     "c_cpp.debuggers.unknownBreakpointHandling.description": "Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit.\nAllowed values are \"throw\", which acts as if an exception was thrown by the application, and \"stop\", which only pauses the debug session. The default value is \"throw\".",
     "c_cpp.debuggers.debuginfod.description": "Controls GDB's debuginfod behavior for downloading debug symbols from debuginfod servers.",
-    "c_cpp.debuggers.debuginfod.enabled.description": "If true (default), GDB's debuginfod support is enabled. Set to false to prevent GDB from contacting debuginfod servers.",
+    "c_cpp.debuggers.debuginfod.enabled.description": "If false (default), GDB will not contact debuginfod servers. Set to true to enable debuginfod support.",
     "c_cpp.debuggers.debuginfod.timeout.description": "The timeout in seconds for debuginfod server requests. Default is 30. Set to 0 to use GDB/libdebuginfod defaults (no override).",
     "c_cpp.debuggers.VSSymbolOptions.description": "Provides configuration for locating and loading symbols to the debug adapter.",
     "c_cpp.debuggers.VSSymbolOptions.searchPaths.description": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -246,7 +246,7 @@
         "enabled": {
           "type": "boolean",
           "description": "%c_cpp.debuggers.debuginfod.enabled.description%",
-          "default": true
+          "default": false
         },
         "timeout": {
           "type": "integer",


### PR DESCRIPTION
Making debuginfod.enable to false by default instead of enabled. 