### PR TITLE
Add 1.34.2 changelog

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.34.2: August 31, 2026
+### Enhancements
+* Improve C/C++ file classification by supporting extensionless headers and additional extensions such as `.cppm` throughout extension features. [PR #14711](https://github.com/microsoft/vscode-cpptools/pull/14711)
+* Update the bundled `clang-tidy` and `clang-format` from 22.1.3 to 23.1.0, including available `clang-tidy` check suggestions and documentation. [PR #14713](https://github.com/microsoft/vscode-cpptools/pull/14713)
+
+### Bug Fixes
+* Fix high CPU and memory usage in workspaces with multiple symbolic links that point to ancestor directories. [#14689](https://github.com/microsoft/vscode-cpptools/issues/14689)
+* Fix include completion and symbol navigation using stale recursive include data after files are replaced by directories or symbolic link roots change.
+* Fix 'Find All References' misclassifying references in inactive preprocessor regions after falling back to header-only IntelliSense.
+
 ## Version 1.34.1: August 28, 2026
 ### Bug Fixes
 * Fix formatting not inserting the final newline requested by `InsertNewlineAtEOF`. [#12680](https://github.com/microsoft/vscode-cpptools/issues/12680)

--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.34.2: August 31, 2026
 ### Enhancements
-* Improve C/C++ file classification by supporting extensionless headers and additional extensions such as `.cppm` throughout extension features. [PR #14711](https://github.com/microsoft/vscode-cpptools/pull/14711)
+* Improve C/C++ file classification by supporting extensionless headers and additional extensions such as `.hip` throughout extension features. [PR #14711](https://github.com/microsoft/vscode-cpptools/pull/14711)
 * Update the bundled `clang-tidy` and `clang-format` from 22.1.3 to 23.1.0, including available `clang-tidy` check suggestions and documentation. [PR #14713](https://github.com/microsoft/vscode-cpptools/pull/14713)
 
 ### Bug Fixes

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.34.1-main",
+    "version": "1.34.2-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
## Summary

Add the C/C++ extension's 1.34.2 release notes and update the extension version to `1.34.2-main`.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Validated the changelog section structure, bullet punctuation, and ordering.
- Parsed `Extension/package.json`.
- Ran `git diff --check`.