### PR TITLE
Use npm ci in issue automation workflows

### DIFF
--- a/.github/workflows/bug-debugger.yml
+++ b/.github/workflows/bug-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Add Comment
         uses: ./.github/actions/AddComment
         with:

--- a/.github/workflows/by-design-closer-debugger.yml
+++ b/.github/workflows/by-design-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/by-design-closer.yml
+++ b/.github/workflows/by-design-closer.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/duplicate-closer.yml
+++ b/.github/workflows/duplicate-closer.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/enhancement-closer-no-milestone.yml
+++ b/.github/workflows/enhancement-closer-no-milestone.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/enhancement-closer-triage.yml
+++ b/.github/workflows/enhancement-closer-triage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/enhancement-reopener.yml
+++ b/.github/workflows/enhancement-reopener.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Run Reopener
         uses: ./.github/actions/Reopener
         with:

--- a/.github/workflows/external-closer-debugger.yml
+++ b/.github/workflows/external-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/feature-request-closer-no-milestone.yml
+++ b/.github/workflows/feature-request-closer-no-milestone.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/feature-request-closer-triage.yml
+++ b/.github/workflows/feature-request-closer-triage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/feature-request-debugger.yml
+++ b/.github/workflows/feature-request-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Add Comment
         uses: ./.github/actions/AddComment
         with:

--- a/.github/workflows/feature-request-reopener.yml
+++ b/.github/workflows/feature-request-reopener.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Run Reopener
         uses: ./.github/actions/Reopener
         with:

--- a/.github/workflows/investigate-closer-debugger.yml
+++ b/.github/workflows/investigate-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/investigate-costing-closer-debugger.yml
+++ b/.github/workflows/investigate-costing-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Run Locker
         uses: ./.github/actions/Locker
         with:

--- a/.github/workflows/more-info-needed-closer-debugger.yml
+++ b/.github/workflows/more-info-needed-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/more-info-needed-closer.yml
+++ b/.github/workflows/more-info-needed-closer.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/question-closer-debugger.yml
+++ b/.github/workflows/question-closer-debugger.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:

--- a/.github/workflows/question-closer.yml
+++ b/.github/workflows/question-closer.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Actions
-        run: cd ./.github/actions && npm install --production && cd ../..
+        run: cd ./.github/actions && npm ci --omit=dev && cd ../..
       - name: Stale Closer
         uses: ./.github/actions/StaleCloser
         with:


### PR DESCRIPTION
## Summary

Use `npm ci --omit=dev` in the 19 scheduled issue-automation workflows so their production dependencies are installed exactly from `.github/actions/package-lock.json`.

## Why this helps

These workflows run on a schedule and automatically label, comment on, close, reopen, or lock issues. Their behavior depends on the JavaScript packages installed before each run, so the install should be repeatable for a given repository commit.

`npm install --production` can reconcile differences between `package.json` and `package-lock.json` while the workflow is running. That makes an accidental mismatch less obvious and can cause the workflow to run with a dependency graph other than the one recorded in the committed lockfile.

`npm ci --omit=dev` instead:

- requires `package.json` and `package-lock.json` to agree, failing the job when they do not;
- installs the production dependency versions recorded in the lockfile;
- starts from a clean `node_modules` directory; and
- leaves the package manifest and lockfile unchanged.

This makes repeated scheduled runs from the same commit more predictable and turns dependency drift into a visible failure instead of silently changing what the automation runs. That is especially useful for workflows that act on user-facing issues without someone manually reviewing every scheduled execution.

This carries forward the supported deterministic dependency-restoration portion of #14701.

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Ran `npm ci --omit=dev` from a clean `.github/actions` directory with Node 24.18.1 and npm 11.16.0.
- Confirmed the install resolved the complete production graph and left `package-lock.json` byte-identical.
- Confirmed `npm ci --omit=dev` rejects a temporary `package.json`/`package-lock.json` mismatch.
- Syntax-checked all four action entry points with Node 24.
- Confirmed YAML diagnostics and `git diff --check` are clean.