### PR TITLE
Bump brace-expansion to latest patched versions (1.1.18, 2.1.4, 5.0.9)

### DIFF
--- a/.github/actions/package-lock.json
+++ b/.github/actions/package-lock.json
@@ -2872,9 +2872,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4551,9 +4551,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/Extension/ThirdPartyNotices.txt
+++ b/Extension/ThirdPartyNotices.txt
@@ -1487,7 +1487,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-brace-expansion 1.1.16 - MIT
+brace-expansion 1.1.18 - MIT
 https://github.com/juliangruber/brace-expansion
 
 Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
@@ -1519,7 +1519,7 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
-brace-expansion 2.1.2 - MIT
+brace-expansion 2.1.4 - MIT
 https://github.com/juliangruber/brace-expansion
 
 Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -1737,24 +1737,24 @@ boundary@^2.0.0:
   integrity sha1-FpyLHw1Ezywlk4lnoyjzfgpOXvw=
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=
+  version "1.1.18"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.1.2"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=
+  version "2.1.4"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=
   dependencies:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.8"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=
+  version "5.0.9"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha1-fHJDiAm1+lur9UGZofHCgaaYT88=
   dependencies:
     balanced-match "^4.0.2"
 

--- a/ExtensionPack/package-lock.json
+++ b/ExtensionPack/package-lock.json
@@ -948,16 +948,16 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+            "version": "5.0.9",
+            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {

--- a/Themes/package-lock.json
+++ b/Themes/package-lock.json
@@ -948,16 +948,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
## Summary

Bumps the transitive `brace-expansion` dependency to the latest patch on each version line, picking up the brace-expansion ReDoS fix and clearing the outstanding Dependabot alert:

- `1.1.16` → `1.1.18`
- `2.1.2` → `2.1.4`
- `5.0.8` → `5.0.9`

Applied across every lockfile/manifest that pins it:

- `.github/actions/package-lock.json` (top-level, plus the `glob` and `mocha` nested copies)
- `Extension/yarn.lock`
- `Extension/ThirdPartyNotices.txt`
- `ExtensionPack/package-lock.json`
- `Themes/package-lock.json`

Each entry's `resolved` URL and `integrity` were updated to match the published tarballs — verified by downloading each tarball and confirming its sha1 matches the recorded integrity, so `npm ci` / `yarn --frozen-lockfile` stay reproducible. The `engines` field for `5.0.9` was updated to `20 || >=22` to match the package's own metadata.

> This PR was investigated and created by Copilot with `Claude Opus 4.8` (in VS Code). Any message starting with `✨ Copilot: ` was sent by Copilot.