### PR TITLE
Ignore empty crash report files

### DIFF
--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -48,7 +48,7 @@ export const CppSourceStr: string = "C/C++";
 export const configPrefix: string = "C/C++: ";
 
 let prevMacCrashFile: string;
-const pendingCppCrashFiles: Set<string> = new Set<string>();
+const pendingCppCrashPaths: Set<string> = new Set<string>();
 let prevCppCrashCallStackData: string = "";
 export let clients: ClientCollection;
 let activeDocument: vscode.TextDocument | undefined;
@@ -1115,7 +1115,6 @@ export function usesCrashHandler(): boolean {
 
 export function watchForCrashes(crashDirectory: string): void {
     if (crashDirectory !== "") {
-        pendingCppCrashFiles.clear();
         fs.stat(crashDirectory, (err) => {
             const crashObject: Record<string, string> = {};
             if (err?.code) {
@@ -1131,21 +1130,22 @@ export function watchForCrashes(crashDirectory: string): void {
                     if (event !== "change") {
                         return;
                     }
-                    if (!filename || pendingCppCrashFiles.has(filename)) {
+                    if (!filename || !filename.startsWith("cpptools")) {
                         return;
                     }
-                    if (!filename.startsWith("cpptools")) {
+                    const crashPath: string = path.resolve(crashDirectory, filename);
+                    if (pendingCppCrashPaths.has(crashPath)) {
                         return;
                     }
-                    pendingCppCrashFiles.add(filename);
+                    pendingCppCrashPaths.add(crashPath);
                     const crashDate: Date = new Date();
                     isWritingCrashCallStack = true;
 
                     // Wait 5 seconds to allow time for the crash log to finish being written.
                     setTimeout(() => {
                         isWritingCrashCallStack = false;
-                        pendingCppCrashFiles.delete(filename);
-                        fs.readFile(path.resolve(crashDirectory, filename), 'utf8', (err, data) => {
+                        pendingCppCrashPaths.delete(crashPath);
+                        fs.readFile(crashPath, 'utf8', (err, data) => {
                             void handleCrashFileRead(crashDirectory, filename, crashDate, err, data);
                         });
                     }, 5000);

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -48,7 +48,7 @@ export const CppSourceStr: string = "C/C++";
 export const configPrefix: string = "C/C++: ";
 
 let prevMacCrashFile: string;
-let prevCppCrashFile: string;
+const pendingCppCrashFiles: Set<string> = new Set<string>();
 let prevCppCrashCallStackData: string = "";
 export let clients: ClientCollection;
 let activeDocument: vscode.TextDocument | undefined;
@@ -1115,7 +1115,7 @@ export function usesCrashHandler(): boolean {
 
 export function watchForCrashes(crashDirectory: string): void {
     if (crashDirectory !== "") {
-        prevCppCrashFile = "";
+        pendingCppCrashFiles.clear();
         fs.stat(crashDirectory, (err) => {
             const crashObject: Record<string, string> = {};
             if (err?.code) {
@@ -1131,19 +1131,20 @@ export function watchForCrashes(crashDirectory: string): void {
                     if (event !== "change") {
                         return;
                     }
-                    if (!filename || filename === prevCppCrashFile) {
+                    if (!filename || pendingCppCrashFiles.has(filename)) {
                         return;
                     }
-                    prevCppCrashFile = filename;
                     if (!filename.startsWith("cpptools")) {
                         return;
                     }
+                    pendingCppCrashFiles.add(filename);
                     const crashDate: Date = new Date();
                     isWritingCrashCallStack = true;
 
                     // Wait 5 seconds to allow time for the crash log to finish being written.
                     setTimeout(() => {
                         isWritingCrashCallStack = false;
+                        pendingCppCrashFiles.delete(filename);
                         fs.readFile(path.resolve(crashDirectory, filename), 'utf8', (err, data) => {
                             void handleCrashFileRead(crashDirectory, filename, crashDate, err, data);
                         });
@@ -1322,6 +1323,9 @@ async function handleCrashFileRead(crashDirectory: string, crashFile: string, cr
             return; // ignore known issue
         }
         return logCppCrashTelemetry("readFile: " + err.code);
+    }
+    if (data.length === 0) {
+        return;
     }
 
     const lines: string[] = data.split("\n");

--- a/Extension/src/LanguageServer/extension.ts
+++ b/Extension/src/LanguageServer/extension.ts
@@ -1143,8 +1143,8 @@ export function watchForCrashes(crashDirectory: string): void {
 
                     // Wait 5 seconds to allow time for the crash log to finish being written.
                     setTimeout(() => {
-                        isWritingCrashCallStack = false;
                         pendingCppCrashPaths.delete(crashPath);
+                        isWritingCrashCallStack = pendingCppCrashPaths.size > 0;
                         fs.readFile(crashPath, 'utf8', (err, data) => {
                             void handleCrashFileRead(crashDirectory, filename, crashDate, err, data);
                         });


### PR DESCRIPTION
## Summary
Prevent empty native crash-report placeholders from being classified and uploaded as crashes. Track delayed reads per file so a later write to the same file is still processed normally.

> This PR was investigated and created by GitHub Copilot (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Root cause
The crash watcher introduced in #11858 assumes every file change represents a completed report. The missing-signal fallback added in #13493 consequently classifies a zero-byte file as `SIGMISSING`, logs it as a crash, and deletes it. A report file can be observed before its crash header has been written, which can produce false telemetry and remove the path before a later real crash writes its report.

## Fix
Use a per-file pending set only while a delayed read is scheduled. Release the filename before reading, and leave zero-byte files untouched without logging telemetry. A later write can then produce another change event and schedule normal processing, while non-empty crash-report parsing remains unchanged.