### PR TITLE
Lock localization literals

### DIFF
--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -863,17 +863,52 @@
     "c_cpp.debuggers.pipeTransport.pipeEnv.description": "Environment variables passed to the pipe program.",
     "c_cpp.debuggers.pipeTransport.quoteArgs.description": "If the pipeProgram's individual arguments contain characters (such as spaces or tabs), should it be quoted? If 'false', the debugger command will no longer be automatically quoted. Default is 'true'.",
     "c_cpp.debuggers.logging.description": "Optional flags to determine what types of messages should be logged to the Debug Console.",
-    "c_cpp.debuggers.logging.exceptions.description": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
-    "c_cpp.debuggers.logging.moduleLoad.description": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",
-    "c_cpp.debuggers.logging.programOutput.description": "Optional flag to determine whether program output should be logged to the Debug Console. Defaults to true.",
-    "c_cpp.debuggers.logging.engineLogging.description": "Optional flag to determine whether diagnostic debug engine messages should be logged to the Debug Console. Defaults to false.",
-    "c_cpp.debuggers.logging.trace.description": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the Debug Console. Defaults to false.",
-    "c_cpp.debuggers.logging.traceResponse.description": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the Debug Console. Defaults to false.",
+    "c_cpp.debuggers.logging.exceptions.description": {
+        "message": "Optional flag to determine whether exception messages should be logged to the Debug Console. Defaults to true.",
+        "comment": [
+            "{Locked=\"true\"}"
+        ]
+    },
+    "c_cpp.debuggers.logging.moduleLoad.description": {
+        "message": "Optional flag to determine whether module load events should be logged to the Debug Console. Defaults to true.",
+        "comment": [
+            "{Locked=\"true\"}"
+        ]
+    },
+    "c_cpp.debuggers.logging.programOutput.description": {
+        "message": "Optional flag to determine whether program output should be logged to the Debug Console. Defaults to true.",
+        "comment": [
+            "{Locked=\"true\"}"
+        ]
+    },
+    "c_cpp.debuggers.logging.engineLogging.description": {
+        "message": "Optional flag to determine whether diagnostic debug engine messages should be logged to the Debug Console. Defaults to false.",
+        "comment": [
+            "{Locked=\"false\"}"
+        ]
+    },
+    "c_cpp.debuggers.logging.trace.description": {
+        "message": "Optional flag to determine whether diagnostic adapter command tracing should be logged to the Debug Console. Defaults to false.",
+        "comment": [
+            "{Locked=\"false\"}"
+        ]
+    },
+    "c_cpp.debuggers.logging.traceResponse.description": {
+        "message": "Optional flag to determine whether diagnostic adapter command and response tracing should be logged to the Debug Console. Defaults to false.",
+        "comment": [
+            "{Locked=\"false\"}"
+        ]
+    },
     "c_cpp.debuggers.cppvsdbg.logging.threadExit.description": "Optional flag to determine whether thread exit messages should be logged to the Debug Console. Default: false.",
     "c_cpp.debuggers.cppvsdbg.logging.processExit.description": "Optional flag to determine whether target process exit messages should be logged to the Debug Console. Default: true.",
     "c_cpp.debuggers.text.description": "The debugger command to execute.",
     "c_cpp.debuggers.description.description": "Optional description for the command.",
-    "c_cpp.debuggers.ignoreFailures.description": "If true, failures from the command should be ignored. Default value is false.",
+    "c_cpp.debuggers.ignoreFailures.description": {
+        "message": "If true, failures from the command should be ignored. Default value is false.",
+        "comment": [
+            "{Locked=\"true\"} {Locked=\"false\"}"
+        ]
+    },
     "c_cpp.debuggers.program.description": "Full path to program executable.",
     "c_cpp.debuggers.args.description": "Command line arguments passed to the program.",
     "c_cpp.debuggers.targetArchitecture.description": "The architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are x86, arm, arm64, mips, x64, amd64, x86_64.",
@@ -912,14 +947,29 @@
     "c_cpp.debuggers.filterStderr.description": "Search stderr stream for server-started pattern and log stderr to debug output. Defaults to false.",
     "c_cpp.debuggers.serverLaunchTimeout.description": "Optional time, in milliseconds, for the debugger to wait for the debugServer to start up. Default is 10000.",
     "c_cpp.debuggers.coreDumpPath.description": "Optional full path to a core dump file for the specified program. Defaults to null.",
