### PR TITLE
Update changelog for 1.33.7

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.33.7: August 11, 2026
+### Bug Fixes
+* Fix another crash when reading files saved in certain multibyte encodings such as GB18030 or EUC-JP.
+* Fix newly created files not being associated with the correct configuration in the browse database.
+* Fix the language server becoming unresponsive during browse database initialization.
+* Fix stale diagnostics and missing code actions after editing visible headers.
+* Fix `/ZW:nostdlib` not being processed correctly by IntelliSense.
+* Update dependencies.
+
 ## Version 1.33.6: August 4, 2026
 ### Bug Fixes
 * Fix a spurious recursive includes (`**`) debug console log warning for paths merged from `c_cpp_properties.json` when `C_Cpp.mergeConfigurations` is enabled. [#14125](https://github.com/microsoft/vscode-cpptools/issues/14125)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.33.6-main",
+    "version": "1.33.7-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
## Summary
Update the C/C++ extension changelog for version 1.33.7 and bump the package version.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.