### PR TITLE
Add processFilter for remote attach process selection

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -5260,6 +5260,11 @@
                                     }
                                 ]
                             },
+                            "processFilter": {
+                                "type": "string",
+                                "description": "%c_cpp.debuggers.processFilter.description%",
+                                "default": ""
+                            },
                             "filterStdout": {
                                 "type": "boolean",
                                 "description": "%c_cpp.debuggers.filterStdout.description%",

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -982,6 +982,7 @@
             "{Locked=\"`${command:pickProcess}`\"}"
         ]
     },
+    "c_cpp.debuggers.processFilter.description": "Optional regular expression used to match remote attach candidates by label, description, or detail. If exactly one process matches, the debugger attaches automatically. If multiple processes match, the process picker is shown with only matching entries. If no process matches, the full process picker is shown. An invalid regular expression reports an error.",
     "c_cpp.debuggers.program.attach.markdownDescription": {
         "message": "Full path to the program executable. The debugger will search for a running process matching this executable path and attach to it. If multiple processes match, a selection prompt will be shown. This field is required to load debug symbols for the attached process.",
         "comment": [

--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -6,6 +6,7 @@
 import { CppSettings } from '../LanguageServer/settings';
 import { AttachItem, showQuickPick } from './attachQuickPick';
 import { PsProcessParser } from './nativeAttach';
+import { filterProcessItems } from './processFilter';
 
 import * as os from 'os';
 import * as path from 'path';
@@ -94,7 +95,7 @@ export class RemoteAttachPicker {
             throw new Error(localize("no.pipetransport.useextendedremote", "Chosen debug configuration does not contain {0} or {1}", "pipeTransport", "useExtendedRemote"));
         }
 
-        const matchingProcesses: AttachItem[] | undefined = this.getMatchingProcessesFromConfig(processes, config);
+        const matchingProcesses: AttachItem[] | undefined = filterProcessItems(processes, config?.processFilter);
         if (matchingProcesses?.length === 1) {
             return matchingProcesses[0].id;
         }
@@ -114,23 +115,6 @@ export class RemoteAttachPicker {
         } else {
             throw new Error(localize("process.not.selected", "Process not selected."));
         }
-    }
-
-    private getMatchingProcessesFromConfig(processes: AttachItem[], config: any): AttachItem[] | undefined {
-        const processFilter: string | undefined = typeof config?.processFilter === 'string' ? config.processFilter.trim() : undefined;
-        if (!processFilter) {
-            return undefined;
-        }
-
-        let processRegex: RegExp;
-        try {
-            processRegex = new RegExp(processFilter);
-        } catch {
-            throw new Error(localize("invalid.processFilter.regex", "Invalid {0} regular expression: {1}", "processFilter", processFilter));
-        }
-
-        return processes.filter((item: AttachItem) => [item.label, item.description, item.detail]
-            .some((value: string | undefined) => typeof value === "string" && processRegex.test(value)));
     }
 
     // Creates a string to run on the host machine which will execute a shell script on the remote machine to retrieve OS and processes

--- a/Extension/src/Debugger/attachToProcess.ts
+++ b/Extension/src/Debugger/attachToProcess.ts
@@ -94,6 +94,14 @@ export class RemoteAttachPicker {
             throw new Error(localize("no.pipetransport.useextendedremote", "Chosen debug configuration does not contain {0} or {1}", "pipeTransport", "useExtendedRemote"));
         }
 
+        const matchingProcesses: AttachItem[] | undefined = this.getMatchingProcessesFromConfig(processes, config);
+        if (matchingProcesses?.length === 1) {
+            return matchingProcesses[0].id;
+        }
+        if (matchingProcesses && matchingProcesses.length > 1) {
+            processes = matchingProcesses;
+        }
+
         const attachPickOptions: vscode.QuickPickOptions = {
             matchOnDetail: true,
             matchOnDescription: true,
@@ -106,6 +114,23 @@ export class RemoteAttachPicker {
         } else {
             throw new Error(localize("process.not.selected", "Process not selected."));
         }
+    }
+
+    private getMatchingProcessesFromConfig(processes: AttachItem[], config: any): AttachItem[] | undefined {
+        const processFilter: string | undefined = typeof config?.processFilter === 'string' ? config.processFilter.trim() : undefined;
+        if (!processFilter) {
+            return undefined;
+        }
+
+        let processRegex: RegExp;
+        try {
+            processRegex = new RegExp(processFilter);
+        } catch {
+            throw new Error(localize("invalid.processFilter.regex", "Invalid {0} regular expression: {1}", "processFilter", processFilter));
+        }
+
+        return processes.filter((item: AttachItem) => [item.label, item.description, item.detail]
+            .some((value: string | undefined) => typeof value === "string" && processRegex.test(value)));
     }
 
     // Creates a string to run on the host machine which will execute a shell script on the remote machine to retrieve OS and processes

--- a/Extension/src/Debugger/processFilter.ts
+++ b/Extension/src/Debugger/processFilter.ts
@@ -1,0 +1,32 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as nls from 'vscode-nls';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
+
+export interface ProcessFilterItem {
+    label?: string;
+    description?: string;
+    detail?: string;
+}
+
+export function filterProcessItems<T extends ProcessFilterItem>(items: T[], processFilter?: unknown): T[] | undefined {
+    // The value comes from launch.json, so it is not guaranteed to be a string.
+    if (typeof processFilter !== 'string' || !processFilter.trim()) {
+        return undefined;
+    }
+
+    let processRegex: RegExp;
+    try {
+        processRegex = new RegExp(processFilter);
+    } catch {
+        throw new Error(localize("invalid.processFilter.regex", "Invalid {0} regular expression: {1}", "processFilter", processFilter));
+    }
+
+    return items.filter((item: T) => [item.label, item.description, item.detail]
+        .some((value: string | undefined) => typeof value === "string" && processRegex.test(value)));
+}

--- a/Extension/test/unit/processFilter.test.ts
+++ b/Extension/test/unit/processFilter.test.ts
@@ -1,0 +1,61 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { deepStrictEqual, strictEqual, throws } from 'assert';
+import { describe, it } from 'mocha';
+import { filterProcessItems } from '../../src/Debugger/processFilter';
+
+interface TestProcessItem {
+    label?: string;
+    description?: string;
+    detail?: string;
+    id: string;
+}
+
+describe('Remote attach process filter', () => {
+    const processes: TestProcessItem[] = [
+        { id: '101', label: 'root /usr/bin/my-daemon --serve', description: '101' },
+        { id: '102', label: 'root /usr/bin/other-service', description: '102', detail: 'worker' },
+        { id: '103', label: 'app /usr/bin/my-daemon --once', description: '103' }
+    ];
+
+    it('returns undefined when filter is empty', () => {
+        strictEqual(filterProcessItems(processes, ''), undefined);
+        strictEqual(filterProcessItems(processes, '   '), undefined);
+        strictEqual(filterProcessItems(processes, undefined), undefined);
+    });
+
+    it('returns undefined when filter is not a string', () => {
+        strictEqual(filterProcessItems(processes, 1234), undefined);
+        strictEqual(filterProcessItems(processes, true), undefined);
+        strictEqual(filterProcessItems(processes, {}), undefined);
+    });
+
+    it('matches by label and description and detail', () => {
+        deepStrictEqual(filterProcessItems(processes, 'other-service')?.map(p => p.id), ['102']);
+        deepStrictEqual(filterProcessItems(processes, '^101$')?.map(p => p.id), ['101']);
+        deepStrictEqual(filterProcessItems(processes, 'worker')?.map(p => p.id), ['102']);
+    });
+
+    it('preserves edge whitespace in the regular expression', () => {
+        deepStrictEqual(filterProcessItems(processes, '^root /usr/bin/my-daemon --serve ')?.map(p => p.id), []);
+    });
+
+    it('returns multiple matches when regex matches more than one process', () => {
+        deepStrictEqual(filterProcessItems(processes, 'my-daemon')?.map(p => p.id), ['101', '103']);
+    });
+
+    it('throws for invalid regular expression', () => {
+        throws(() => filterProcessItems(processes, '['), /Invalid processFilter regular expression/);
+    });
+
+    it('does not treat missing fields as empty strings', () => {
+        const items: TestProcessItem[] = [
+            { id: '201' }, // label, description, and detail are all missing
+            { id: '202', detail: '' } // detail is explicitly an empty string
+        ];
+        deepStrictEqual(filterProcessItems(items, '^$')?.map(p => p.id), ['202']);
+    });
+});

--- a/Extension/tools/OptionsSchema.json
+++ b/Extension/tools/OptionsSchema.json
@@ -923,6 +923,11 @@
             }
           ]
         },