-    "c_cpp.debuggers.cppdbg.externalConsole.description": "If true, a console is launched for the debuggee. If false, on Linux and Windows, it will appear in the Integrated Console.",
-    "c_cpp.debuggers.cppvsdbg.externalConsole.description": "[Deprecated by 'console'] If true, a console is launched for the debuggee. If false, no console is launched.",
+    "c_cpp.debuggers.cppdbg.externalConsole.description": {
+        "message": "If true, a console is launched for the debuggee. If false, on Linux and Windows, it will appear in the Integrated Console.",
+        "comment": [
+            "{Locked=\"true\"} {Locked=\"false\"}"
+        ]
+    },
+    "c_cpp.debuggers.cppvsdbg.externalConsole.description": {
+        "message": "[Deprecated by 'console'] If true, a console is launched for the debuggee. If false, no console is launched.",
+        "comment": [
+            "{Locked=\"'console'\"} {Locked=\"true\"} {Locked=\"false\"}"
+        ]
+    },
     "c_cpp.debuggers.cppvsdbg.console.description": "Where to launch the debug target. Defaults to 'internalConsole' if not defined.",
     "c_cpp.debuggers.cppvsdbg.console.internalConsole.description": "Output to the VS Code Debug Console. This doesn't support reading console input (ex:'std::cin' or 'scanf').",
     "c_cpp.debuggers.cppvsdbg.console.integratedTerminal.description": "VS Code's integrated terminal.",
     "c_cpp.debuggers.cppvsdbg.console.externalTerminal.description": "Console applications will be launched in an external terminal window. The window will be reused in relaunch scenarios and will not automatically disappear when the application exits.",
     "c_cpp.debuggers.cppvsdbg.console.newExternalWindow.description": "Console applications will be launched in their own external console window which will end when the application stops. Non-console applications will run without a terminal, and stdout/stderr will be ignored.",
-    "c_cpp.debuggers.avoidWindowsConsoleRedirection.description": "If true, disables debuggee console redirection that is required for Integrated Terminal support.",
+    "c_cpp.debuggers.avoidWindowsConsoleRedirection.description": {
+        "message": "If true, disables debuggee console redirection that is required for Integrated Terminal support.",
+        "comment": [
+            "{Locked=\"true\"}"
+        ]
+    },
     "c_cpp.debuggers.sourceFileMap.markdownDescription": {
         "message": "Optional source file mappings passed to the debug engine. Example: `{ \"<original source path>\": \"<current source path>\" }`.",
         "comment": [
@@ -940,10 +990,25 @@
     },
     "c_cpp.debuggers.symbolSearchPath.description": "Semicolon separated list of directories to use to search for symbol (that is, pdb or .so) files. Example: \"c:\\dir1;c:\\dir2\".",
     "c_cpp.debuggers.dumpPath.description": "Optional full path to a dump file for the specified program. Example: \"c:\\temp\\app.dmp\". Defaults to null.",
-    "c_cpp.debuggers.enableDebugHeap.description": "If false, the process will be launched with debug heap disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+    "c_cpp.debuggers.enableDebugHeap.description": {
+        "message": "If false, the process will be launched with debug heap disabled. This sets the environment variable '_NO_DEBUG_HEAP' to '1'.",
+        "comment": [
+            "{Locked=\"false\"} {Locked=\"_NO_DEBUG_HEAP\"} {Locked=\"1\"}"
+        ]
+    },
     "c_cpp.debuggers.symbolLoadInfo.description": "Explicit control of symbol loading.",
-    "c_cpp.debuggers.symbolLoadInfo.loadAll.description": "If true, symbols for all libs will be loaded, otherwise no solib symbols will be loaded. Default value is true.",
-    "c_cpp.debuggers.symbolLoadInfo.exceptionList.description": "List of filenames (wildcards allowed) separated by semicolons ';'. Modifies behavior of LoadAll. If LoadAll is true then don't load symbols for libs that match any name in the list. Otherwise only load symbols for libs that match. Example: \"foo.so;bar.so\".",
+    "c_cpp.debuggers.symbolLoadInfo.loadAll.description": {
+        "message": "If true, symbols for all libs will be loaded, otherwise no solib symbols will be loaded. Default value is true.",
+        "comment": [
+            "{Locked=\"true\"}"
+        ]
+    },
+    "c_cpp.debuggers.symbolLoadInfo.exceptionList.description": {
+        "message": "List of filenames (wildcards allowed) separated by semicolons ';'. Modifies behavior of LoadAll. If LoadAll is true then don't load symbols for libs that match any name in the list. Otherwise only load symbols for libs that match. Example: \"foo.so;bar.so\".",
+        "comment": [
+            "{Locked=\";\"} {Locked=\"LoadAll\"} {Locked=\"true\"} {Locked=\"foo.so;bar.so\"}"
+        ]
+    },
     "c_cpp.debuggers.requireExactSource.description": "Optional flag to require current source code to match the pdb.",
     "c_cpp.debuggers.stopAtConnect.description": "If true, the debugger should stop after connecting to the target. If false, the debugger will continue after connecting. Defaults to false.",
     "c_cpp.debuggers.hardwareBreakpoints.description": "Explicit control of hardware breakpoint behavior for remote targets.",
