### PR TITLE
Fix TypeScript compilation errors in common.ts

### DIFF
--- a/Extension/.scripts/common.ts
+++ b/Extension/.scripts/common.ts
@@ -39,7 +39,7 @@ chdir($root);
 
 // dump unhandled async errors to the console and exit.
 process.on('unhandledRejection', (reason: any, _promise) => {
-    error(`${reason?.stack?.split(/\r?\n/).filter(l => !l.includes('node:internal') && !l.includes('node_modules')).join('\n')}`);
+    error(`${reason?.stack?.split(/\r?\n/).filter((l: string) => !l.includes('node:internal') && !l.includes('node_modules')).join('\n')}`);
     process.exit(1);
 });
 

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -14,12 +14,12 @@ import * as vscode from 'vscode';
 import { DocumentFilter, Range } from 'vscode-languageclient';
 import * as nls from 'vscode-nls';
 import { TargetPopulation } from 'vscode-tas-client';
-import * as which from "which";
 import { ManualPromise } from './Utility/Async/manualPromise';
 import { isWindows } from './constants';
 import { getOutputChannelLogger, showOutputChannel } from './logger';
 import { PlatformInformation } from './platform';
 import * as Telemetry from './telemetry';
+import which = require("which");
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -1528,7 +1528,7 @@ export interface ISshLocalForwardInfo {
 
 export function whichAsync(name: string, path?: string): Promise<string | undefined> {
     return new Promise<string | undefined>(resolve => {
-        which(name, path ? { path } : {}, (err, resolved) => {
+        which(name, path ? { path } : {}, (err: Error | null, resolved: string | undefined) => {
             if (err) {
                 resolve(undefined);
             } else {

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -19,7 +19,7 @@ import { isWindows } from './constants';
 import { getOutputChannelLogger, showOutputChannel } from './logger';
 import { PlatformInformation } from './platform';
 import * as Telemetry from './telemetry';
-import which = require("which");
+import which = require('which');
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();


### PR DESCRIPTION
Fix by Copilot with Claude Opus 4.8 in VS Code.

## Summary

Fixes four TypeScript errors across two files that were breaking the build:
three in `src/common.ts` and one in `.scripts/common.ts`. All were caused by
missing type information — an uncallable namespace import and several
implicitly-`any` parameters that violate the project's `strict` settings.

## Errors fixed

### 1. `src/common.ts` — `which` is not callable (TS2349)

```
This expression is not callable.
  Type 'typeof which' has no call signatures.
```

`whichAsync` invoked the `which` module directly: `which(name, ...)`. The module
was imported with a namespace import:

```ts
import * as which from "which";
```

`@types/which` v2 declares the module using `export = which`, where `which` is a
callable function (CommonJS-style export). Under the current TypeScript rules, a
namespace-style import (`import * as`) of an `export =` value cannot be called or
constructed, because doing so would fail at runtime when `esModuleInterop` is off
(this project does not enable it). TypeScript surfaces this as "Type 'typeof
which' has no call signatures."

Fix: use an import-require binding, which maps directly onto the CommonJS
`export =` shape and is callable:

```ts
import which = require("which");
```

### 2 & 3. `src/common.ts` — implicit `any` callback parameters (TS7006)

```
Parameter 'err' implicitly has an 'any' type.
Parameter 'resolved' implicitly has an 'any' type.
```

The `which` callback parameters had no annotations. Once the import was fixed so
the call resolves to a typed overload, the parameters were annotated to match the
`@types/which` async-first overload:

```ts
which(name, path ? { path } : {}, (err: Error | null, resolved: string | undefined) => {
    ...
});
```

### 4. `.scripts/common.ts` — implicit `any` filter parameter (TS7006)

```
Parameter 'l' implicitly has an 'any' type.
```

The `unhandledRejection` handler split a stack trace and filtered the lines, but
the filter callback parameter was untyped. Since `String.prototype.split` returns
`string[]`, the parameter is annotated as `string`:

```ts
.filter((l: string) => !l.includes('node:internal') && !l.includes('node_modules'))
```

## Why these surfaced

All four are `strict` / `noImplicitAny` violations. The namespace-import issue is
a correctness fix (the previous form would have thrown at runtime if it had
compiled); the rest are purely type annotations that restore proper inference
without changing any runtime behavior.

## Testing

- `tsc` no longer reports errors in either file (verified — 0 errors).
- `yarn run lint` passes.
- No runtime behavior change: the `which` call site is functionally identical,
  and the added annotations only describe existing values.
