### PR TITLE
Fix build tools walkthrough for VS 2026.

### DIFF
--- a/Extension/walkthrough/installcompiler/install-compiler-windows11.md
+++ b/Extension/walkthrough/installcompiler/install-compiler-windows11.md
@@ -2,7 +2,7 @@
 <p data-loc-id="walkthrough.windows.text1">If you&#39;re doing C++ development for Windows, we recommend installing the Microsoft Visual C++ (MSVC) compiler.</p>
 <ol>
 <li><p data-loc-id="walkthrough.windows.text2">To install MSVC, open the VS Code terminal (CTRL + `) and paste in the following command:</p>
-<p><code>winget install Microsoft.<wbr>VisualStudio.<wbr>2022.<wbr>BuildTools --force --override "--wait --passive --add Microsoft.<wbr>VisualStudio.<wbr>Workload.<wbr>VCTools --add Microsoft.<wbr>VisualStudio.<wbr>Component.<wbr>VC.<wbr>Tools.<wbr>x86.<wbr>x64 --add Microsoft.<wbr>VisualStudio.<wbr>Component.<wbr>Windows11SDK.<wbr>26100"</code></p>
+<p><code>winget install Microsoft.<wbr>VisualStudio.<wbr>BuildTools --force --override "--wait --passive --add Microsoft.<wbr>VisualStudio.<wbr>Workload.<wbr>VCTools --add Microsoft.<wbr>VisualStudio.<wbr>Component.<wbr>VC.<wbr>Tools.<wbr>x86.<wbr>x64 --add Microsoft.<wbr>VisualStudio.<wbr>Component.<wbr>Windows11SDK.<wbr>26100"</code></p>
 <blockquote>
 <p><strong data-loc-id="walkthrough.windows.note1">Note</strong>: <span data-loc-id="walkthrough.windows.note1.text">You can use the C++ toolset from Visual Studio Build Tools along with Visual Studio Code to compile, build, and verify any C++ codebase as long as you also have a valid Visual Studio license (either Community, Pro, or Enterprise) that you are actively using to develop that C++ codebase.</span></p>
 </blockquote>


### PR DESCRIPTION
Fixed by Copilot with Claude Opus 4.8 in VS Code.

It looks like Windows 10 isn't supported.

See also https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Microsoft/VisualStudio

<img width="783" height="69" alt="image" src="https://github.com/user-attachments/assets/f69faace-0b9b-428f-8e01-d9b1c85a1d87" />