@@ -1009,7 +1074,12 @@
     "c_cpp.taskDefinitions.detail.description": "Additional details of the task.",
     "c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.description": "Current and compile-time paths to the same source trees. Files found under the EditorPath are mapped to the CompileTimePath path for breakpoint matching and mapped from CompileTimePath to EditorPath when displaying stacktrace locations.",
     "c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.editorPath.description": "The path to the source tree the editor will use.",
-    "c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.useForBreakpoints.description": "False if this entry is only used for stack frame location mapping. True if this entry should also be used when specifying breakpoint locations.",
+    "c_cpp.debuggers.sourceFileMap.sourceFileMapEntry.useForBreakpoints.description": {
+        "message": "Set to false if this entry is only used for stack frame location mapping. Set to true if this entry should also be used when specifying breakpoint locations.",
+        "comment": [
+            "{Locked=\"false\"} {Locked=\"true\"}"
+        ]
+    },
     "c_cpp.debuggers.symbolOptions.description": "Options to control how symbols (.pdb files) are found and loaded.",
     "c_cpp.debuggers.unknownBreakpointHandling.description": "Controls how breakpoints set externally (usually via raw GDB commands) are handled when hit.\nAllowed values are \"throw\", which acts as if an exception was thrown by the application, and \"stop\", which only pauses the debug session. The default value is \"throw\".",
     "c_cpp.debuggers.debuginfod.description": "Controls GDB's debuginfod behavior for downloading debug symbols from debuginfod servers.",

--- a/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
+++ b/Extension/src/Debugger/debugAdapterDescriptorFactory.ts
@@ -112,6 +112,6 @@ function logReasonForNoDebugNotSupported(configuration: vscode.DebugConfiguratio
     }
     outputChannel.appendLine(localize("debugger.unsupported.properties", "Launch configurations with the following properties cannot be run directly in the terminal: {0}", disallowedProperties.join(', ')));
     outputChannel.appendLine(localize("debugger.fallback.message", "Program output will appear in the Debug Console instead."));
-    outputChannel.appendLine(localize("debugger.fallback.message2", "To suppress this warning, set the 'ignoreRunWithoutDebuggingWarnings' property to true in your launch configuration."));
+    outputChannel.appendLine(localize({ key: "debugger.fallback.message2", comment: ["{Locked=\"ignoreRunWithoutDebuggingWarnings\"} {Locked=\"true\"}"] }, "To suppress this warning, set the 'ignoreRunWithoutDebuggingWarnings' property to true in your launch configuration."));
 }
 

--- a/Extension/src/nativeStrings.json
+++ b/Extension/src/nativeStrings.json
@@ -10,9 +10,18 @@
     "edit_include_path": "Edit \"includePath\" setting",
     "disable_error_squiggles": "Disable error squiggles",
     "enable_error_squiggles": "Enable all error squiggles",
-    "include_errors_update_include_path_squiggles_disabled2": "#include errors detected. Please update your includePath. Syntax errors for this file will not be reported until included files are found.",
-    "include_errors_update_include_path_intellisense_disabled": "#include errors detected. Please update your includePath. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
-    "include_errors_update_compile_commands_or_include_path_intellisense_disabled": "#include errors detected. Consider updating your compile_commands.json or includePath. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
+    "include_errors_update_include_path_squiggles_disabled2": {
+        "text": "#include errors detected. Please update your includePath. Syntax errors for this file will not be reported until included files are found.",
+        "hint": "{Locked=\"#include\"} {Locked=\"includePath\"}"
+    },
+    "include_errors_update_include_path_intellisense_disabled": {
+        "text": "#include errors detected. Please update your includePath. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
+        "hint": "{0} is the translation unit. {Locked=\"#include\"} {Locked=\"includePath\"} {Locked=\"{0}\"}"
+    },
+    "include_errors_update_compile_commands_or_include_path_intellisense_disabled": {
+        "text": "#include errors detected. Consider updating your compile_commands.json or includePath. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
+        "hint": "{0} is the translation unit. {Locked=\"#include\"} {Locked=\"compile_commands.json\"} {Locked=\"includePath\"} {Locked=\"{0}\"}"
+    },
     "could_not_parse_compile_commands": "\"{0}\" could not be parsed. 'includePath' from c_cpp_properties.json in folder '{1}' will be used instead.",
     "could_not_find_compile_commands": "\"{0}\" could not be found. 'includePath' from c_cpp_properties.json in folder '{1}' will be used instead.",
     "file_not_found_in_path": "\"{0}\" not found in \"{1}\". 'includePath' from c_cpp_properties.json in folder '{2}' will be used for this file instead.",
