### PR TITLE
Update js-yaml in remaining lockfiles

### DIFF
--- a/.github/actions/package-lock.json
+++ b/.github/actions/package-lock.json
@@ -4302,9 +4302,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+      "version": "4.3.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
         {

--- a/ExtensionPack/package-lock.json
+++ b/ExtensionPack/package-lock.json
@@ -2097,9 +2097,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+            "version": "4.3.1",
+            "resolved": "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

Updates the remaining transitive `js-yaml` resolutions in the GitHub Actions and Extension Pack lockfiles from 4.3.0 to patched version 4.3.1.

## Validation

- Clean `npm ci` completed for both package roots.
- `npm ls js-yaml --all` resolves only 4.3.1 in both roots.
- `npm audit` reports zero vulnerabilities in both roots.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.