### PR TITLE
get OptionsSchema.json back in sync with package.json

### DIFF
--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -856,11 +856,6 @@
         "program"
       ],
       "properties": {
-        "program": {
-          "type": "string",
-          "description": "%c_cpp.debuggers.program.description%",
-          "default": "${workspaceRoot}/a.out"
-        },
         "targetArchitecture": {
           "type": "string",
           "description": "%c_cpp.debuggers.targetArchitecture.description%",
@@ -905,6 +900,10 @@
           "type": "boolean",
           "description": "%c_cpp.debuggers.useExtendedRemote.description%",
           "default": false
+        },
+        "program": {
+          "type": "string",
+          "markdownDescription": "%c_cpp.debuggers.program.attach.markdownDescription%"
         },
         "processId": {
           "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",
@@ -1123,14 +1122,16 @@
     "CppvsdbgAttachOptions": {
       "type": "object",
       "default": {},
-      "required": [
-        "processId"
-      ],
+      "required": [],
       "properties": {
         "symbolSearchPath": {
           "type": "string",
           "description": "%c_cpp.debuggers.symbolSearchPath.description%",
           "default": ""
+        },
+        "program": {
+          "type": "string",
+          "markdownDescription": "%c_cpp.debuggers.program.attach.markdownDescription%"
         },
         "processId": {
           "markdownDescription": "%c_cpp.debuggers.processId.anyOf.markdownDescription%",

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -192,7 +192,6 @@
     },
     "SourceFileMapEntry": {
       "type": "object",
-      "description": "%c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description%",
       "default": {
         "<source-path>": {
           "editorPath": "",


### PR DESCRIPTION
Two changes for the debugger were made directly to package.json without a matching OptionsSchema.json update so I got a surprise when generating it for my last change.

This PR gets it back in sync.