### PR TITLE
Retry transient Yarn install failures

### DIFF
--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -43,7 +43,22 @@ jobs:
         working-directory: Extension
 
       - name: Install Dependencies
-        run: yarn install ${{ inputs.yarn-args }}
+        shell: bash
+        env:
+          YARN_ARGS: ${{ inputs.yarn-args }}
+        run: |
+          read -r -a yarn_args <<< "$YARN_ARGS"
+          for attempt in 1 2 3; do
+            if yarn install "${yarn_args[@]}"; then
+              exit 0
+            fi
+            if (( attempt == 3 )); then
+              exit 1
+            fi
+            delay=$((attempt * 15))
+            printf 'yarn install failed; retrying in %d seconds.\n' "$delay" >&2
+            sleep "$delay"
+          done
         working-directory: Extension
 
       - name: Install gdb (linux)


### PR DESCRIPTION
## Summary

Retries `yarn install` up to three times with 15- and 30-second backoff in the shared compile-and-test workflow. This prevents transient registry or proxy failures such as the HTTP 503 in [CI (Windows) run 32850406154](https://github.com/microsoft/vscode-cpptools/actions/runs/32850406154) from immediately failing CI while preserving the final nonzero result when all attempts fail.

## Validation

- Parsed the workflow with PyYAML and asserted the retry step structure.
- Ran `bash -n` and ShellCheck on the extracted retry script.
- Exercised mocked success-on-third-attempt and permanent-failure paths, including workflow argument preservation and backoff timing.
- Ran `git diff --check`.

> This PR was investigated and created by GitHub Copilot in VS Code. Any message starting with `✨Copilot:` was sent by Copilot.