### PR TITLE
Handle localization path casing generically

### DIFF
--- a/Extension/.scripts/import_edge_strings.ts
+++ b/Extension/.scripts/import_edge_strings.ts
@@ -5,7 +5,7 @@
 import * as fs from "fs";
 import * as path from 'path';
 import { parseString } from 'xml2js';
-import { mkdir, write } from './common';
+import { glob, mkdir, write } from './common';
 
 export async function main() {
 
@@ -45,11 +45,16 @@ export async function main() {
 
     const locFolderNames = fs.readdirSync(localizeRepoPath).filter(f => fs.lstatSync(path.join(localizeRepoPath, f)).isDirectory());
     for (const locFolderName of locFolderNames) {
-        const lclPath = path.join(localizeRepoPath, locFolderName, locFolderName === "csy" ? "VC/vc/cpfeui.dll.lcl" : "vc/vc/cpfeui.dll.lcl");
         const languageInfo = languages.find(l => l.folderName === locFolderName);
         if (!languageInfo) {
             return;
         }
+        const localePath = path.join(localizeRepoPath, locFolderName);
+        const lclPaths = await glob("vc/vc/cpfeui.dll.lcl", { cwd: localePath, nocase: true, nodir: true });
+        if (lclPaths.length !== 1) {
+            throw new Error(`Expected one cpfeui.dll.lcl under '${localePath}', found ${lclPaths.length}.`);
+        }
+        const lclPath = path.join(localePath, lclPaths[0]);
         const languageId = languageInfo.id;
         const outputLanguageFolder = path.join(cpptoolsRepoPath, "Extension/bin/messages", languageId);
         const outputPath = path.join(outputLanguageFolder, "messages.json");


### PR DESCRIPTION
## Summary

Use case-insensitive path matching when locating `cpfeui.dll.lcl` so localization imports work on Linux regardless of the `vc` directory casing. Missing or ambiguous matches now fail explicitly instead of requiring a locale-specific casing exception.

This is a follow-up to #14668 requested by Colen.

## Validation

- ESLint on `Extension/.scripts/import_edge_strings.ts`
- Focused TypeScript no-emit check for the changed script and its import graph
- Synthetic localization imports using lowercase, uppercase, and mixed-case paths
- Ambiguous `VC`/`vc` fixture rejection

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.