### PR TITLE
Fix C++ agent definition lookup returning declarations

### DIFF
--- a/Extension/src/LanguageServer/Providers/goToDefinitionProvider.ts
+++ b/Extension/src/LanguageServer/Providers/goToDefinitionProvider.ts
@@ -3,9 +3,15 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as vscode from 'vscode';
-import { Definition, DefinitionLink, DefinitionRequest, Position, ResponseError, TextDocumentPositionParams } from 'vscode-languageclient';
+import { Definition, DefinitionLink, Position, RequestType, ResponseError, TextDocumentPositionParams } from 'vscode-languageclient';
 import { DefaultClient } from '../client';
 import { RequestCancelled, ServerCancelled } from '../protocolFilter';
+
+const StandardDefinitionRequest: RequestType<TextDocumentPositionParams, Definition | DefinitionLink[] | null, void> =
+    new RequestType<TextDocumentPositionParams, Definition | DefinitionLink[] | null, void>('textDocument/definition');
+
+const DefinitionForAgentRequest: RequestType<TextDocumentPositionParams, Definition | DefinitionLink[] | null, void> =
+    new RequestType<TextDocumentPositionParams, Definition | DefinitionLink[] | null, void>('cpptools/definitionForAgent');
 
 function convertDefinitionsToLocations(definitionsResult: vscode.Definition | vscode.DefinitionLink[] | undefined): vscode.Location[] {
     if (!definitionsResult) {
@@ -28,14 +34,20 @@ function convertDefinitionsToLocations(definitionsResult: vscode.Definition | vs
     return result;
 }
 
-export async function sendGoToDefinitionRequest(client: DefaultClient, uri: vscode.Uri, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Location[] | undefined> {
+async function sendGoToDefinitionRequest(
+    client: DefaultClient,
+    uri: vscode.Uri,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    requestType: RequestType<TextDocumentPositionParams, Definition | DefinitionLink[] | null, void>
+): Promise<vscode.Location[] | undefined> {
     const params: TextDocumentPositionParams = {
         position: Position.create(position.line, position.character),
         textDocument: { uri: uri.toString() }
     };
     let response: Definition | DefinitionLink[] | null;
     try {
-        response = await client.languageClient.sendRequest(DefinitionRequest.type, params, token);
+        response = await client.languageClient.sendRequest(requestType, params, token);
     } catch (e: any) {
         if (e instanceof ResponseError && (e.code === RequestCancelled || e.code === ServerCancelled)) {
             return undefined;
@@ -54,4 +66,22 @@ export async function sendGoToDefinitionRequest(client: DefaultClient, uri: vsco
     }
 
     return convertDefinitionsToLocations(result);
+}
+
+export function sendStandardGoToDefinitionRequest(
+    client: DefaultClient,
+    uri: vscode.Uri,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+): Promise<vscode.Location[] | undefined> {
+    return sendGoToDefinitionRequest(client, uri, position, token, StandardDefinitionRequest);
+}
+
+export function sendGoToDefinitionForAgentRequest(
+    client: DefaultClient,
+    uri: vscode.Uri,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+): Promise<vscode.Location[] | undefined> {
+    return sendGoToDefinitionRequest(client, uri, position, token, DefinitionForAgentRequest);
 }

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -25,7 +25,7 @@ import * as telemetry from '../telemetry';
 import { CopilotHoverProvider } from './Providers/CopilotHoverProvider';
 import { sendCallHierarchyCallsFromRequest, sendCallHierarchyCallsToRequest, sendPrepareCallHierarchyRequest } from './Providers/callHierarchyProvider';
 import { sendFindAllReferencesRequest } from './Providers/findAllReferencesProvider';
-import { sendGoToDefinitionRequest } from './Providers/goToDefinitionProvider';
+import { sendGoToDefinitionForAgentRequest, sendStandardGoToDefinitionRequest } from './Providers/goToDefinitionProvider';
 import { Client, DefaultClient, DoxygenCodeActionCommandArguments, openFileVersions } from './client';
 import { ClientCollection } from './clientCollection';
 import { CodeActionDiagnosticInfo, CodeAnalysisDiagnosticIdentifiersAndUri, codeAnalysisAllFixes, codeAnalysisCodeToFixes, codeAnalysisFileToCodeActions } from './codeAnalysis';
@@ -405,6 +405,7 @@ export async function registerCommands(enabled: boolean): Promise<void> {
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.ShowReferencesProgress', enabled ? onShowReferencesProgress : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.FindAllReferences', enabled ? onFindAllReferences : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.GoToDefinition', enabled ? onGoToDefinition : onDisabledCommand));
+    commandDisposables.push(vscode.commands.registerCommand('C_Cpp.GoToDefinitionForAgent', enabled ? onGoToDefinitionForAgent : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.PrepareCallHierarchy', enabled ? onPrepareCallHierarchy : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CallHierarchyCallsTo', enabled ? onCallHierarchyCallsTo : onDisabledCommand));
     commandDisposables.push(vscode.commands.registerCommand('C_Cpp.CallHierarchyCallsFrom', enabled ? onCallHierarchyCallsFrom : onDisabledCommand));
@@ -893,7 +894,21 @@ async function onGoToDefinition(uri: vscode.Uri, position: vscode.Position, toke
     }
 
     await client.ready;
-    return sendGoToDefinitionRequest(client, uri, position, token ?? CancellationToken.None);
+    return sendStandardGoToDefinitionRequest(client, uri, position, token ?? CancellationToken.None);
+}
+
+async function onGoToDefinitionForAgent(uri: vscode.Uri, position: vscode.Position, token?: vscode.CancellationToken): Promise<vscode.Location[] | undefined> {
+    if (!uri || !position) {
+        throw new Error("C_Cpp.GoToDefinitionForAgent requires both a uri and position.");
+    }
+
+    const client: Client = clients.getClientFor(uri);
+    if (!(client instanceof DefaultClient)) {
+        return undefined;
+    }
+
+    await client.ready;
+    return sendGoToDefinitionForAgentRequest(client, uri, position, token ?? CancellationToken.None);
 }
 
 async function onPrepareCallHierarchy(uri: vscode.Uri, position: vscode.Position, token?: vscode.CancellationToken): Promise<vscode.CallHierarchyItem[] | undefined> {


### PR DESCRIPTION
Tracks [DevDiv 2860151](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2860151) and [DevDiv 3030687](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3030687).

Agent lookup currently routes through the human definition request, which may return declarations. This adds an internal command backed by the strict native request while preserving standard navigation behavior.