### PR TITLE
Skip terminate_handler( frames.

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1414,7 +1414,7 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
                         funcStr = funcStr.replace(/, std::allocator<std::string>/g, "");
                     }
                 }
-                if (!validFrameFound && (funcStr.startsWith("crash_handler(") || funcStr.startsWith("_sigtramp"))) {
+                if (!validFrameFound && (funcStr.startsWith("crash_handler(") || funcStr.startsWith("terminate_handler(") || funcStr.startsWith("_sigtramp"))) {
                     continue; // Skip these on early frames.
                 }
                 validFrameFound = true;


### PR DESCRIPTION
Skip the terminate_handler frame for crash call stacks since that is logged now.

Fixed by Copilot with Claude Opus 4.8 (in VS Code) -- part of a larger change with a cpptools change.