### PR TITLE
upgrade language client to version 10

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7252,7 +7252,7 @@
         "ssh-config": "^4.4.4",
         "tmp": "^0.2.7",
         "vscode-cpptools": "^7.1.1",
-        "vscode-languageclient": "^9.0.1",
+        "vscode-languageclient": "^10.1.0",
         "vscode-nls": "^5.2.0",
         "vscode-tas-client": "^0.1.84",
         "which": "^2.0.2"

--- a/Extension/src/Debugger/configurationProvider.ts
+++ b/Extension/src/Debugger/configurationProvider.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as jsonc from 'comment-json';
-import * as glob from 'glob';
+import { glob, IOptions } from 'glob';
 import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
@@ -40,7 +40,7 @@ enum StepType {
     command = 'command'
 }
 
-const globAsync: (pattern: string, options?: glob.IOptions | undefined) => Promise<string[]> = promisify(glob);
+const globAsync: (pattern: string, options?: IOptions | undefined) => Promise<string[]> = promisify(glob);
 
 /*
  * Retrieves configurations from a provider and displays them in a quickpick menu to be selected.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -28,7 +28,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { SourceFileConfiguration, SourceFileConfigurationItem, Version, WorkspaceBrowseConfiguration } from 'vscode-cpptools';
 import { IntelliSenseStatus, Status } from 'vscode-cpptools/out/testApi';
-import { CloseAction, DidOpenTextDocumentParams, ErrorAction, LanguageClientOptions, NotificationType, Position, Range, RequestType, ResponseError, TextDocumentIdentifier, TextDocumentPositionParams } from 'vscode-languageclient';
+import { CloseAction, DidOpenTextDocumentParams, ErrorAction, LanguageClientOptions, NotificationType, Position, Range, RequestType, RequestType0, ResponseError, TextDocumentIdentifier, TextDocumentPositionParams } from 'vscode-languageclient';
 import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
 import * as nls from 'vscode-nls';
 import { DebugConfigurationProvider } from '../Debugger/configurationProvider';
@@ -608,11 +608,11 @@ export interface SetOpenFileOriginalEncodingParams {
 }
 
 // Requests
-const PreInitializationRequest: RequestType<void, string, void> = new RequestType<void, string, void>('cpptools/preinitialize');
+const PreInitializationRequest: RequestType0<string, void> = new RequestType0<string, void>('cpptools/preinitialize');
 const InitializationRequest: RequestType<CppInitializationParams, CppInitializationResult, void> = new RequestType<CppInitializationParams, CppInitializationResult, void>('cpptools/initialize');
 const QueryCompilerDefaultsRequest: RequestType<QueryDefaultCompilerParams, configs.CompilerDefaults, void> = new RequestType<QueryDefaultCompilerParams, configs.CompilerDefaults, void>('cpptools/queryCompilerDefaults');
 const SwitchHeaderSourceRequest: RequestType<SwitchHeaderSourceParams, string, void> = new RequestType<SwitchHeaderSourceParams, string, void>('cpptools/didSwitchHeaderSource');
-const GetDiagnosticsRequest: RequestType<void, GetDiagnosticsResult, void> = new RequestType<void, GetDiagnosticsResult, void>('cpptools/getDiagnostics');
+const GetDiagnosticsRequest: RequestType0<GetDiagnosticsResult, void> = new RequestType0<GetDiagnosticsResult, void>('cpptools/getDiagnostics');
 export const GetDocumentSymbolRequest: RequestType<GetDocumentSymbolRequestParams, GetDocumentSymbolResult, void> = new RequestType<GetDocumentSymbolRequestParams, GetDocumentSymbolResult, void>('cpptools/getDocumentSymbols');
 export const GetSymbolInfoRequest: RequestType<WorkspaceSymbolParams, LocalizeSymbolInformation[], void> = new RequestType<WorkspaceSymbolParams, LocalizeSymbolInformation[], void>('cpptools/getWorkspaceSymbols');
 export const GetFoldingRangesRequest: RequestType<GetFoldingRangesParams, GetFoldingRangesResult, void> = new RequestType<GetFoldingRangesParams, GetFoldingRangesResult, void>('cpptools/getFoldingRanges');
@@ -1836,12 +1836,12 @@ export class DefaultClient implements Client {
         await languageClient.start();
 
         if (usesCrashHandler()) {
-            watchForCrashes(await languageClient.sendRequest(PreInitializationRequest, null));
+            watchForCrashes(await languageClient.sendRequest(PreInitializationRequest));
         } else if (os.platform() === "win32") {
             const settings: CppSettings = new CppSettings();
             if ((settings.windowsErrorReportingMode === "default" && !languageClientHasCrashed) ||
                 settings.windowsErrorReportingMode === "enabled") {
-                await languageClient.sendRequest(PreInitializationRequest, null);
+                await languageClient.sendRequest(PreInitializationRequest);
             }
         }
 
@@ -2202,7 +2202,7 @@ export class DefaultClient implements Client {
 
     public async logDiagnostics(): Promise<void> {
         await this.ready;
-        const response: GetDiagnosticsResult = await this.languageClient.sendRequest(GetDiagnosticsRequest, null);
+        const response: GetDiagnosticsResult = await this.languageClient.sendRequest(GetDiagnosticsRequest);
         const diagnosticsChannel: vscode.OutputChannel = getDiagnosticsChannel();
         diagnosticsChannel.clear();
 

--- a/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
@@ -5,7 +5,6 @@
 import { ContextResolver, ResolveRequest, SupportedContextItem, type ContextProvider } from '@github/copilot-language-server';
 import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
-import { DocumentSelector } from 'vscode-languageserver-protocol';
 import { isBoolean, isNumber, isString } from '../common';
 import { getOutputChannelLogger, Logger } from '../logger';
 import * as telemetry from '../telemetry';
@@ -74,7 +73,7 @@ type CacheEntry = [string, CopilotCompletionContextResult];
 export class CopilotCompletionContextProvider implements ContextResolver<SupportedContextItem> {
     private static readonly providerId = 'ms-vscode.cpptools';
     private readonly completionContextCache: Map<string, CacheEntry> = new Map();
-    private static readonly defaultCppDocumentSelector: DocumentSelector = [{ language: 'cpp' }, { language: 'c' }, { language: 'cuda-cpp' }];
+    private static readonly defaultCppDocumentSelector: string[] = ['cpp', 'c', 'cuda-cpp'];
     // The default time budget for providing a value from resolve().
     private static readonly defaultTimeBudgetMs: number = 7;
     // Assume the cache is stale when the distance to the current caret is greater than this value.

--- a/Extension/src/SSH/sshHosts.ts
+++ b/Extension/src/SSH/sshHosts.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { promises as fs } from 'fs';
-import * as glob from 'glob';
+import { glob, IOptions } from 'glob';
 import * as os from 'os';
 import * as path from 'path';
 import {
@@ -12,8 +12,8 @@ import {
     ConfigurationEntry,
     Type as ConfigurationEntryType,
     HostConfigurationDirective,
-    ResolvedConfiguration,
-    parse
+    parse,
+    ResolvedConfiguration
 } from 'ssh-config';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
@@ -25,7 +25,7 @@ import { getSshChannel } from '../logger';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
-const globAsync: (pattern: string, options?: glob.IOptions | undefined) => Promise<string[]> = promisify(glob);
+const globAsync: (pattern: string, options?: IOptions | undefined) => Promise<string[]> = promisify(glob);
 
 const userSshConfigurationFile: string = path.resolve(os.homedir(), '.ssh/config');
 

--- a/Extension/src/common.ts
+++ b/Extension/src/common.ts
@@ -11,7 +11,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import * as vscode from 'vscode';
-import { DocumentFilter, Range } from 'vscode-languageclient';
+import { Range } from 'vscode-languageclient';
 import * as nls from 'vscode-nls';
 import { TargetPopulation } from 'vscode-tas-client';
 import { ManualPromise } from './Utility/Async/manualPromise';
@@ -1538,7 +1538,7 @@ export function whichAsync(name: string, path?: string): Promise<string | undefi
     });
 }
 
-export const documentSelector: DocumentFilter[] = [
+export const documentSelector: vscode.DocumentFilter[] = [
     { scheme: 'file', language: 'c' },
     { scheme: 'file', language: 'cpp' },
     { scheme: 'file', language: 'cuda-cpp' }

--- a/Extension/test.tsconfig.json
+++ b/Extension/test.tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
+        "moduleResolution": "node16",
         "target": "ES2022",
         "outDir": "dist",
         "lib": [

--- a/Extension/test/common/selectTests.ts
+++ b/Extension/test/common/selectTests.ts
@@ -5,12 +5,12 @@
 
 import { readdir, readFile } from 'fs/promises';
 import { glob as globSync, IOptions } from 'glob';
-import * as Mocha from 'mocha';
 import { basename, dirname, resolve } from 'path';
 import { env } from 'process';
 import { promisify } from 'util';
 import { returns } from '../../src/Utility/Async/returns';
 import { filepath } from '../../src/Utility/Filesystem/filepath';
+import Mocha = require('mocha');
 
 export const glob: (pattern: string, options?: IOptions | undefined) => Promise<string[]> = promisify(globSync);
 

--- a/Extension/test/scenarios/SingleRootProject/tests/ParsedEnvironmentFile.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/ParsedEnvironmentFile.test.ts
@@ -10,12 +10,12 @@ function assertEnvironmentEqual(env: Environment[], name: string, value: string)
     let found: boolean = false;
     for (const e of env) {
         if (e.name === name) {
-            assert(e.value === value, `Checking if ${e.value} == ${value}`);
+            assert.ok(e.value === value, `Checking if ${e.value} == ${value}`);
             found = true;
             break;
         }
     }
-    assert(found, `${name} was not found in env.`);
+    assert.ok(found, `${name} was not found in env.`);
 }
 
 suite("ParsedEnvironmentFile", () => {
@@ -23,7 +23,7 @@ suite("ParsedEnvironmentFile", () => {
         const content: string = `MyName=VALUE`;
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName", "VALUE");
     });
 
@@ -31,7 +31,7 @@ suite("ParsedEnvironmentFile", () => {
         const content: string = `MyName="VALUE"`;
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName", "VALUE");
     });
 
@@ -39,7 +39,7 @@ suite("ParsedEnvironmentFile", () => {
         const content: string = "\uFEFFMyName=VALUE";
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName", "VALUE");
     });
 
@@ -51,7 +51,7 @@ MyName2=Value2
 `;
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName1", "Value1");
         assertEnvironmentEqual(result.Env, "MyName2", "Value2");
     });
@@ -68,7 +68,7 @@ MyName2=Value2
 
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", initialEnv);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName1", "Value1");
         assertEnvironmentEqual(result.Env, "ThisShouldNotChange", "StillHere");
         assertEnvironmentEqual(result.Env, "MyName2", "Value2");
@@ -82,7 +82,7 @@ MyName2=Value2
 `;
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
+        assert.ok(!result.Warning, `Failed to assert that Warning was empty: ${result.Warning}`);
         assertEnvironmentEqual(result.Env, "MyName1", "Value1");
         assertEnvironmentEqual(result.Env, "MyName2", "Value2");
     });
@@ -96,7 +96,7 @@ MyName2=Value2
 `;
         const result: ParsedEnvironmentFile = ParsedEnvironmentFile.CreateFromContent(content, "TestEnvFileName", []);
 
-        assert(result.Warning && result.Warning.startsWith("Ignoring non-parsable lines in envFile TestEnvFileName"), 'Checking if warning exists');
+        assert.ok(result.Warning && result.Warning.startsWith("Ignoring non-parsable lines in envFile TestEnvFileName"), 'Checking if warning exists');
         assertEnvironmentEqual(result.Env, "MyName1", "Value1");
         assertEnvironmentEqual(result.Env, "MyName2", "Value2");
     });

--- a/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/copilotProviders.test.ts
@@ -6,7 +6,6 @@
 import { ContextProviderApiV1 } from '@github/copilot-language-server';
 import { ok } from 'assert';
 import { afterEach, beforeEach, describe, it } from 'mocha';
-import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as util from '../../../../src/common';
@@ -17,6 +16,7 @@ import * as extension from '../../../../src/LanguageServer/extension';
 import * as lmTool from '../../../../src/LanguageServer/lmTool';
 import { ProjectContext } from '../../../../src/LanguageServer/lmTool';
 import * as telemetry from '../../../../src/telemetry';
+import proxyquire = require('proxyquire');
 
 describe('copilotProviders Tests', () => {
     let moduleUnderTest: any;

--- a/Extension/tsconfig.json
+++ b/Extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
+        "moduleResolution": "node16",
         "target": "ES2022",
         "outDir": "dist",
         "lib": [

--- a/Extension/ui.tsconfig.json
+++ b/Extension/ui.tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
+        "moduleResolution": "node16",
         "target": "ES2022",
         "outDir": "dist",
         "lib": [

--- a/Extension/ui/settings.ts
+++ b/Extension/ui/settings.ts
@@ -411,5 +411,4 @@ class SettingsApp {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const app: SettingsApp = new SettingsApp();
+void new SettingsApp();

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1763,6 +1763,13 @@ brace-expansion@^5.0.2:
   dependencies:
     balanced-match "^4.0.2"
 
+brace-expansion@^5.0.5:
+  version "5.0.7"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=
+  dependencies:
+    balanced-match "^4.0.2"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -4418,6 +4425,13 @@ minimatch@^10.1.1, minimatch@^10.2.2:
   dependencies:
     brace-expansion "^5.0.2"
 
+minimatch@^10.2.5:
+  version "10.2.5"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=
+  dependencies:
+    brace-expansion "^5.0.5"
+
 minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^3.1.3:
   version "3.1.5"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
@@ -4432,7 +4446,7 @@ minimatch@^4.2.6:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^5.1.6:
+minimatch@^5.0.1, minimatch@^5.1.6:
   version "5.1.9"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
   integrity sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=
@@ -5438,10 +5452,15 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=
 
-semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.4, semver@^7.6.2, semver@^7.6.3, semver@^7.7.3:
+semver@^7.3.4, semver@^7.3.5, semver@^7.5.2, semver@^7.5.4, semver@^7.6.2, semver@^7.6.3, semver@^7.7.3:
   version "7.7.4"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha1-KEZONgYOmR+noR0CedLT87V6foo=
+
+semver@^7.8.1:
+  version "7.8.5"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=
 
 serialize-javascript@^6.0.2, serialize-javascript@^7.0.5:
   version "7.0.5"
@@ -6473,16 +6492,30 @@ vscode-jsonrpc@8.2.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
   integrity sha1-9D36NftR52PRfNlNzKDJRY81q/k=
 
-vscode-languageclient@^9.0.1:
+vscode-jsonrpc@9.0.1:
   version "9.0.1"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz#cdfe20267726c8d4db839dc1e9d1816e1296e854"
-  integrity sha1-zf4gJncmyNTbg53B6dGBbhKW6FQ=
-  dependencies:
-    minimatch "^5.1.0"
-    semver "^7.3.7"
-    vscode-languageserver-protocol "3.17.5"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz#5e848a4addf004b6337156f7858a006e0838b4f5"
+  integrity sha1-XoSKSt3wBLYzcVb3hYoAbgg4tPU=
 
-vscode-languageserver-protocol@3.17.5, vscode-languageserver-protocol@^3.17.5:
+vscode-languageclient@^10.1.0:
+  version "10.1.0"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz#38c09d836f5833d5972fb5524b362b9d1721f35f"
+  integrity sha1-OMCdg29YM9WXL7VSSzYrnRch818=
+  dependencies:
+    minimatch "^10.2.5"
+    semver "^7.8.1"
+    vscode-languageserver-protocol "3.18.2"
+    vscode-languageserver-textdocument "1.0.13"
+
+vscode-languageserver-protocol@3.18.2:
+  version "3.18.2"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz#e7fb36e6ba32bc7ba622257adb78a6126273ddc5"
+  integrity sha1-5/s25royvHumIiV623imEmJz3cU=
+  dependencies:
+    vscode-jsonrpc "9.0.1"
+    vscode-languageserver-types "3.18.0"
+
+vscode-languageserver-protocol@^3.17.5:
   version "3.17.5"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz#864a8b8f390835572f4e13bd9f8313d0e3ac4bea"
   integrity sha1-hkqLjzkINVcvThO9n4MT0OOsS+o=
@@ -6490,10 +6523,20 @@ vscode-languageserver-protocol@3.17.5, vscode-languageserver-protocol@^3.17.5:
     vscode-jsonrpc "8.2.0"
     vscode-languageserver-types "3.17.5"
 
+vscode-languageserver-textdocument@1.0.13:
+  version "1.0.13"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz#81846745d77b9fc787911e64e2e110d244c9b8b2"
+  integrity sha1-gYRnRdd7n8eHkR5k4uEQ0kTJuLI=
+
 vscode-languageserver-types@3.17.5:
   version "3.17.5"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
   integrity sha1-MnNnbwzy6rQLP0TQhay7fwijnYo=
+
+vscode-languageserver-types@3.18.0:
+  version "3.18.0"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz#132321229604836bab710c97487e6cdafb9bd7bb"
+  integrity sha1-EyMhIpYEg2urcQyXSH5s2vub17s=
 
 vscode-nls-dev@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
I'm seeing some strange behavior in the crashing telemetry. It's hard to tell why the client is disconnecting from cpptools. In some cases it looks like cpptools is orphaned, not crashed, so I'm starting with upgrading the client module.

A follow up PR will add additional telemetry when an error happens in case that can provide us additional information.