### PR TITLE
Fix si_code=, si_addr=undefined.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1362,7 +1362,16 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
     }
     if (lines[crashStackStartLine].startsWith("SIG")) {
         signalType = `${lines[crashStackStartLine]}\n`;
-        signalInfo = `si_code=${lines[crashStackStartLine + 1]}, si_addr=${bucketSignalAddress(lines[crashStackStartLine + 2])}\n`;
+        const siCode: string = lines[crashStackStartLine + 1] ?? "";
+        const siAddr: string = lines[crashStackStartLine + 2] ?? "";
+        const signalInfoParts: string[] = [];
+        if (siCode.length > 0) {
+            signalInfoParts.push(`si_code=${siCode}`);
+        }
+        if (siAddr.length > 0) {
+            signalInfoParts.push(`si_addr=${bucketSignalAddress(siAddr)}`);
+        }
+        signalInfo = signalInfoParts.length > 0 ? `${signalInfoParts.join(", ")}\n` : "";
         crashStackStartLine += 3;
     } else {
         // The signal type may fail to be written.

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1362,8 +1362,10 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
     }
     if (lines[crashStackStartLine].startsWith("SIG")) {
         signalType = `${lines[crashStackStartLine]}\n`;
-        const siCode: string = lines[crashStackStartLine + 1] ?? "";
-        const siAddr: string = lines[crashStackStartLine + 2] ?? "";
+        const siCodeRaw: string | undefined = lines[crashStackStartLine + 1];
+        const siAddrRaw: string | undefined = lines[crashStackStartLine + 2];
+        const siCode: string = siCodeRaw?.trim() ?? "";
+        const siAddr: string = siAddrRaw?.trim() ?? "";
         const signalInfoParts: string[] = [];
         if (siCode.length > 0) {
             signalInfoParts.push(`si_code=${siCode}`);
@@ -1372,7 +1374,9 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
             signalInfoParts.push(`si_addr=${bucketSignalAddress(siAddr)}`);
         }
         signalInfo = signalInfoParts.length > 0 ? `${signalInfoParts.join(", ")}\n` : "";
-        crashStackStartLine += 3;
+        // Only advance past the header lines that actually exist so a missing si_code/si_addr
+        // line does not cause the first stack frame to be skipped.
+        crashStackStartLine += 1 + (siCodeRaw !== undefined ? 1 : 0) + (siAddrRaw !== undefined ? 1 : 0);
     } else {
         // The signal type may fail to be written.
         // Intentionally different from SIGUNKNOWN from cpptools,


### PR DESCRIPTION
I noticed this in the crash call stack data.

Fixed by Copilot with Claude Opus 4.8 (in VS Code).
