### PR TITLE
Upgrade nanoid to 3.3.18

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -7261,7 +7261,7 @@
     },
     "resolutions": {
         "postcss": "^8.5.23",
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "gulp-typescript/**/glob-parent": "^5.1.2",
         "serialize-javascript": "^7.0.5",
         "@azure/msal-browser": "^4.29.1",

--- a/Extension/yarn.lock
+++ b/Extension/yarn.lock
@@ -4493,10 +4493,10 @@ mute-stream@~0.0.4:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=
 
-nanoid@^3.3.16, nanoid@^3.3.17:
-  version "3.3.17"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha1-8cOqJTxSVHlWpSxQv/dUMW9hA3o=
+nanoid@^3.3.16, nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=
 
 napi-build-utils@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Upgrade the `nanoid` Yarn resolution and lockfile entry from 3.3.17 to 3.3.18 to address the vulnerability reported by `yarn audit`.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts --non-interactive --offline`
- `yarn test-yarn-lock`
- `yarn verify-yarn-lock`
- `yarn audit` (0 vulnerabilities)

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.