### PR TITLE
Fix portable ps command for remote process picker

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.33.4: July 8, 2026
 ### Bug Fixes
+* Fix remote process selection on systems with personality-dependent `ps` option parsing. [#14442](https://github.com/microsoft/vscode-cpptools/issues/14442)
 * Fix the wording for the `#include` errors detected message. [#8227](https://github.com/microsoft/vscode-cpptools/issues/8227)
 * Fix another "directory_cache" crash.
 * Update some localization.

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Version 1.33.4: July 8, 2026
 ### Bug Fixes
-* Fix remote process selection on systems with personality-dependent `ps` option parsing. [#14442](https://github.com/microsoft/vscode-cpptools/issues/14442)
 * Fix the wording for the `#include` errors detected message. [#8227](https://github.com/microsoft/vscode-cpptools/issues/8227)
 * Fix another "directory_cache" crash.
 * Update some localization.

--- a/Extension/src/Debugger/nativeAttach.ts
+++ b/Extension/src/Debugger/nativeAttach.ts
@@ -117,7 +117,7 @@ export class PsProcessParser {
     // Note that comm on Linux systems is truncated to 16 characters:
     // https://bugzilla.redhat.com/show_bug.cgi?id=429565
     // Since 'args' contains the full path to the executable, even if truncated, searching will work as desired.
-    public static get psLinuxCommand(): string { return `ps axww -o pid=,comm=${PsProcessParser.commColumnTitle},args=`; }
+    public static get psLinuxCommand(): string { return `ps axww -o pid= -o comm=${PsProcessParser.commColumnTitle} -o args=`; }
     public static get psDarwinCommand(): string { return `ps axww -o pid=,comm=${PsProcessParser.commColumnTitle},args= -c`; }
     public static get psToyboxCommand(): string { return `ps -A -o pid=,comm=${PsProcessParser.commColumnTitle},args=`; }
 

--- a/Extension/test/scenarios/SingleRootProject/tests/extension.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/extension.test.ts
@@ -126,6 +126,12 @@ suite("Pick Process Tests", () => {
         assert.equal(process2.pid, '15220');
     });
 
+    test("Use portable ps options on Linux", () => {
+        assert.equal(
+            PsProcessParser.psLinuxCommand,
+            `ps axww -o pid= -o comm=${'a'.repeat(49)} -o args=`);
+    });
+
     test('Parse valid CIM output', () => {
         // output from the command used in CimAttachItemsProvider
         const cimOutput: string = String.raw`[


### PR DESCRIPTION
## Summary

Fixes #14442.

The Linux remote process picker now passes each output column to `ps` with a separate `-o` option. This avoids the personality-dependent interpretation of comma-separated format specifications while preserving the existing PID, command name, and arguments output layout.

A regression test verifies the portable command construction.

## Validation

- `corepack yarn compile` (passed)
- Targeted ESLint for the changed TypeScript files (passed)
- `git diff --check` (passed)
- Executed the new command under Ubuntu/WSL and confirmed it produces the expected fixed-width PID, command, and arguments columns

The `SingleRootProject` scenario runner could not execute locally because the native cpptools binaries are not included in the public source checkout. The scenario test containing the new assertion compiled successfully.