### PR TITLE
rename telemetry properties

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -1767,8 +1767,8 @@ export class DefaultClient implements Client {
             errorHandler: {
                 error: (error, message, count) => {
                     telemetry.logLanguageServerEvent("languageClientError", {
-                        error: error.toString(),
-                        message: message?.toString() ?? '',
+                        clientError: error.toString(),
+                        clientMessage: message?.toString() ?? '',
                         count: count?.toString() ?? ''
                     });
                     return { action: ErrorAction.Continue };


### PR DESCRIPTION
I hit that problem again where telemetry doesn't come through for certain properties because someone made them common properties. I checked that these names are ok.