### PR TITLE
Substitute `${env:X}` with an empty string for unset environment variables

### DIFF
--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -400,13 +400,11 @@ export function resolveVariables(input: string | undefined, additionalEnvironmen
     while (!cycleCache.has(ret)) {
         cycleCache.add(ret);
         ret = ret.replace(regexp(), (match: string, ignored1: string, varType: string, ignored2: string, name: string) => {
-            // Historically, if the variable didn't have anything before the "." or ":"
-            // it was assumed to be an environment variable
-            if (!varType) {
-                varType = "env";
-            }
             let newValue: string | undefined;
             switch (varType) {
+                // Historically, if the variable didn't have anything before the "." or ":"
+                // it was assumed to be an environment variable
+                case undefined:
                 case "env": {
                     if (additionalEnvironment) {
                         const v: string | string[] | undefined = additionalEnvironment[name];
@@ -424,6 +422,12 @@ export function resolveVariables(input: string | undefined, additionalEnvironmen
                     }
                     if (newValue === undefined) {
                         newValue = process.env[name];
+                    }
+
+                    // If the environment variable is not set, we return an empty string. Only do
+                    // this for ${env:X} variables, not ${X} variables.
+                    if (newValue === undefined && varType !== undefined) {
+                        newValue = "";
                     }
                     break;
                 }

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -399,7 +399,7 @@ export function resolveVariables(input: string | undefined, additionalEnvironmen
     const cycleCache = new Set<string>();
     while (!cycleCache.has(ret)) {
         cycleCache.add(ret);
-        ret = ret.replace(regexp(), (match: string, ignored1: string, varType: string, ignored2: string, name: string) => {
+        ret = ret.replace(regexp(), (match: string, ignored1: string | undefined, varType: string | undefined, ignored2: string | undefined, name: string) => {
             let newValue: string | undefined;
             switch (varType) {
                 // Historically, if the variable didn't have anything before the "." or ":"

--- a/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
@@ -199,16 +199,21 @@ suite("resolveVariables", () => {
             .shouldLookupSymbol("Root");
     });
 
-    test("${env:UNDEFINED_ENV_VAR} expands to empty", () => {
-        resolveVariablesWithInput("${env:UNDEFINED_ENV_VAR}")
+    test("${env:X} expands to empty when unset", () => {
+        const processKey: string = `cpptoolstests_unset_${Date.now()}`;
+        delete process.env[processKey];
+        resolveVariablesWithInput("${env:" + processKey + "}")
             .withEnvironment({})
             .shouldResolveTo("");
     });
 
-    test("${UNDEFINED_ENV_VAR} left unexpanded", () => {
-        resolveVariablesWithInput("${UNDEFINED_ENV_VAR}")
+    test("${X} left unexpanded when unset", () => {
+        const processKey: string = `cpptoolstests_unset_${Date.now()}`;
+        delete process.env[processKey];
+        const token: string = "${" + processKey + "}";
+        resolveVariablesWithInput(token)
             .withEnvironment({})
-            .shouldResolveTo("${UNDEFINED_ENV_VAR}");
+            .shouldResolveTo(token);
     });
 
     test("escapeForSquiggles:", () => {

--- a/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/common.test.ts
@@ -199,6 +199,18 @@ suite("resolveVariables", () => {
             .shouldLookupSymbol("Root");
     });
 
+    test("${env:UNDEFINED_ENV_VAR} expands to empty", () => {
+        resolveVariablesWithInput("${env:UNDEFINED_ENV_VAR}")
+            .withEnvironment({})
+            .shouldResolveTo("");
+    });
+
+    test("${UNDEFINED_ENV_VAR} left unexpanded", () => {
+        resolveVariablesWithInput("${UNDEFINED_ENV_VAR}")
+            .withEnvironment({})
+            .shouldResolveTo("${UNDEFINED_ENV_VAR}");
+    });
+
     test("escapeForSquiggles:", () => {
         const testEscapeForSquigglesScenario: any = (input: string, expectedOutput: string) => {
             const result: string = escapeForSquiggles(input);


### PR DESCRIPTION
Change how `${env:X}` (and `${env.X}`) blocks are handled so that if the variable `X` is not set, the block is replaced with an empty string, rather than the existing behavior of leaving the entire `${env:X}` block unsubstituted.

1. This makes this extension consistent with the behavior of VSCode itself, which substitutes an empty string for unset environment variables:

<details>

<summary>VSCode behavior examples</summary>

VSCode's behavior is not really documented (their [variable reference](https://code.visualstudio.com/docs/reference/variables-reference#_environment-variables) page doesn't say anything about what happens when an env var is unset). However there are a number of ways it can be observed while using VSCode.

#### Example 1: `tasks.json`

1. Put the following in `.vscode/tasks.json`:
```jsonc
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "echo vars",
            "type": "shell",
            "command": "echo 'UNSET_VAR=(${env:UNSET_VAR}), HOME=(${env:HOME})'",
        }
    ]
}
```

2. In the command palette , select "Tasks: Run Task", then select "echo vars".

3. Observe the terminal output:

```text
Executing task: echo 'UNSET_VAR=(), HOME=(/home/myname)' 

UNSET_VAR=(), HOME=(/home/myname)
```

#### Example 2: `settings.json`

1. Put the following in `.vscode/settings.json`:

```jsonc
{
    // Replace "linux" with "windows" or "osx" if you're on Windows or Mac
    "terminal.integrated.env.linux": {
        "MY_TEST": "UNSET_VAR=(${env:UNSET_VAR}), HOME=(${env:HOME})",
    }
}
```

2. Open a new terminal

3. Print out the value that VSCode set:
```shell
$ echo "$MY_TEST" 
UNSET_VAR=(), HOME=(/home/nelul)
```

As you can see, in both of these instances VSCode expands `${env:UNSET_VAR}` to the empty string. This behavior is consistent across everywhere that VSCode expands `${env:X}` blocks as far as I can tell.

</details>

2. This is also consistent with how we already handle environment variables in other places like `expand.ts`: https://github.com/microsoft/vscode-cpptools/blob/main/Extension/src/expand.ts#L102

Note that this behavior change is only being made for variables written as `${env:X}` or `${env.X}`, but not to those specified as `${X}` (which are otherwise treated the same as environment variables)