### PR TITLE
Update changelog and version for 1.34.0

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,24 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.34.0: August 21, 2026
+### Enhancements
+* Improve workspace indexing performance by reducing redundant browse paths from `compile_commands.json` and avoiding unnecessary tag parsing of non-included extensionless files. [#14693](https://github.com/microsoft/vscode-cpptools/issues/14693)
+* Reduce language server memory usage and RPC overhead for large messages and browse database snapshots.
+* Add IntelliSense support for C23 `_BitInt`, C++26 pack indexing, and C++26 structured binding packs.
+
+### Bug Fixes
+* Fix inactive code being dimmed from the wrong column when a preprocessor directive is preceded by a comment. [#12882](https://github.com/microsoft/vscode-cpptools/issues/12882)
+  * Thanks for the contribution. [@8prashant (Prashant Kumar Rai)](https://github.com/8prashant) [PR #14666](https://github.com/microsoft/vscode-cpptools/pull/14666)
+* Fix enum member completion in a `switch` label before the trailing `:`. [#14605](https://github.com/microsoft/vscode-cpptools/issues/14605)
+* Fix configuration path diagnostics for paths containing regular expression metacharacters and for incorrect source ranges. [PR #14674](https://github.com/microsoft/vscode-cpptools/pull/14674), [PR #14679](https://github.com/microsoft/vscode-cpptools/pull/14679)
+* Prevent browse database crashes on filesystems that do not support SQLite WAL shared memory, and warn when no compatible database location is available. [PR #14683](https://github.com/microsoft/vscode-cpptools/pull/14683)
+* Fix runaway CPU and memory usage caused by cyclic document symbol data, and prevent `cpptools` from remaining active after VS Code exits. [#14689](https://github.com/microsoft/vscode-cpptools/issues/14689)
+* Fix various IntelliSense completion, navigation, false error, code analysis, formatting, and colorization issues.
+* Fix several language server crashes during startup, shutdown, and diagnostic processing.
+* Fix a potential language server deadlock caused by inconsistent lock ordering.
+* Various localization updates.
+* Update dependencies.
+
 ## Version 1.33.8: August 17, 2026
 ### New Feature
 * Unification of tag parsing with the VS implementation. In particular, it's now done using multiple parallel `cpptools-srv2` processes. [PR #14426](https://github.com/microsoft/vscode-cpptools/pull/14426)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.33.8-main",
+    "version": "1.34.0-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
## Summary

- Add the August 21, 2026 changelog entry for version 1.34.0.
- Update the extension manifest version to `1.34.0-main`.

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Verified the extension manifest parses as JSON and reports `1.34.0-main`.
- Verified the changelog heading, links, and entry ordering.
- Ran `git diff --check`.