### PR TITLE
Document the macOS formatting dependency

### DIFF
--- a/Extension/ThirdPartyNotices.txt
+++ b/Extension/ThirdPartyNotices.txt
@@ -2979,6 +2979,7 @@ The notices below are from non-npm sources.
 - C++11 Sublime Text Snippets (https://github.com/Rapptz/cpp-sublime-snippet)
 - Clang (https://clang.llvm.org/)
 - editorconfig-core-js (https://github.com/editorconfig/editorconfig-core-js)
+- fmt (https://github.com/fmtlib/fmt)
 - gcc-11/libgcc (https://packages.ubuntu.com/jammy/gcc-11-base)
 - Guidelines Support Library (https://github.com/Microsoft/GSL)
 - libc++ (https://libcxx.llvm.org/index.html)
@@ -3253,6 +3254,38 @@ THE SOFTWARE.
 
 =========================================
 END OF editorconfig-core-js NOTICES AND INFORMATION
+
+%% fmt NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.
+=========================================
+END OF fmt NOTICES AND INFORMATION
 
 %% gcc-9/libgcc NOTICES AND INFORMATION BEGIN HERE
 =========================================


### PR DESCRIPTION
The macOS logging compatibility backend uses `{fmt}` as a shipping dependency. Include its license in the extension's third-party notices.