### PR TITLE
Add .vscode/settings.json to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ OneLocBuild
 
 # ignore imported localization xlf directory
 vscode-translations-import
+
+.vscode/settings.json


### PR DESCRIPTION
This is because I use a settings.json with

```json
    "files.exclude": {
        "Extension": false
    }
```

for our vscode-cpptools root folder because I have a separate Extension root folder open in the workspace.
