### PR TITLE
Harden Linux GDB installation in CI

### DIFF
--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -44,9 +44,18 @@ jobs:
 
       - name: Install gdb (linux)
         if: ${{ inputs.platform == 'linux' }}
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gdb
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y gdb
 
       - name: Compile Sources
         run: yarn run compile


### PR DESCRIPTION
## Summary

Bound Linux CI's GDB installation to 10 minutes and configured APT retries and transport timeouts. This prevents transient Ubuntu mirror outages from holding a runner until GitHub's six-hour default job timeout.

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Parsed the workflow as YAML.
- Validated the inline script with Bash and ShellCheck.
- Verified the APT options with `apt-config`.
- Ran `git diff --check`.