### PR TITLE
Remove Take Survey command

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -406,7 +406,6 @@ export async function registerCommands(enabled: boolean): Promise<void> {
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.PrepareCallHierarchy', enabled ? onPrepareCallHierarchy : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CallHierarchyCallsTo', enabled ? onCallHierarchyCallsTo : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CallHierarchyCallsFrom', enabled ? onCallHierarchyCallsFrom : onDisabledCommand));
-    commandDisposables.push(vscode.commands.registerCommand('C_Cpp.TakeSurvey', enabled ? onTakeSurvey : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.LogDiagnostics', enabled ? onLogDiagnostics : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.RescanWorkspace', enabled ? onRescanWorkspace : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ShowReferenceItem', enabled ? onShowRefCommand : onDisabledCommand));
@@ -940,12 +939,6 @@ function onToggleRefGroupView(): void {
     // Set context to switch icons
     const client: Client = getActiveClient();
     client.toggleReferenceResultsView();
-}
-
-function onTakeSurvey(): void {
-    telemetry.logLanguageServerEvent("onTakeSurvey");
-    const uri: vscode.Uri = vscode.Uri.parse(`https://www.research.net/r/VBVV6C6?o=${os.platform()}&m=${vscode.env.machineId}`);
-    void vscode.commands.executeCommand('vscode.open', uri);
 }
 
 function onVcpkgOnlineHelpSuggested(dummy?: any): void {


### PR DESCRIPTION
Removing the exposed, manually invokable 'Take Survey' command.

Alternatively, we could keep it and update the URL to use an aka.ms link.  (The survey is being moved from SurveyMoney to customervoice.microsoft.com)