### PR TITLE
Update nanoid to 3.3.17

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7259,6 +7259,7 @@
     },
     "resolutions": {
         "postcss": "^8.5.23",
+        "nanoid": "^3.3.17",
         "gulp-typescript/**/glob-parent": "^5.1.2",
         "serialize-javascript": "^7.0.5",
         "@azure/msal-browser": "^4.29.1",

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -4493,10 +4493,10 @@ mute-stream@~0.0.4:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=
+nanoid@^3.3.16, nanoid@^3.3.17:
+  version "3.3.17"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=
 
 napi-build-utils@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Adds a Yarn `^3.3.17` resolution for the transitive `nanoid` dependency and updates the lockfile to 3.3.17, addressing the audit advisory inherited through `gulp-sourcemaps`.

## Validation

- `yarn audit --level high` (0 vulnerabilities)
- `yarn install --frozen-lockfile --offline --ignore-scripts`
- `yarn compile`

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.