### PR TITLE
Update dependencies to address security advisories

### DIFF
--- a/.github/actions/package-lock.json
+++ b/.github/actions/package-lock.json
@@ -4181,9 +4181,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
+      "version": "10.3.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha1-kp+WKdFyT34bdIXOiXUvNnUzahA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5463,9 +5463,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha1-Qfnkj3xaQNJzdsqurYyan8e8qcQ=",
+      "version": "6.28.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha1-nw44V0T+9QIdZZbFvM14P2EZPBw=",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7258,7 +7258,7 @@
         "which": "^2.0.2"
     },
     "resolutions": {
-        "postcss": "^8.5.18",
+        "postcss": "^8.5.23",
         "gulp-typescript/**/glob-parent": "^5.1.2",
         "serialize-javascript": "^7.0.5",
         "@azure/msal-browser": "^4.29.1",

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -4996,10 +4996,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha1-k+NYK8DlQmWG2dB7ee5A/IQd5K4=
 
-postcss@^7.0.16, postcss@^8.5.18:
-  version "8.5.22"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/postcss/-/postcss-8.5.22.tgz#086a0d5685a715acf5950ebbcb1538faf3051697"
-  integrity sha1-CGoNVoWnFaz1lQ67yxU4+vMFFpc=
+postcss@^7.0.16, postcss@^8.5.23:
+  version "8.5.25"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=
   dependencies:
     nanoid "^3.3.16"
     picocolors "^1.1.1"
@@ -6241,7 +6241,7 @@ undici-types@~7.18.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha1-KTV6iee3ykrvO/D9P9DNc4hCKek=
 
-undici@^7.19.0, undici@^7.28.0:
+undici@^7.19.0, undici@^7.29.0:
   version "7.29.0"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
   integrity sha1-rg9vYuBuBXqcu3srX94rt095G48=

--- a/ExtensionPack/package-lock.json
+++ b/ExtensionPack/package-lock.json
@@ -3642,9 +3642,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha1-l9ZFZBmLKFvCgfDo4pWX49Ef5+w=",
+            "version": "7.29.0",
+            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha1-rg9vYuBuBXqcu3srX94rt095G48=",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## Summary

Updates transitive dependencies to patched releases:
- `ip-address` to 10.3.1 and `undici` to 6.28.0 for the GitHub Actions package
- `postcss` to 8.5.25 for the main extension
- `undici` to 7.29.0 for the Extension Pack

The remaining `fast-uri@3.1.4` advisory is not addressed because its patched release, 3.1.5, is not currently available from the repository's configured npm registry.

## Validation

- The GitHub Actions package reports zero audit vulnerabilities.
- The main extension passes a frozen Yarn install and TypeScript compilation.
- The main extension and Extension Pack audits report only the unavailable `fast-uri@3.1.5` fix.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.