### PR TITLE
Bump @vscode/test-electron to 3.1.0 and move test VS Code pin to 1.131.0

### DIFF
--- a/Extension/.scripts/vscode.ts
+++ b/Extension/.scripts/vscode.ts
@@ -15,9 +15,9 @@ export const extensionsDir = resolve(isolated, 'extensions');
 export const userDir = resolve(isolated, 'user-data');
 export const settings = resolve(userDir, "User", 'settings.json');
 
-// Pin the test VS Code build; the newest stable can ship a bundle layout that the installed
-// @vscode/test-electron fails to launch (macOS arm64 1.131.0 spawns Electron with ENOENT).
-export const testVSCodeVersion = '1.130.0';
+// Pin the test VS Code build to a known-good stable release for deterministic CI instead of
+// always pulling latest. Launching macOS 1.110+ builds requires @vscode/test-electron >= 3.1.0.
+export const testVSCodeVersion = '1.131.0';
 
 export const options = {
     version: testVSCodeVersion,

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7203,7 +7203,7 @@
         "@vscode/debugadapter": "^1.65.0",
         "@vscode/debugprotocol": "^1.65.0",
         "@vscode/dts": "^0.4.0",
-        "@vscode/test-electron": "^2.3.10",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "async-child-process": "^1.1.1",
         "await-notify": "^1.0.1",

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1055,10 +1055,10 @@
     "@microsoft/1ds-post-js" "^4.3.4"
     "@microsoft/applicationinsights-web-basic" "^3.3.4"
 
-"@vscode/test-electron@^2.3.10":
-  version "2.5.2"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@vscode/test-electron/-/test-electron-2.5.2.tgz#f7d4078e8230ce9c94322f2a29cc16c17954085d"
-  integrity sha1-99QHjoIwzpyUMi8qKcwWwXlUCF0=
+"@vscode/test-electron@^3.1.0":
+  version "3.1.0"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/@vscode/test-electron/-/test-electron-3.1.0.tgz#46b93d118dcd3b3c89caae296a13f9a7f5eb63c5"
+  integrity sha1-Rrk9EY3NOzyJyq4pahP5p/XrY8U=
   dependencies:
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.5"
@@ -1744,19 +1744,19 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^5.0.2:
-  version "5.0.8"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=
-  dependencies:
-    balanced-match "^4.0.2"
-
 brace-expansion@^2.0.1:
   version "2.1.2"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
   integrity sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.2:
+  version "5.0.8"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"


### PR DESCRIPTION
## Summary

Bumps `@vscode/test-electron` `^2.3.10` → `^3.1.0` and advances the pinned test VS Code from `1.130.0` to the current stable `1.131.0`.

VS Code 1.110 renamed the macOS main binary from `Contents/MacOS/Electron` to the product name and later removed the compatibility symlink (microsoft/vscode#326502), so `@vscode/test-electron` ≤ 3.0.0 — which hardcodes the `Electron` name — fails to launch downloaded stable builds on macOS with `spawn .../Contents/MacOS/Electron ENOENT`. 3.1.0 resolves the executable from the bundle's `Info.plist` `CFBundleExecutable` (microsoft/vscode-test#348, #349), so macOS 1.110+ builds launch again.

With 3.1.0 in place, the pin introduced in #14618 is moved forward to `1.131.0` (kept pinned for deterministic CI rather than always pulling latest). The bump and the pin move go together — 1.131.0 only launches on macOS with 3.1.0.

Lockfile churn is limited to the `test-electron` entry (its 3.1.0 dependencies were already present). 3.1.0 remains CommonJS and preserves the APIs used here (`downloadAndUnzipVSCode`, `runVSCodeCommand`, `resolveCliArgsFromVSCodeExecutablePath`, `runTests`, `VSCodeCommandError`); it requires Node ≥ 22, which CI already uses (Node 24).

> This PR was created by Copilot with `Claude Opus 4.8` (in VS Code). Any PR comments starting with `Copilot says:` are generated by Copilot.