### PR TITLE
Retry OneLocBuild dependency installation

### DIFF
--- a/Build/loc/TranslationsImportExport.yml
+++ b/Build/loc/TranslationsImportExport.yml
@@ -56,6 +56,7 @@ extends:
         - task: CmdLine@2
           inputs:
             script: 'cd Extension && yarn install'
+          retryCountOnTaskFailure: 3
 
         - task: CmdLine@2
           inputs:


### PR DESCRIPTION
## Summary

Retry the OneLocBuild dependency installation when the package feed returns a transient error. Subsequent attempts run on the same agent and can reuse Yarn's partially populated cache.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.