### PR TITLE
Update Node.js developer setup documentation

### DIFF
--- a/Documentation/Building the Extension.md
+++ b/Documentation/Building the Extension.md
@@ -5,7 +5,7 @@ These steps will allow you to debug the TypeScript code that is part of the Micr
 Prerequisite steps:
   * Clone the release branch of [this](https://github.com/Microsoft/vscode-cpptools) repository.
       * git clone -b release https://github.com/Microsoft/vscode-cpptools
-  * Install [node](https://nodejs.org).
+  * Install the [required Node.js version](../Extension/readme.developer.md#required-tools).
   * Install [yarn](https://yarnpkg.com).
   * From a command line, run the following commands from the **Extension** folder in the root of the repository:
       * `yarn install` will install the dependencies needed to build the extension.

--- a/Extension/readme.developer.md
+++ b/Extension/readme.developer.md
@@ -35,7 +35,7 @@
 
 ### Required Tools 
 
-* [Node.js](https://nodejs.org/en/download/) v16.*
+* [Node.js](https://nodejs.org/en/download/) 24.x
 * npm (comes with Node.js)
 
 ### Setting up the repository


### PR DESCRIPTION
## Summary

Updates the extension developer prerequisites from Node.js 16.x to Node.js 24.x, matching the version used by the GitHub compile-and-test workflows. The secondary extension-building guide now links to that canonical prerequisite instead of maintaining a separate Node.js version that could drift.

This follows up on the Node.js compatibility discussion in #14633. The related Node.js pins were also audited:

- GitHub compile/test workflows and custom actions consistently use Node.js 24.
- Azure packaging, publishing, component-governance, and localization pipelines consistently use Node.js 22, which remains supported by the current dependency graph and was intentionally introduced as a separate production baseline.
- TypeScript `module: node16`, `@types/node`, and Node.js runtime comments are module/type or VS Code extension-host compatibility settings, not developer build-tool version pins.

Validation: `git diff --check`, relative link target/anchor verification, and a repository documentation search confirming no stale Node.js 16 prerequisite remains.

> This PR was investigated and created by Copilot with `GPT 5.6 Sol` (in VS Code). Any message starting with `✨ Copilot: ` was sent by Copilot.