### PR TITLE
Fix format settings.

### DIFF
--- a/Extension/.vscode/settings.json
+++ b/Extension/.vscode/settings.json
@@ -27,12 +27,16 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "vscode.json-language-features",
         "editor.tabSize": 4,
+        // Preserve each file's existing indentation on format/save (i18n/*.json are tab-indented).
+        "editor.detectIndentation": true,
         "files.insertFinalNewline": false
     },
     "[jsonc]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "vscode.json-language-features",
         "editor.tabSize": 4,
+        // Preserve each file's existing indentation on format/save.
+        "editor.detectIndentation": true,
         "files.insertFinalNewline": true
     },
     "[typescript]": {

--- a/Extension/.vscode/settings.json
+++ b/Extension/.vscode/settings.json
@@ -27,7 +27,6 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "vscode.json-language-features",
         "editor.tabSize": 4,
-        // Preserve each file's existing indentation on format/save (i18n/*.json are tab-indented).
         "editor.detectIndentation": true,
         "files.insertFinalNewline": false
     },
@@ -35,7 +34,6 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "vscode.json-language-features",
         "editor.tabSize": 4,
-        // Preserve each file's existing indentation on format/save.
         "editor.detectIndentation": true,
         "files.insertFinalNewline": true
     },


### PR DESCRIPTION
Some of our localization json files use tabs and was having them get incorrectly switched to spaces after an edit.