### PR TITLE
Fix custom configuration provider regression

### DIFF
--- a/.github/workflows/job-compile-and-test.yml
+++ b/.github/workflows/job-compile-and-test.yml
@@ -97,6 +97,11 @@ jobs:
         run: yarn test --scenario=SingleRootProject
         working-directory: Extension
 
+      - name: Run SimpleCppProject tests (Windows)
+        if: ${{ inputs.platform == 'windows' }}
+        run: yarn test --scenario=SimpleCppProject
+        working-directory: Extension
+
       - name: Run E2E IntelliSense features tests (Windows)
         if: ${{ inputs.platform == 'windows' }}
         run: yarn test --scenario=MultirootDeadlockTest
@@ -115,6 +120,13 @@ jobs:
         uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
         with:
           run: yarn test --scenario=SingleRootProject
+          working-directory: Extension
+
+      - name: Run SimpleCppProject tests (linux/macOS)
+        if: ${{ inputs.platform == 'mac' || inputs.platform == 'linux' }}
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+        with:
+          run: yarn test --scenario=SimpleCppProject
           working-directory: Extension
 
       - name: Run E2E IntelliSense features tests (linux/macOS)

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2774,7 +2774,7 @@ export class DefaultClient implements Client {
                 const isTrackedFile: boolean = hasNativeFileTypeMappings()
                     ? isTagParsableFile(uri.fsPath)
                     : isTagParsableFile(uri.fsPath) ||
-                        (ext !== undefined && this.associations_for_did_change?.has(ext.toLowerCase()) === true);
+                    (ext !== undefined && this.associations_for_did_change?.has(ext.toLowerCase()) === true);
                 if (isTrackedFile) {
                     // VS Code has a bug that causes onDidChange events to happen to files that aren't changed,
                     // which causes a large backlog of "files to parse" to accumulate.

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2316,7 +2316,7 @@ export class DefaultClient implements Client {
                 supportedUris.push(uri);
             }
             if (supportedUris.length === 0) {
-                return [];
+                return undefined;
             }
 
             let configs: util.Mutable<SourceFileConfigurationItem>[] = [];

--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -2304,9 +2304,24 @@ export class DefaultClient implements Client {
 
         // Wrap the provider lookup in a single task, so we can apply a timeout to the entire duration.
         const provideConfigurationAsync: () => Thenable<SourceFileConfigurationItem[] | undefined> = async () => {
+            const supportedUris: vscode.Uri[] = [];
+            for (const uri of docUris) {
+                try {
+                    if (!await provider.canProvideConfiguration(uri, tokenSource.token)) {
+                        continue;
+                    }
+                } catch {
+                    console.warn("Caught exception from canProvideConfiguration");
+                }
+                supportedUris.push(uri);
+            }
+            if (supportedUris.length === 0) {
+                return [];
+            }
+
             let configs: util.Mutable<SourceFileConfigurationItem>[] = [];
             try {
-                configs = await provider.provideConfigurations(docUris, tokenSource.token);
+                configs = await provider.provideConfigurations(supportedUris, tokenSource.token);
             } catch {
                 console.warn("Caught exception from provideConfigurations");
             }

--- a/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
+++ b/Extension/test/scenarios/SimpleCppProject/tests/languageServer.integration.test.ts
@@ -133,6 +133,8 @@ async function changeCppProperties(cppProperties: config.ConfigurationJson, _dis
 suite("extensibility tests v3", function(): void {
     let cpptools: apit.CppToolsTestApi;
     let lastResult: api.SourceFileConfigurationItem[];
+    let configurationProvidedBeforeCanProvide: boolean = false;
+    const supportedUris: Set<string> = new Set<string>();
     const defaultConfig: api.SourceFileConfiguration = {
         includePath: [ "${workspaceFolder}", "/v3/folder" ],
         defines: [ "${workspaceFolder}" ],
@@ -156,14 +158,19 @@ suite("extensibility tests v3", function(): void {
     const provider: api.CustomConfigurationProvider = {
         name: "cpptoolsTest-v3",
         extensionId: "ms-vscode.cpptools-test3",
-        canProvideConfiguration(_document: vscode.Uri): Thenable<boolean> {
+        canProvideConfiguration(document: vscode.Uri): Thenable<boolean> {
+            supportedUris.add(document.toString());
             return Promise.resolve(true);
         },
         provideConfigurations(uris: vscode.Uri[]): Thenable<api.SourceFileConfigurationItem[]> {
             const result: api.SourceFileConfigurationItem[] = [];
             uris.forEach(uri => {
+                const uriString: string = uri.toString();
+                if (!supportedUris.has(uriString)) {
+                    configurationProvidedBeforeCanProvide = true;
+                }
                 result.push({
-                    uri: uri.toString(),
+                    uri: uriString,
                     configuration: defaultConfig
                 });
             });
@@ -220,10 +227,15 @@ suite("extensibility tests v3", function(): void {
             disposables.push(testHook.IntelliSenseStatusChanged(result => {
                 result = result as apit.IntelliSenseStatus;
                 if (result.filename === "main3.cpp" && result.status === apit.Status.IntelliSenseReady) {
-                    const expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
-                    assert.deepEqual(lastResult, expected);
-                    assert.deepEqual(lastBrowseResult, defaultFolderBrowseConfig);
-                    resolve();
+                    try {
+                        const expected: api.SourceFileConfigurationItem[] = [ {uri: uri.toString(), configuration: defaultConfig} ];
+                        assert.strictEqual(configurationProvidedBeforeCanProvide, false);
+                        assert.deepEqual(lastResult, expected);
+                        assert.deepEqual(lastBrowseResult, defaultFolderBrowseConfig);
+                        resolve();
+                    } catch (error) {
+                        reject(error);
+                    }
                 }
             }));
             setTimeout(() => { reject(new Error("timeout")); }, testHelpers.defaultTimeout);


### PR DESCRIPTION
## Summary

Restore `canProvideConfiguration` calls for each requested URI before invoking the batched `provideConfigurations` request. This preserves provider initialization and filtering behavior while retaining the multi-file batching introduced in #14582.

Add integration coverage for a provider that prepares its file configuration during `canProvideConfiguration`, and run the containing `SimpleCppProject` scenario in CI on Windows, Linux, and macOS.

Fixes #14724.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.