### PR TITLE
Reduce settings change noise

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -38,7 +38,7 @@ import { CppConfigurationLanguageModelTool } from './lmTool';
 import { getLocaleId } from './localization';
 import { PersistentState } from './persistentState';
 import { NodeType, TreeNode } from './referencesModel';
-import { CppSettings } from './settings';
+import { CppSettings, trackedSections } from './settings';
 import { LanguageStatusUI, getUI } from './ui';
 import { makeLspRange, rangeEquals, showInstallCompilerWalkthrough } from './utils';
 
@@ -293,7 +293,7 @@ export function updateLanguageConfigurations(): void {
 async function onDidChangeSettings(event: vscode.ConfigurationChangeEvent): Promise<void> {
     clients.forEach(client => {
         if (client instanceof DefaultClient) {
-            if (['C_Cpp', 'files', 'editor', 'search', 'workbench'].some(section => event.affectsConfiguration(section, client.RootUri))) {
+            if (trackedSections.some(section => event.affectsConfiguration(section, client.RootUri))) {
                 void client.onDidChangeSettings(event).catch(logAndReturn.undefined);
             }
         }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -293,7 +293,9 @@ export function updateLanguageConfigurations(): void {
 async function onDidChangeSettings(event: vscode.ConfigurationChangeEvent): Promise<void> {
     clients.forEach(client => {
         if (client instanceof DefaultClient) {
-            void client.onDidChangeSettings(event).catch(logAndReturn.undefined);
+            if (['C_Cpp', 'files', 'editor', 'search', 'workbench'].some(section => event.affectsConfiguration(section, client.RootUri))) {
+                void client.onDidChangeSettings(event).catch(logAndReturn.undefined);
+            }
         }
     });
 }

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -32,6 +32,10 @@ export interface Associations {
     [key: string]: string;
 }
 
+// The settings sections that we provide accessors for.
+// This is used to filter out settings changed events that do not impact the extension.
+export const trackedSections: string[] = ['C_Cpp', 'editor', 'files', 'search', 'workbench'];
+
 // Settings that can be undefined have default values assigned in the native code or are meant to return undefined.
 export interface WorkspaceFolderSettingsParams {
     uri: string | undefined;


### PR DESCRIPTION
While testing the other PR for ensuring language client readiness, we saw excessive calls to `onDidChangeSettings`. These have been around for a while and it turns out that there is a filtering API on the event that we can use to skip over settings changes that we don't care about. It's not perfectly granular, but does reduce the number of "no op" settings change events we need to process on the native side.

Tested with single folder workspace, multi-root workspace, and no folder opened workspace.