### PR TITLE
Remove ignored network isolation policy from pipelines

### DIFF
--- a/Build/cg/cg.yml
+++ b/Build/cg/cg.yml
@@ -61,7 +61,7 @@ extends:
     featureFlags:
       autoBaseline: false
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: build

--- a/Build/package/cpptools_extension_pack.yml
+++ b/Build/package/cpptools_extension_pack.yml
@@ -32,7 +32,7 @@ extends:
         image: 1ESPT-Windows2025
         os: windows
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: package

--- a/Build/package/cpptools_themes.yml
+++ b/Build/package/cpptools_themes.yml
@@ -32,7 +32,7 @@ extends:
         image: 1ESPT-Windows2025
         os: windows
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: package


### PR DESCRIPTION
## Summary
Removes the incompatible `Permissive` network isolation policy from the component-governance, extension-pack, and themes pipelines. The effective `CFSClean`, `CFSClean2`, and `CFSClean3` policies remain enabled.

> This PR was investigated and created by GitHub Copilot (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Root cause
#14284 retained `Permissive` while enabling `CFSClean3`. The current 1ES `DefaultDeny` policy ignores `Permissive` as incompatible, producing a warning without changing effective network isolation.

## Fix
Pass only the compatible CFS policies to 1ES network isolation.