### PR TITLE
Ignore process wait test helper

### DIFF
--- a/Extension/.gitignore
+++ b/Extension/.gitignore
@@ -17,6 +17,7 @@ bin/isense_driver
 bin/libc.so
 bin/LICENSE.txt
 bin/scout_driver
+bin/process_wait_test_helper
 bin/unittests
 bin/vcpkgsrvtest
 bin/*.dll


### PR DESCRIPTION
## Summary

Ignore the generated `process_wait_test_helper` binary installed into `Extension/bin` on Linux and macOS.

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.