### PR TITLE
Don't report Node deprecation warnings as script errors

### DIFF
--- a/Extension/.scripts/installAndCopyBinaries.ts
+++ b/Extension/.scripts/installAndCopyBinaries.ts
@@ -6,7 +6,7 @@
 import { runVSCodeCommand } from '@vscode/test-electron';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { $root, error, heading, note } from './common';
+import { $root, error, heading, note, warn } from './common';
 import * as copy from './copyExtensionBinaries';
 import { install, isolated, options } from "./vscode";
 
@@ -24,7 +24,9 @@ export async function main() {
         console.log(result.stdout.toString());
     }
     if (result.stderr) {
-        error(result.stderr.toString());
+        // runVSCodeCommand resolves only when the command succeeds (it throws on a non-zero exit), so stderr here is
+        // non-fatal output such as Node deprecation warnings and must not be reported as an error.
+        warn(result.stderr.toString());
     }
 
     const binaryVersion = await copy.main(isolated);

--- a/Extension/.scripts/test.ts
+++ b/Extension/.scripts/test.ts
@@ -27,6 +27,7 @@ const filters = [
     /^Unexpected token A/,
     /Cannot register 'cmake.cmakePath'/,
     /\[DEP0005\] DeprecationWarning/,
+    /\[DEP0169\] DeprecationWarning/,
     /--trace-deprecation/,
     /Iconv-lite warning/,
     /^Extension '/,


### PR DESCRIPTION
## Summary

`yarn install-and-copy-binaries-for-test` printed a red `ERROR:` for a harmless Node `[DEP0169] url.parse()` deprecation warning that the VS Code CLI writes to stderr, even though the extension installed successfully and the binaries were copied. The script called `error()` unconditionally whenever the `--install-extension` subprocess produced any stderr output.

`runVSCodeCommand` only resolves when the command succeeds (it throws `VSCodeCommandError` on a non-zero exit), so its stderr here is inherently non-fatal (e.g. Node deprecation warnings). It is now logged with `warn()` instead of `error()`, which handles `DEP0169` and any future deprecation warning without an allow-list.

The same `DEP0169` pattern is also added to the `test.ts` `filterStdio()` deny-list, alongside the existing `DEP0005` entry, so the `yarn test` path stays quiet as well.

> This PR was created by Copilot with `Claude Opus 4.8` (in VS Code). Any PR comments starting with `Copilot says:` are generated by Copilot.