### PR TITLE
Update brace-expansion.

### DIFF
--- a/ExtensionPack/package-lock.json
+++ b/ExtensionPack/package-lock.json
@@ -948,9 +948,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
+            "version": "5.0.8",
+            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/Themes/package-lock.json
+++ b/Themes/package-lock.json
@@ -948,9 +948,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
+      "version": "5.0.8",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
For some reason, both dependabot and npm audit fix weren't able to update it, but Copilot was able to patch it, but for some reason our Extension brace-expansion somehow was able to update in a previous PR (not sure what the difference is, maybe some yarn versus npm thing).
