### PR TITLE
Don't discard custom configurations whose uri is a vscode.Uri

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2328,6 +2328,21 @@ export class DefaultClient implements Client {
             if (configs && configs.length > 0 && configs[0]) {
                 const fileConfiguration: configs.Configuration | undefined = this.configuration.CurrentConfiguration;
                 if (fileConfiguration?.mergeConfigurations) {
+                    // deepCopy is a JSON round trip, which a vscode.Uri does not survive. The copy is
+                    // a plain object that is neither a string nor a Uri, so sendCustomConfigurations
+                    // discards the item. The uri field also accepts a string, so normalize it into a
+                    // new item before copying, without assigning into what the provider returned or
+                    // calling a method on its array.
+                    if (configs instanceof Array) {
+                        const normalized: util.Mutable<SourceFileConfigurationItem>[] = [];
+                        const count: number = configs.length;
+                        for (let i: number = 0; i < count; ++i) {
+                            const config: util.Mutable<SourceFileConfigurationItem> = configs[i];
+                            const uri = config?.uri;
+                            normalized.push(util.isUri(uri) ? { uri: uri.toString(), configuration: config.configuration } : config);
+                        }
+                        configs = normalized;
+                    }
                     configs = deepCopy(configs);
                     configs.forEach(config => {
                         if (fileConfiguration.includePath) {


### PR DESCRIPTION
Fixes #14621

With `C_Cpp.mergeConfigurations` enabled, `provideCustomConfigurationAsync` deep copies the provider's configurations before merging in the entries from `c_cpp_properties.json`. `deepCopy` is `JSON.parse(JSON.stringify(...))` and `vscode.Uri` declares `toJSON()`, so the round trip leaves a plain object behind. `isSourceFileConfigurationItem` accepts only a string or a real `Uri`, so every item a provider returned with a `vscode.Uri` was discarded, `sanitized.length` was 0, and nothing reached the language server.

`SourceFileConfigurationItem.uri` is declared `string | vscode.Uri` and `sendCustomConfigurations` already converts a `Uri` with `toString()`, so this normalizes the field to a string before the copy, which is the option you preferred on the issue.

Makefile Tools builds its items with a `Uri` object, in [`src/extension.ts`](https://github.com/microsoft/vscode-makefile-tools/blob/main/src/extension.ts):

```ts
let uri: vscode.Uri = vscode.Uri.file(filePath);
let sourceFileConfigurationItem: cpptools.SourceFileConfigurationItem = {
    uri,
    configuration,
    compileCommand: { ... }
};
```

CMake Tools passes `vscode.Uri.file(absolutePath).toString()`, a string.

Measured by driving `provideCustomConfigurationAsync` with a stub provider and recording what reaches `sendCustomConfigurations`:

| `uri` | `mergeConfigurations` | before | after |
| --- | --- | --- | --- |
| string | off | all | all |
| string | on | all | all |
| `vscode.Uri` | off | all | all |
| `vscode.Uri` | on | none | all |

The string the item now carries is the result of the same `Uri.toString()` call the merge off path already made, and `sendCustomConfigurations` passes a string that starts with `file://` through unchanged.

Two details are separable, if you would rather not have them:

- The `configs instanceof Array` guard. `sendCustomConfigurations` gates on that same test, so a value that is array like but not an `Array` is discarded there today with merge off, which I measured. Removing the guard makes that value work with merge on while it still fails with merge off.
- The index loop rather than `configs.map`, and building a new item rather than spreading the old one. Today this function calls no method on the array the provider returns, and the deep copy reads `uri` once. I measured three inputs against both: an array whose own `map` is shadowed, an item whose `uri` is a getter, and an array like object. With `configs.map` the first one stopped delivering an item that is delivered today; with the spread the second one read `uri` twice. The version in this PR leaves all three as they are today. `sendCustomConfigurations` reads only `uri` and `configuration`, so anything else a provider attaches to an item, such as the `compileCommand` field above, is dropped there either way.

One behavior difference worth naming: with merge on, an item whose `uri` is a `Uri` with a scheme other than `file` now arrives as `file:///<the original uri>`, because `sendCustomConfigurations` treats any string that does not start with `file://` as an fsPath. I measured that this is already what a provider gets today when it passes that same value as a string, in both merge modes. The API documents the field as following the file URI scheme.

No test is included. Nothing in the unit suite loads the `vscode` module, so a test for this would go in the integration suite, which needs the native binaries, and I did not want to add a test I could not run. `tsc --build`, the full lint, the 193 unit tests and `git diff --check` are clean.

This touches the same lines as #14620. Whichever lands first, I will rebase the other.
