### PR TITLE
Use frozen lockfile for webpack install

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7172,7 +7172,7 @@
         "watch": "yarn install && (yarn verify prep --quiet || yarn prep) && tsc --build tsconfig.json --watch",
         "rebuild": "yarn install && yarn clean && yarn prep && yarn build",
         "vsix-prepublish": "npm run bootstrap && yarn clean && yarn webpack",
-        "webpack": "yarn install && (yarn verify prep --quiet || yarn prep) && tsc --build ui.tsconfig.json && webpack --mode production --env vscode_nls",
+        "webpack": "yarn install --frozen-lockfile && (yarn verify prep --quiet || yarn prep) && tsc --build ui.tsconfig.json && webpack --mode production --env vscode_nls",
         "generate-native-strings": "ts-node -T ./.scripts/generateNativeStrings.ts",
         "generate-options-schema": "ts-node -T ./.scripts/generateOptionsSchema.ts",
         "copy-walkthrough-media": "ts-node -T ./.scripts/copyWalkthruMedia.ts",


### PR DESCRIPTION
## Summary

A VSIX packaging build failed when the `yarn install` invoked by the `webpack` script attempted package resolution and exited with a network `EACCES` error. Update that nested install to use `--frozen-lockfile`, matching the bootstrap install and preventing lockfile-changing registry resolution during packaging.

## Validation

- Ran `yarn install --frozen-lockfile --offline --ignore-scripts --non-interactive` successfully.
- Verified `package.json` parses and the `webpack` script invokes the frozen install.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.