### PR TITLE
Fix SimpleCppProject E2E test setup

### DIFF
--- a/Extension/src/LanguageServer/devcmd.ts
+++ b/Extension/src/LanguageServer/devcmd.ts
@@ -17,7 +17,7 @@ nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFo
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const errorNoContext = localize('no.context.provided', 'No context provided');
-const errorNotWindows = localize('not.windows', 'The "Set Visual Studio Developer Environment" command is only available on Windows');
+export const errorNotWindows = localize('not.windows', 'The "Set Visual Studio Developer Environment" command is only available on Windows');
 const errorNoVSFound = localize('error.no.vs', 'A Visual Studio installation with the C++ compiler was not found');
 export const errorOperationCancelled = localize('operation.cancelled', 'The operation was cancelled');
 const errorNoHostsFound = localize('no.hosts', 'No hosts found');

--- a/Extension/test/scenarios/SimpleCppProject/tests/compilerPath.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/compilerPath.test.ts
@@ -3,16 +3,21 @@
  * See 'LICENSE' in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { describe, it } from 'mocha';
+import { before, describe, it } from 'mocha';
 import { deepEqual, equal, ok } from 'node:assert';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { extractCompilerPathAndArgs } from '../../../../src/common';
 import { isWindows } from '../../../../src/constants';
 import { CppProperties } from '../../../../src/LanguageServer/configurations';
+import * as testHelpers from '../../../common/testHelpers';
 
 const assetsFolder = Uri.file(path.normalize(path.join(__dirname.replace(/dist[\/\\]/, ''), '..', 'assets')));
 const assetsFolderFsPath = assetsFolder.fsPath;
+
+before(async () => {
+    await testHelpers.activateCppExtension();
+});
 
 // A simple test counter for the tests that loop over several cases.
 // This is to make it easier to see which test failed in the output.

--- a/Extension/test/scenarios/SimpleCppProject/tests/devEnvironment.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/devEnvironment.test.ts
@@ -7,7 +7,7 @@ import { suite } from 'mocha';
 import * as vscode from 'vscode';
 import * as util from '../../../../src/common';
 import { isWindows } from "../../../../src/constants";
-import { errorOperationCancelled } from '../../../../src/LanguageServer/devcmd';
+import { errorNotWindows } from '../../../../src/LanguageServer/devcmd';
 
 suite("set developer environment", () => {
     if (isWindows) {
@@ -32,7 +32,7 @@ suite("set developer environment", () => {
                 equal(false, true, "Should not be able to set developer environment on non-Windows platform.");
             }
             catch (e) {
-                equal((e as Error).message, errorOperationCancelled, "Should throw error when trying to set developer environment on non-Windows platform.");
+                equal((e as Error).message, errorNotWindows, "Should throw error when trying to set developer environment on non-Windows platform.");
             }
             equal(util.hasMsvcEnvironment(), false, "MSVC environment should not be set on non-Windows platforms.");
         });


### PR DESCRIPTION
## Summary

Activate the C/C++ extension before the compiler-path tests so extension state is initialized before resolving the native argument-parsing helper. Also update the non-Windows developer-environment test to expect the command's explicit platform error.

## Validation

- `yarn run compile`
- `yarn run lint`
- `yarn test --scenario=SimpleCppProject` (`21 passing`)
- I verified the lab builds pass now too.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.