### PR TITLE
Don't warn about recursive includes merged from c_cpp_properties.json

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2329,6 +2329,19 @@ export class DefaultClient implements Client {
                 const fileConfiguration: configs.Configuration | undefined = this.configuration.CurrentConfiguration;
                 if (fileConfiguration?.mergeConfigurations) {
                     configs = deepCopy(configs);
+                }
+                // Only the include paths from the provider are checked for recursive includes, so
+                // this has to happen before the include paths from c_cpp_properties.json are
+                // appended below, where a trailing '**' is a supported way to recurse.
+                if (configs instanceof Array) {
+                    configs.forEach(config => {
+                        if (util.isArrayOfString(config?.configuration?.includePath) &&
+                            config.configuration.includePath.some(path => path.endsWith('**'))) {
+                            console.warn("custom include paths should not use recursive includes ('**')");
+                        }
+                    });
+                }
+                if (fileConfiguration?.mergeConfigurations) {
                     configs.forEach(config => {
                         if (fileConfiguration.includePath) {
                             fileConfiguration.includePath.forEach(p => {
@@ -3457,9 +3470,6 @@ export class DefaultClient implements Client {
                 this.configurationLogging.set(uri, JSON.stringify(item.configuration, null, 4));
                 out.appendLineAtLevel(6, `  uri: ${uri}`);
                 out.appendLineAtLevel(6, `  config: ${JSON.stringify(item.configuration, null, 2)}`);
-                if (item.configuration.includePath.some(path => path.endsWith('**'))) {
-                    console.warn("custom include paths should not use recursive includes ('**')");
-                }
                 // Separate compiler path and args before sending to language client
                 const itemConfig: util.Mutable<InternalSourceFileConfiguration> = deepCopy(item.configuration);
                 if (util.isString(itemConfig.compilerPath)) {


### PR DESCRIPTION
Fixes #14125

## Problem

`sendCustomConfigurations` warned whenever any `includePath` entry ended in `**`:

```ts
if (item.configuration.includePath.some(path => path.endsWith('**'))) {
    console.warn("custom include paths should not use recursive includes ('**')");
}
```

Its only caller is `provideCustomConfigurationAsync`, and when `mergeConfigurations` is enabled that caller has already appended the `includePath` entries from the user's `c_cpp_properties.json` to every configuration returned by the provider. A trailing `**` is a supported way to recurse there, so the warning fired for paths the configuration provider never supplied.

## Change

Move the check ahead of that append, so it only ever sees the provider's own include paths. The warning for a provider that really does use `**` is unchanged, with or without `mergeConfigurations`.

The check now runs before `isSourceFileConfigurationItem` validates each item, so it is guarded by `configs instanceof Array` and `util.isArrayOfString(...)` to keep the same tolerance for malformed third-party data. It also sits after `deepCopy`, so when merging it reads the same normalized copy the existing merge loop reads.

## Testing

I drove `provideCustomConfigurationAsync` against the compiled extension with a stub provider and compared every case to `main`:

| `**` comes from | `mergeConfigurations` | before | after |
| --- | --- | --- | --- |
| `c_cpp_properties.json` only | on | warns | no warning |
| the provider | on | warns | warns |
| `c_cpp_properties.json` only | off | no warning | no warning |
| the provider | off | warns | warns |

I also checked malformed provider input that the pre-patch code tolerated, so the earlier validation is not skipped: an `includePath` that is not an array, an array-like object instead of an array, and a falsy first element all behave exactly as they did before.

One difference worth flagging: an item that carries a recursive include *and* fails validation for an unrelated reason now produces the recursive-include warning in addition to the existing "discarding invalid SourceFileConfigurationItem" one, because the check no longer sits behind that validation. Both are `console.warn` diagnostics for provider authors and neither item is sent either way, but I can restrict the check to fully valid items if you would rather keep that exact.

`tsc --build`, `eslint src test ui .scripts`, the unit suite (193 passing) and `git diff --check` are all clean. I could not run the `SimpleCppProject` integration suite, which is where a regression test for this would belong, because it needs the native binaries and I have no way to run it here, so I did not add a test I could not execute.