@@ -120,7 +129,10 @@
     "formatting_diff": "Formatting diffed output:",
     "disable_inactive_regions": "Disable inactive region colorization",
     "error_limit_exceeded": "Error limit exceeded, {0} error(s) not reported.",
-    "include_errors_update_compile_commands_or_include_path_squiggles_disabled2": "#include errors detected. Consider updating your compile_commands.json or includePath. Syntax errors for this file will not be reported until included files are found.",
+    "include_errors_update_compile_commands_or_include_path_squiggles_disabled2": {
+        "text": "#include errors detected. Consider updating your compile_commands.json or includePath. Syntax errors for this file will not be reported until included files are found.",
+        "hint": "{Locked=\"#include\"} {Locked=\"compile_commands.json\"} {Locked=\"includePath\"}"
+    },
     "cannot_reset_database": "The IntelliSense database could not be reset. To manually reset, close all VS Code instances and then delete this file: {0}",
     "formatting_failed_see_output": "Formatting failed. See the output window for details.",
     "populating_include_completion_cache": "Populating include completion cache.",
@@ -157,8 +169,14 @@
     "fallback_to_64_bit_mode2": "Failed to query compiler. Falling back to 64-bit intelliSenseMode.",
     "fallback_to_no_bitness": "Failed to query compiler. Falling back to no bitness.",
     "intellisense_client_creation_aborted": "IntelliSense client creation aborted: {0}",
-    "include_errors_config_provider_intellisense_disabled": "#include errors detected based on information provided by the configurationProvider setting. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
-    "include_errors_config_provider_squiggles_disabled2": "#include errors detected based on information provided by the configurationProvider setting. Syntax errors for this file will not be reported until included files are found.",
+    "include_errors_config_provider_intellisense_disabled": {
+        "text": "#include errors detected based on information provided by the configurationProvider setting. IntelliSense features for this translation unit ({0}) will be provided by the Tag Parser.",
+        "hint": "{0} is the translation unit. {Locked=\"#include\"} {Locked=\"configurationProvider\"} {Locked=\"{0}\"}"
+    },
+    "include_errors_config_provider_squiggles_disabled2": {
+        "text": "#include errors detected based on information provided by the configurationProvider setting. Syntax errors for this file will not be reported until included files are found.",
+        "hint": "{Locked=\"#include\"} {Locked=\"configurationProvider\"}"
+    },
     "preprocessor_keyword": {
         "text": "preprocessor keyword",
         "hint": "Refers to C/C++ processor keywords"
@@ -713,7 +731,7 @@
     },
     "check_requires_source": {
         "text": "--check requires a source file: --check=<file>",
-        "hint": "{Locked=\"--check\"} {Locked=\"--check=\"}"
+        "hint": "<file> is a placeholder for the source file path and should be translated. {Locked=\"--check\"} {Locked=\"--check=\"}"
     },
     "check_source_not_found": {
         "text": "source file not found: {0}",
@@ -725,7 +743,7 @@
     },
     "check_compile_commands_not_discovered": {
         "text": "could not find compile_commands.json in any parent directory of {0}; pass --check-compile-commands=<path> to specify it explicitly",
-        "hint": "{0} is the starting directory path. {Locked=\"compile_commands.json\"} {Locked=\"{0}\"} {Locked=\"--check-compile-commands=\"}"
+        "hint": "{0} is the starting directory path. <path> is a placeholder for the compile_commands.json path and should be translated. {Locked=\"compile_commands.json\"} {Locked=\"{0}\"} {Locked=\"--check-compile-commands=\"}"
     },
     "check_engine_init_failed": "failed to initialize the language engine",
     "check_no_workspace_folder": {


### PR DESCRIPTION
## Summary

Adds localization metadata to preserve technical literals that were mistranslated in #14662, including `#include`, configuration names, boolean values, and command-line option prefixes. The `file` and `path` metavariable labels inside angle brackets remain translatable and include explicit translator guidance.

The `useForBreakpoints` description is also rephrased from sentence-initial “False”/“True” wording to lowercase `false`/`true` literals so those values can be locked consistently.

## Validation

- Exported and inspected all affected XLF metadata
- Regenerated native localization artifacts and verified native message text was unchanged
- Ran focused ESLint and the Extension TypeScript build

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.