### PR TITLE
Respect inactive region column offsets when applying decorations

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -223,7 +223,9 @@ interface FileChangedParams extends WorkspaceFolderParams {
 
 interface InputRegion {
     startLine: number;
+    startColumn?: number;
     endLine: number;
+    endColumn?: number;
 }
 
 interface DecorationRangesPair {
@@ -3054,7 +3056,11 @@ export class DefaultClient implements Client {
             this.inactiveRegionsDecorations.set(uriString, currentSet);
         }
 
-        Array.prototype.push.apply(currentSet.ranges, inactiveRegions.map(element => new vscode.Range(element.startLine, 0, element.endLine, 0)));
+        Array.prototype.push.apply(currentSet.ranges, inactiveRegions.map(element => new vscode.Range(
+            element.startLine,
+            element.startColumn ?? 0,
+            element.endLine,
+            element.endColumn ?? 0)));
 
         // Apply the decorations to all *visible* text editors
         const editors: vscode.TextEditor[] = vscode.window.visibleTextEditors.filter(e => e.document.uri.toString() === uriString);


### PR DESCRIPTION
## Summary

Fixes #12882

This change updates inactive-region decoration ranges to preserve the column offsets reported by the IntelliSense engine.

Previously, inactive regions were converted to whole-line VS Code ranges by forcing both start and end columns to `0`. That caused lines containing active text before a preprocessor directive, such as a leading comment before `#if 0`, to be dimmed incorrectly.

The decoration range now uses `startColumn` and `endColumn` when they are present, while preserving the existing line-based fallback behavior for responses that do not include column data.

## Changes

- Added optional `startColumn` and `endColumn` fields to `InputRegion`.
- Updated inactive-region decoration creation to use the reported start/end columns.
- Kept `0` as the fallback column value for compatibility with line-only inactive region data.

## Testing

Tested locally on Windows.

- `yarn compile`
- `yarn lint`
- `yarn test`
- `git diff --check`

Also manually verified in an isolated Extension Development Host using a repro case where a comment precedes `#if 0` on the same line. The comment remains active while the inactive block is dimmed.