### PR TITLE
Pin test VS Code version to 1.130.0 to unbreak macOS CI

### DIFF
--- a/Extension/.scripts/vscode.ts
+++ b/Extension/.scripts/vscode.ts
@@ -15,7 +15,12 @@ export const extensionsDir = resolve(isolated, 'extensions');
 export const userDir = resolve(isolated, 'user-data');
 export const settings = resolve(userDir, "User", 'settings.json');
 
+// Pin the test VS Code build; the newest stable can ship a bundle layout that the installed
+// @vscode/test-electron fails to launch (macOS arm64 1.131.0 spawns Electron with ENOENT).
+export const testVSCodeVersion = '1.130.0';
+
 export const options = {
+    version: testVSCodeVersion,
     cachePath: `${isolated}/cache`,
     launchArgs: ['--no-sandbox', '--disable-updates', '--skip-welcome', '--skip-release-notes', '--disable-extensions', `--extensions-dir=${extensionsDir}`, `--user-data-dir=${userDir}`, '--disable-workspace-trust']
 };


### PR DESCRIPTION
## Summary

The macOS CI legs are failing deterministically on every run because the integration tests download the newest stable VS Code (1.131.0, released today) and the installed `@vscode/test-electron` (`^2.3.10`) cannot launch its macOS arm64 bundle:

```
✔ Downloaded VS Code into .../vscode-darwin-arm64-1.131.0
✔ Validated version: 1.131.0
Test error: Error: spawn .../vscode-darwin-arm64-1.131.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Exit code: -2
```

The scenario tests resolve the test VS Code via `downloadAndUnzipVSCode(options)` with no pinned `version`, so they always pull latest stable — meaning a brand-new release can break CI for `main` and every open PR at once (Linux/Windows currently pass; only macOS is affected). This pins the downloaded test VS Code to `1.130.0` (the last release that launches under the current `@vscode/test-electron`) so CI is deterministic again.

Follow-up (separate change): bump `@vscode/test-electron` so newer stable releases launch, then the pin can be raised or removed.

> This PR was created by Copilot with `Claude Opus 4.8` (in VS Code). Any PR comments starting with `Copilot says:` are generated by Copilot.