### PR TITLE
Fix configuration path regex escaping

### DIFF
--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -14,6 +14,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import * as which from 'which';
 import { logAndReturn, returns } from '../Utility/Async/returns';
+import { escapePathForSquiggles } from '../Utility/Text/escape';
 import * as util from '../common';
 import { isWindows } from '../constants';
 import { getOutputChannelLogger } from '../logger';
@@ -2119,10 +2120,8 @@ export class CppProperties {
                 continue;
             }
 
-            // Escape the path string for literal use in a regular expression
-            // Need to escape any quotes to match the original text
-            let escapedPath: string = curPath.replace(/"/g, '\\"');
-            escapedPath = escapedPath.replace(/[-\"\/\\^$*+?.()|[\]{}]/g, '\\$&');
+            // Escape the parsed path for a literal regex match against its JSON spelling.
+            const escapedPath: string = escapePathForSquiggles(curPath);
 
             // Create a pattern to search for the path with either a quote or semicolon immediately before and after,
             // and extend that pattern to the next quote before and next quote after it.

--- a/Extension/src/Utility/Text/escape.ts
+++ b/Extension/src/Utility/Text/escape.ts
@@ -1,0 +1,9 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export function escapePathForSquiggles(s: string): string {
+    return s.replace(/[-"\/\\^$*+?.()|[\]{}]/g, (character: string): string =>
+        character === '"' ? '\\\\"' : `\\${character}`);
+}

--- a/Extension/test/unit/escape.test.ts
+++ b/Extension/test/unit/escape.test.ts
@@ -1,0 +1,32 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { describe, it } from 'mocha';
+import { doesNotMatch, match, strictEqual } from 'node:assert';
+import { escapePathForSquiggles } from '../../src/Utility/Text/escape';
+
+describe('Text escaping', () => {
+    it('escapes paths for matching their JSON spelling', () => {
+        strictEqual(escapePathForSquiggles('"'), '\\\\"');
+        strictEqual(escapePathForSquiggles('\\'), '\\\\');
+        strictEqual(escapePathForSquiggles('.*'), '\\.\\*');
+
+        const parsedPath: string = String.raw`C:\src"quoted"`;
+        const sourcePath: string = String.raw`C:\src\"quoted\"`;
+        const pattern: RegExp = new RegExp(`^${escapePathForSquiggles(parsedPath)}$`);
+        match(sourcePath, pattern);
+        doesNotMatch(parsedPath, pattern);
+    });
+
+    it('handles repeated backslashes and regex metacharacters', () => {
+        const parsedPath: string = String.raw`C:\\sdk\\[headers]+(x)?.h\\say"hello"and"goodbye`;
+        const sourcePath: string = String.raw`C:\\sdk\\[headers]+(x)?.h\\say\"hello\"and\"goodbye`;
+        const pattern: RegExp = new RegExp(`^${escapePathForSquiggles(parsedPath)}$`);
+
+        match(sourcePath, pattern);
+        doesNotMatch(String.raw`C:\sdk\[headers]+(x)?.h\say\"hello\"and\"goodbye`, pattern);
+        doesNotMatch(String.raw`C:\\sdk\\headers+(x)?.h\\say\"hello\"and\"goodbye`, pattern);
+    });
+});


### PR DESCRIPTION
## Summary

- Replace sequential configuration-path escaping with a single-pass helper while preserving literal matching against paths as written in JSON.
- Add focused unit coverage for quotes, repeated backslashes, and regular-expression metacharacters.
- Address the `js/double-escaping` and `js/incomplete-sanitization` CodeQL findings together.

## Validation

- TypeScript project build
- Targeted ESLint validation
- Extension unit tests (`203 passing`)

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.