### PR TITLE
send telemetry for language client errors

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1755,7 +1755,14 @@ export class DefaultClient implements Client {
             initializationOptions: lspInitializationOptions,
             middleware: createProtocolFilter(),
             errorHandler: {
-                error: (_error, _message, _count) => ({ action: ErrorAction.Continue }),
+                error: (error, message, count) => {
+                    telemetry.logLanguageServerEvent("languageClientError", {
+                        error: error.toString(),
+                        message: message?.toString() ?? '',
+                        count: count?.toString() ?? ''
+                    });
+                    return { action: ErrorAction.Continue };
+                },
                 closed: () => {
                     languageClientHasCrashed = true;
                     languageClientCrashTimes.push(Date.now());


### PR DESCRIPTION
I am seeing languageClientCrash telemetry in cases where I suspect a crash in cpptools has not actually happened. The logs show cpptools.exe being orphaned in some cases. I'm hoping this will give us some insight into what is breaking the connection so we can stop sending the crash telemetry for routine disconnect cases.