+        "processFilter": {
+          "type": "string",
+          "description": "%c_cpp.debuggers.processFilter.description%",
+          "default": ""
+        },
         "filterStdout": {
           "type": "boolean",
           "description": "%c_cpp.debuggers.filterStdout.description%",


### PR DESCRIPTION
## Problem

When attaching to a process on a remote target (`useExtendedRemote` or `pipeTransport`), the process to attach to always has to be picked manually from the full process list on every debug session, even though a generated `launch.json` already knows which executable it targets. The PID can't be hard-coded because it changes on every restart/boot, and picking the wrong entry silently produces a session with mismatched symbols and source mappings.

This mirrors the existing `program`-based auto-selection already used for **local** attach (`findProcessByProgramName`), which does not apply to remote attach because the remote process list comes from a different source (`RemoteAttachPicker`) and its `label`/`detail` shapes differ per transport.

## Solution

Adds an optional `processFilter` (regular expression) to the `cppdbg` attach configuration:

- Matched against `label`, `description`, and `detail` of each remote process entry (the exact fields differ by transport: `useExtendedRemote` puts the user + full command line in `label`; `pipeTransport` puts the process name in `label` and the command line in `detail`).
- **Exactly one match** → attach to it directly, no picker.
- **Multiple matches** → show the picker, pre-filtered to only the matching entries.
- **No match** → fall back to the full picker, unchanged from today.
- An invalid regular expression throws a clear error instead of silently matching nothing.

Scope: this only affects remote attach (`pipeTransport` / `useExtendedRemote`). Local attach is unaffected by this PR.

Example `launch.json`:
```jsonc
{
    "name": "attach my-daemon",
    "type": "cppdbg",
    "request": "attach",
    "program": "/path/on/build/host/to/unstripped/my-daemon",
    "MIMode": "gdb",
    "miDebuggerPath": "/path/to/aarch64-poky-linux-gdb",
    "miDebuggerServerAddress": "192.168.7.2:1234",
    "useExtendedRemote": true,
    "processFilter": "/usr/bin/my-daemon"
}
```

Closes #14682.

## Open question for maintainers

Should `processFilter` also apply to **local** attach, in addition to (or instead of) the existing `program`-based basename matching? Since `program` is a required field for `cppdbg` attach, both would typically be present locally at the same time, so the semantics need a decision — I'd lean towards intersecting with the `program` match (never letting `processFilter` alone select a process unrelated to `program`) rather than giving it precedence, but wanted to keep this PR scoped to the originally requested remote-only case and get feedback before extending it.

## Testing

- Added unit tests for the matching helper (empty/non-string filter, label/description/detail matching, multiple matches, invalid regex) — see `Extension/test/unit/processFilter.test.ts`.
- Full existing unit test suite passes (208 passing).
- Manually verified against a real `gdbserver --multi` target with `useExtendedRemote: true`:
  - unique `processFilter` match attaches directly without showing the picker
  - a filter matching multiple processes shows the picker pre-filtered to those entries
  - a filter matching nothing falls back to the full, unfiltered picker (existing behavior)
