### PR TITLE
Harden Copilot completion context caching

### DIFF
--- a/Extension/src/LanguageServer/client.ts
+++ b/Extension/src/LanguageServer/client.ts
@@ -926,7 +926,7 @@ export class DefaultClient implements Client {
     private browsePath?: string[];
     private hoverProvider: HoverProvider | undefined;
     private copilotHoverProvider: CopilotHoverProvider | undefined;
-    private copilotCompletionProvider?: CopilotCompletionContextProvider;
+    private static copilotCompletionProvider?: CopilotCompletionContextProvider;
 
     public lastCustomBrowseConfiguration: PersistentFolderState<WorkspaceBrowseConfiguration | undefined> | undefined;
     public lastCustomBrowseConfigurationProviderId: PersistentFolderState<string | undefined> | undefined;
@@ -1450,9 +1450,9 @@ export class DefaultClient implements Client {
                     this.semanticTokensProviderDisposable = vscode.languages.registerDocumentSemanticTokensProvider(util.documentSelector, this.semanticTokensProvider, semanticTokensLegend);
                 }
 
-                this.copilotCompletionProvider = CopilotCompletionContextProvider.Create();
+                DefaultClient.copilotCompletionProvider = CopilotCompletionContextProvider.Create();
                 util.setProgress(util.getProgressCopilotSuccess());
-                this.disposables.push(this.copilotCompletionProvider);
+                this.disposables.push(DefaultClient.copilotCompletionProvider);
 
                 // Listen for messages from the language server.
                 this.registerNotifications();
@@ -1875,6 +1875,7 @@ export class DefaultClient implements Client {
 
     public async onDidChangeSettings(_event: vscode.ConfigurationChangeEvent): Promise<Record<string, string>> {
         const defaultClient: Client = clients.getDefaultClient();
+        DefaultClient.copilotCompletionProvider?.clear();
         if (this === defaultClient) {
             // Only send the updated settings information once, as it includes values for all folders.
             void this.sendDidChangeSettings().catch(logAndReturn.undefined);
@@ -2023,6 +2024,7 @@ export class DefaultClient implements Client {
 
     public onDidChangeTextDocument(textDocumentChangeEvent: vscode.TextDocumentChangeEvent): void {
         if (util.isCpp(textDocumentChangeEvent.document)) {
+            DefaultClient.copilotCompletionProvider?.clear();
             // If any file has changed, we need to abort the current rename operation
             if (workspaceReferences !== undefined // Occurs when a document changes before cpptools starts.
                 && workspaceReferences.renamePending) {
@@ -2056,7 +2058,7 @@ export class DefaultClient implements Client {
         if (diagnosticsCollectionIntelliSense) {
             diagnosticsCollectionIntelliSense.delete(document.uri);
         }
-        this.copilotCompletionProvider?.removeFile(uri);
+        DefaultClient.copilotCompletionProvider?.removeFile(uri);
         openFileVersions.delete(uri);
     }
 

--- a/Extension/src/LanguageServer/copilotCompletionContextCache.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextCache.ts
@@ -1,0 +1,86 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+export interface CompletionContextCachePolicy {
+    featureFlag: number;
+    maxSnippetCount: number;
+    maxSnippetLength: number;
+    doAggregateSnippets: boolean;
+}
+
+export interface CompletionContextCacheEntry<T> {
+    id: string;
+    result: T;
+    policy: CompletionContextCachePolicy;
+}
+
+export class CompletionContextCache<T extends { caretOffset: number }> {
+    private readonly entries = new Map<string, CompletionContextCacheEntry<T>>();
+    private generation = 0;
+
+    public get size(): number {
+        return this.entries.size;
+    }
+
+    public get currentGeneration(): number {
+        return this.generation;
+    }
+
+    public set(uri: string, id: string, result: T, policy: CompletionContextCachePolicy, generation = this.generation): boolean {
+        if (generation !== this.generation) {
+            return false;
+        }
+        this.entries.set(uri, { id, result, policy });
+        return true;
+    }
+
+    public get(uri: string, caretOffset: number, maxCaretDistance: number,
+        policy: CompletionContextCachePolicy): CompletionContextCacheEntry<T> | undefined {
+        const entry = this.entries.get(uri);
+        if (!entry || Math.abs(caretOffset - entry.result.caretOffset) > maxCaretDistance) {
+            return undefined;
+        }
+        const cachedPolicy = entry.policy;
+        return cachedPolicy.featureFlag === policy.featureFlag &&
+            cachedPolicy.maxSnippetCount === policy.maxSnippetCount &&
+            cachedPolicy.maxSnippetLength === policy.maxSnippetLength &&
+            cachedPolicy.doAggregateSnippets === policy.doAggregateSnippets ? entry : undefined;
+    }
+
+    public has(uri: string): boolean {
+        return this.entries.has(uri);
+    }
+
+    public clear(): void {
+        this.entries.clear();
+        this.generation++;
+    }
+}
+
+export function formatCompletionContextLocation(requestUri: string, sourceFileUri: string, caretOffset: number): string {
+    return `(response.uriMatchesRequest:${sourceFileUri === requestUri})(response.caretOffset:${caretOffset})`;
+}
+
+export class DisposableStore<T extends { dispose(): unknown }> {
+    private disposables: T[] = [];
+    private disposed = false;
+
+    public add(disposable: T): boolean {
+        if (this.disposed) {
+            disposable.dispose();
+            return false;
+        }
+        this.disposables.push(disposable);
+        return true;
+    }
+
+    public dispose(): void {
+        this.disposed = true;
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+        this.disposables = [];
+    }
+}

--- a/Extension/src/LanguageServer/copilotCompletionContextCache.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextCache.ts
@@ -59,10 +59,6 @@ export class CompletionContextCache<T extends { caretOffset: number }> {
     }
 }
 
-export function formatCompletionContextLocation(requestUri: string, sourceFileUri: string, caretOffset: number): string {
-    return `(response.uriMatchesRequest:${sourceFileUri === requestUri})(response.caretOffset:${caretOffset})`;
-}
-
 export class DisposableStore<T extends { dispose(): unknown }> {
     private disposables: T[] = [];
     private disposed = false;

--- a/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
@@ -10,6 +10,7 @@ import { isBoolean, isNumber, isString } from '../common';
 import { getOutputChannelLogger, Logger } from '../logger';
 import * as telemetry from '../telemetry';
 import { CopilotCompletionContextResult } from './client';
+import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore, formatCompletionContextLocation } from './copilotCompletionContextCache';
 import { CopilotCompletionContextTelemetry } from './copilotCompletionContextTelemetry';
 import { getCopilotChatApi, getCopilotClientApi, type CopilotContextProviderAPI } from './copilotProviders';
 import { clients } from './extension';
@@ -69,11 +70,9 @@ export enum CopilotCompletionKind {
     Unknown = 'unknown'
 }
 
-type CacheEntry = [string, CopilotCompletionContextResult];
-
 export class CopilotCompletionContextProvider implements ContextResolver<SupportedContextItem> {
     private static readonly providerId = 'ms-vscode.cpptools';
-    private readonly completionContextCache: Map<string, CacheEntry> = new Map();
+    private readonly completionContextCache = new CompletionContextCache<CopilotCompletionContextResult>();
     private static readonly defaultCppDocumentSelector: DocumentSelector = [{ language: 'cpp' }, { language: 'c' }, { language: 'cuda-cpp' }];
     // The default time budget for providing a value from resolve().
     private static readonly defaultTimeBudgetMs: number = 7;
@@ -83,7 +82,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
     private static readonly defaultMaxSnippetLength = 3 * 1024;
     private static readonly defaultDoAggregateSnippets = true;
     private completionContextCancellation = new vscode.CancellationTokenSource();
-    private contextProviderDisposables: vscode.Disposable[] | undefined;
+    private readonly contextProviderDisposables = new DisposableStore<vscode.Disposable>();
     static readonly CppContextProviderEnabledFeatures = 'enabledFeatures';
     static readonly CppContextProviderTimeBudgetMs = 'timeBudgetMs';
     static readonly CppContextProviderMaxSnippetCount = 'maxSnippetCount';
@@ -136,14 +135,14 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
     // The cancellationToken indicates that the value should not be returned nor cached.
     private async getCompletionContextWithCancellation(context: ResolveRequest, featureFlag: CopilotCompletionContextFeatures,
         maxSnippetCount: number, maxSnippetLength: number, doAggregateSnippets: boolean, startTime: number, telemetry: CopilotCompletionContextTelemetry,
-        internalToken: vscode.CancellationToken):
+        internalToken: vscode.CancellationToken, cacheGeneration: number):
         Promise<CopilotCompletionContextResult | undefined> {
         const documentUri = context.documentContext.uri;
         const caretOffset = context.documentContext.offset;
-        let logMessage = `Copilot: getCompletionContext(${documentUri}:${caretOffset}):`;
+        let logMessage = `Copilot: getCompletionContext:`;
         try {
             const snippetsFeatureFlag = CopilotCompletionContextProvider.normalizeFeatureFlag(featureFlag);
-            telemetry.addRequestMetadata(documentUri, caretOffset, context.completionId,
+            telemetry.addRequestMetadata(caretOffset, context.completionId,
                 context.documentContext.languageId, { featureFlag: snippetsFeatureFlag });
             const docUri = vscode.Uri.parse(documentUri);
             const getClientForTime = performance.now();
@@ -161,22 +160,33 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
                 if (resultMismatch) { logMessage += `(mismatch TU vs result)`; }
             }
             const cacheEntryId = randomUUID().toString();
-            this.completionContextCache.set(copilotCompletionContext.sourceFileUri, [cacheEntryId, copilotCompletionContext]);
+            const cached = this.completionContextCache.set(
+                copilotCompletionContext.sourceFileUri,
+                cacheEntryId,
+                copilotCompletionContext,
+                { featureFlag: snippetsFeatureFlag, maxSnippetCount, maxSnippetLength, doAggregateSnippets },
+                cacheGeneration);
             const duration = CopilotCompletionContextProvider.getRoundedDuration(startTime);
-            telemetry.addCacheComputedData(duration, cacheEntryId);
-            logMessage += ` cached in ${duration}ms ${copilotCompletionContext.traits.length} trait(s)`;
+            if (cached) {
+                telemetry.addCacheComputedData(duration, cacheEntryId);
+                logMessage += ` cached in ${duration}ms`;
+            } else {
+                logMessage += ` invalidated before caching in ${duration}ms`;
+            }
+            logMessage += ` ${copilotCompletionContext.traits.length} trait(s)`;
             if (copilotCompletionContext.areSnippetsMissing) { logMessage += `(missing code snippets)`; }
             else {
                 logMessage += ` and ${copilotCompletionContext.snippets.length} snippet(s)`;
                 logMessage += `(response.featureFlag:${copilotCompletionContext.featureFlag})`;
-                logMessage += `(response.uri:${copilotCompletionContext.sourceFileUri || "<not-set>"}:${copilotCompletionContext.caretOffset})`;
+                logMessage += formatCompletionContextLocation(
+                    documentUri, copilotCompletionContext.sourceFileUri, copilotCompletionContext.caretOffset);
             }
 
             telemetry.addResponseMetadata(copilotCompletionContext.areSnippetsMissing, copilotCompletionContext.snippets.length,
                 copilotCompletionContext.traits.length, copilotCompletionContext.caretOffset, copilotCompletionContext.featureFlag);
             telemetry.addComputeContextElapsed(CopilotCompletionContextProvider.getRoundedDuration(getCompletionContextStartTime));
 
-            return copilotCompletionContext;
+            return cached ? copilotCompletionContext : undefined;
         } catch (e: any) {
             if (e instanceof vscode.CancellationError || e.message === CancellationError.Canceled) {
                 telemetry.addInternalCanceled(CopilotCompletionContextProvider.getRoundedDuration(startTime));
@@ -189,7 +199,8 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
             }
 
             telemetry.addError();
-            this.logger.appendLineAtLevel(7, `Copilot: getCompletionContextWithCancellation(${documentUri}: ${caretOffset}): Error: '${e}'`);
+            const errorType = e instanceof Error ? e.name : typeof e;
+            this.logger.appendLineAtLevel(7, `Copilot: getCompletionContextWithCancellation: Error type: '${errorType}'`);
             return undefined;
         } finally {
             this.logger.
@@ -312,16 +323,20 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
 
     public dispose(): void {
         this.completionContextCancellation.cancel();
-        if (this.contextProviderDisposables) {
-            for (const disposable of this.contextProviderDisposables) {
-                disposable.dispose();
-            }
-            this.contextProviderDisposables = undefined;
-        }
+        this.contextProviderDisposables.dispose();
     }
 
     public removeFile(fileUri: string): void {
-        this.completionContextCache.delete(fileUri);
+        void fileUri;
+        this.clear();
+    }
+
+    public clear(): void {
+        this.completionContextCache.clear();
+        CopilotCompletionContextProvider.paramsCacheCreated = false;
+        for (const key of Object.keys(CopilotCompletionContextProvider.paramsCache)) {
+            delete CopilotCompletionContextProvider.paramsCache[key];
+        }
     }
 
     private computeSnippetsResolved: boolean = true;
@@ -332,18 +347,16 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
         copilotCancel: vscode.CancellationToken): Promise<[CopilotCompletionContextResult | undefined, CopilotCompletionKind]> {
         if (this.computeSnippetsResolved) {
             this.computeSnippetsResolved = false;
+            const cacheGeneration = this.completionContextCache.currentGeneration;
             const computeSnippetsPromise = this.getCompletionContextWithCancellation(context, featureFlag,
-                maxSnippetCount, maxSnippetLength, doAggregateSnippets, resolveStartTime, telemetry.fork(), this.completionContextCancellation.token).finally(
+                maxSnippetCount, maxSnippetLength, doAggregateSnippets, resolveStartTime, telemetry.fork(),
+                this.completionContextCancellation.token, cacheGeneration).finally(
                     () => this.computeSnippetsResolved = true
                 );
             const res = await this.waitForCompletionWithTimeoutAndCancellation(
                 computeSnippetsPromise, defaultValue, timeBudgetMs, copilotCancel);
             return res;
         } else { return [defaultValue, defaultValue ? CopilotCompletionKind.GotFromCache : CopilotCompletionKind.MissingCacheMiss]; }
-    }
-
-    private static isStaleCacheHit(caretOffset: number, cacheCaretOffset: number, maxCaretDistance: number): boolean {
-        return Math.abs(caretOffset - caretOffset) > maxCaretDistance;
     }
 
     private static createContextItems(copilotCompletionContext: CopilotCompletionContextResult | undefined): SupportedContextItem[] {
@@ -353,7 +366,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
     public async resolve(context: ResolveRequest, copilotCancel: vscode.CancellationToken): Promise<SupportedContextItem[]> {
         const proposedEdits = context.documentContext.proposedEdits;
         const resolveStartTime = performance.now();
-        let logMessage = `Copilot: resolve(${context.documentContext.uri}:${context.documentContext.offset}):`;
+        let logMessage = `Copilot: resolve:`;
         const cppTimeBudgetMs = await this.fetchTimeBudgetMs(context);
         const maxCaretDistance = await this.fetchMaxDistanceToCaret(context);
         const maxSnippetCount = await this.fetchMaxSnippetCount(context);
@@ -367,39 +380,38 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
         const docOffset = context.documentContext.offset;
         try {
             featureFlag = await this.getEnabledFeatureFlag(context);
-            telemetry.addRequestMetadata(context.documentContext.uri, context.documentContext.offset,
+            telemetry.addRequestMetadata(context.documentContext.offset,
                 context.completionId, context.documentContext.languageId, {
                 featureFlag, timeBudgetMs: cppTimeBudgetMs, maxCaretDistance,
                 maxSnippetCount, maxSnippetLength, doAggregateSnippets
             });
             if (featureFlag === undefined) { return []; }
-            const cacheEntry: CacheEntry | undefined = this.completionContextCache.get(docUri.toString());
+            const cachePolicy: CompletionContextCachePolicy = {
+                featureFlag: CopilotCompletionContextProvider.normalizeFeatureFlag(featureFlag),
+                maxSnippetCount,
+                maxSnippetLength,
+                doAggregateSnippets
+            };
+            const hadCacheEntry = this.completionContextCache.has(docUri.toString());
+            const cacheEntry = this.completionContextCache.get(
+                docUri.toString(), docOffset, maxCaretDistance, cachePolicy);
             if (proposedEdits) {
-                const defaultValue = cacheEntry?.[1];
-                const isStaleCache = defaultValue !== undefined ? CopilotCompletionContextProvider.isStaleCacheHit(docOffset, defaultValue.caretOffset, maxCaretDistance) : true;
-                const contextItems = isStaleCache ? [] : CopilotCompletionContextProvider.createContextItems(defaultValue);
-                copilotCompletionContext = isStaleCache ? undefined : defaultValue;
-                copilotCompletionContextKind = isStaleCache ? CopilotCompletionKind.StaleCacheHit : CopilotCompletionKind.GotFromCache;
+                copilotCompletionContext = cacheEntry?.result;
+                copilotCompletionContextKind = cacheEntry ? CopilotCompletionKind.GotFromCache :
+                    hadCacheEntry ? CopilotCompletionKind.StaleCacheHit : CopilotCompletionKind.MissingCacheMiss;
                 telemetry.addSpeculativeRequestMetadata(proposedEdits.length);
-                if (cacheEntry?.[0]) {
-                    telemetry.addCacheHitEntryGuid(cacheEntry[0]);
+                if (cacheEntry) {
+                    telemetry.addCacheHitEntryGuid(cacheEntry.id);
                 }
-                return contextItems;
+                return CopilotCompletionContextProvider.createContextItems(copilotCompletionContext);
             }
             const [resultContext, resultKind] = await this.resolveResultAndKind(context, featureFlag,
-                telemetry.fork(), cacheEntry?.[1], resolveStartTime, cppTimeBudgetMs, maxSnippetCount, maxSnippetLength, doAggregateSnippets, copilotCancel);
+                telemetry.fork(), cacheEntry?.result, resolveStartTime, cppTimeBudgetMs, maxSnippetCount, maxSnippetLength, doAggregateSnippets, copilotCancel);
             copilotCompletionContext = resultContext;
             copilotCompletionContextKind = resultKind;
             logMessage += `(id: ${copilotCompletionContext?.requestId})`;
-            // Fix up copilotCompletionContextKind accounting for stale-cache-hits.
-            if (copilotCompletionContextKind === CopilotCompletionKind.GotFromCache &&
-                copilotCompletionContext && cacheEntry) {
-                telemetry.addCacheHitEntryGuid(cacheEntry[0]);
-                const cachedData = cacheEntry[1];
-                if (CopilotCompletionContextProvider.isStaleCacheHit(docOffset, cachedData.caretOffset, maxCaretDistance)) {
-                    copilotCompletionContextKind = CopilotCompletionKind.StaleCacheHit;
-                    copilotCompletionContext.snippets = [];
-                }
+            if (copilotCompletionContextKind === CopilotCompletionKind.GotFromCache && cacheEntry) {
+                telemetry.addCacheHitEntryGuid(cacheEntry.id);
             }
             // Handle cancellation.
             if (copilotCompletionContextKind === CopilotCompletionKind.Canceled) {
@@ -431,7 +443,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
             if (copilotCompletionContext === undefined) {
                 logMessage += `result is undefined and no code snippets provided(${copilotCompletionContextKind.toString()}), elapsed time:${duration} ms`;
             } else {
-                logMessage += `for ${docUri}:${docOffset} provided ${copilotCompletionContext.snippets.length} code snippet(s)(${copilotCompletionContextKind.toString()}\
+                logMessage += `provided ${copilotCompletionContext.snippets.length} code snippet(s)(${copilotCompletionContextKind.toString()}\
 ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}) and ${copilotCompletionContext.traits.length} trait(s), elapsed time:${duration} ms`;
             }
             telemetry.addCompletionContextKind(copilotCompletionContextKind);
@@ -459,9 +471,7 @@ ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}
             }
             const disposable = await this.installContextProvider(api, contextProvider);
             if (disposable) {
-                this.contextProviderDisposables = this.contextProviderDisposables ?? [];
-                this.contextProviderDisposables.push(disposable);
-                return true;
+                return this.contextProviderDisposables.add(disposable);
             } else {
                 throw new CopilotContextProviderException("getContextProviderAPI() is not available in Copilot Chat.");
             }
@@ -492,9 +502,7 @@ ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}
                 }
                 const disposable = await this.installContextProvider(api, contextProvider);
                 if (disposable) {
-                    this.contextProviderDisposables = this.contextProviderDisposables ?? [];
-                    this.contextProviderDisposables.push(disposable);
-                    return true;
+                    return this.contextProviderDisposables.add(disposable);
                 } else {
                     throw new CopilotContextProviderException("getContextProviderAPI() is not available in Copilot client.");
                 }

--- a/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextProvider.ts
@@ -10,7 +10,7 @@ import { isBoolean, isNumber, isString } from '../common';
 import { getOutputChannelLogger, Logger } from '../logger';
 import * as telemetry from '../telemetry';
 import { CopilotCompletionContextResult } from './client';
-import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore, formatCompletionContextLocation } from './copilotCompletionContextCache';
+import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore } from './copilotCompletionContextCache';
 import { CopilotCompletionContextTelemetry } from './copilotCompletionContextTelemetry';
 import { getCopilotChatApi, getCopilotClientApi, type CopilotContextProviderAPI } from './copilotProviders';
 import { clients } from './extension';
@@ -139,10 +139,10 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
         Promise<CopilotCompletionContextResult | undefined> {
         const documentUri = context.documentContext.uri;
         const caretOffset = context.documentContext.offset;
-        let logMessage = `Copilot: getCompletionContext:`;
+        let logMessage = `Copilot: getCompletionContext(${documentUri}:${caretOffset}):`;
         try {
             const snippetsFeatureFlag = CopilotCompletionContextProvider.normalizeFeatureFlag(featureFlag);
-            telemetry.addRequestMetadata(caretOffset, context.completionId,
+            telemetry.addRequestMetadata(documentUri, caretOffset, context.completionId,
                 context.documentContext.languageId, { featureFlag: snippetsFeatureFlag });
             const docUri = vscode.Uri.parse(documentUri);
             const getClientForTime = performance.now();
@@ -178,8 +178,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
             else {
                 logMessage += ` and ${copilotCompletionContext.snippets.length} snippet(s)`;
                 logMessage += `(response.featureFlag:${copilotCompletionContext.featureFlag})`;
-                logMessage += formatCompletionContextLocation(
-                    documentUri, copilotCompletionContext.sourceFileUri, copilotCompletionContext.caretOffset);
+                logMessage += `(response.uri:${copilotCompletionContext.sourceFileUri || "<not-set>"}:${copilotCompletionContext.caretOffset})`;
             }
 
             telemetry.addResponseMetadata(copilotCompletionContext.areSnippetsMissing, copilotCompletionContext.snippets.length,
@@ -199,8 +198,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
             }
 
             telemetry.addError();
-            const errorType = e instanceof Error ? e.name : typeof e;
-            this.logger.appendLineAtLevel(7, `Copilot: getCompletionContextWithCancellation: Error type: '${errorType}'`);
+            this.logger.appendLineAtLevel(7, `Copilot: getCompletionContextWithCancellation(${documentUri}: ${caretOffset}): Error: '${e}'`);
             return undefined;
         } finally {
             this.logger.
@@ -366,7 +364,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
     public async resolve(context: ResolveRequest, copilotCancel: vscode.CancellationToken): Promise<SupportedContextItem[]> {
         const proposedEdits = context.documentContext.proposedEdits;
         const resolveStartTime = performance.now();
-        let logMessage = `Copilot: resolve:`;
+        let logMessage = `Copilot: resolve(${context.documentContext.uri}:${context.documentContext.offset}):`;
         const cppTimeBudgetMs = await this.fetchTimeBudgetMs(context);
         const maxCaretDistance = await this.fetchMaxDistanceToCaret(context);
         const maxSnippetCount = await this.fetchMaxSnippetCount(context);
@@ -380,7 +378,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
         const docOffset = context.documentContext.offset;
         try {
             featureFlag = await this.getEnabledFeatureFlag(context);
-            telemetry.addRequestMetadata(context.documentContext.offset,
+            telemetry.addRequestMetadata(context.documentContext.uri, context.documentContext.offset,
                 context.completionId, context.documentContext.languageId, {
                 featureFlag, timeBudgetMs: cppTimeBudgetMs, maxCaretDistance,
                 maxSnippetCount, maxSnippetLength, doAggregateSnippets
@@ -443,7 +441,7 @@ export class CopilotCompletionContextProvider implements ContextResolver<Support
             if (copilotCompletionContext === undefined) {
                 logMessage += `result is undefined and no code snippets provided(${copilotCompletionContextKind.toString()}), elapsed time:${duration} ms`;
             } else {
-                logMessage += `provided ${copilotCompletionContext.snippets.length} code snippet(s)(${copilotCompletionContextKind.toString()}\
+                logMessage += `for ${docUri}:${docOffset} provided ${copilotCompletionContext.snippets.length} code snippet(s)(${copilotCompletionContextKind.toString()}\
 ${copilotCompletionContext?.areSnippetsMissing ? "(missing code snippets)" : ""}) and ${copilotCompletionContext.traits.length} trait(s), elapsed time:${duration} ms`;
             }
             telemetry.addCompletionContextKind(copilotCompletionContextKind);

--- a/Extension/src/LanguageServer/copilotCompletionContextTelemetry.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextTelemetry.ts
@@ -92,7 +92,7 @@ export class CopilotCompletionContextTelemetry {
         this.addMetric('response.traitsCount', traitsCount ?? -1);
     }
 
-    public addRequestMetadata(uri: string, caretOffset: number, completionId: string,
+    public addRequestMetadata(caretOffset: number, completionId: string,
         languageId: string, { featureFlag, timeBudgetMs, maxCaretDistance, maxSnippetCount, maxSnippetLength, doAggregateSnippets }: {
             featureFlag?: CopilotCompletionContextFeatures; timeBudgetMs?: number; maxCaretDistance?: number;
             maxSnippetCount?: number; maxSnippetLength?: number; doAggregateSnippets?: boolean;

--- a/Extension/src/LanguageServer/copilotCompletionContextTelemetry.ts
+++ b/Extension/src/LanguageServer/copilotCompletionContextTelemetry.ts
@@ -92,7 +92,7 @@ export class CopilotCompletionContextTelemetry {
         this.addMetric('response.traitsCount', traitsCount ?? -1);
     }
 
-    public addRequestMetadata(caretOffset: number, completionId: string,
+    public addRequestMetadata(uri: string, caretOffset: number, completionId: string,
         languageId: string, { featureFlag, timeBudgetMs, maxCaretDistance, maxSnippetCount, maxSnippetLength, doAggregateSnippets }: {
             featureFlag?: CopilotCompletionContextFeatures; timeBudgetMs?: number; maxCaretDistance?: number;
             maxSnippetCount?: number; maxSnippetLength?: number; doAggregateSnippets?: boolean;

--- a/Extension/test/unit/copilotCompletionContextCache.test.ts
+++ b/Extension/test/unit/copilotCompletionContextCache.test.ts
@@ -1,0 +1,80 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { describe } from 'mocha';
+import { doesNotMatch, strictEqual } from 'node:assert';
+import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore, formatCompletionContextLocation } from '../../src/LanguageServer/copilotCompletionContextCache';
+
+interface TestContext {
+    caretOffset: number;
+    value: string;
+}
+
+const defaultPolicy: CompletionContextCachePolicy = {
+    featureFlag: 1,
+    maxSnippetCount: 7,
+    maxSnippetLength: 3072,
+    doAggregateSnippets: true
+};
+
+describe('Copilot completion context cache', () => {
+    it('requires a matching request policy and caret distance', () => {
+        const cache = new CompletionContextCache<TestContext>();
+        cache.set('file:///source.cpp', 'entry', { caretOffset: 100, value: 'cached' }, defaultPolicy);
+
+        strictEqual(cache.get('file:///source.cpp', 108, 8, defaultPolicy)?.result.value, 'cached');
+        strictEqual(cache.get('file:///source.cpp', 109, 8, defaultPolicy), undefined);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, { ...defaultPolicy, featureFlag: 2 }), undefined);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, { ...defaultPolicy, maxSnippetCount: 1 }), undefined);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, { ...defaultPolicy, maxSnippetLength: 128 }), undefined);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, { ...defaultPolicy, doAggregateSnippets: false }), undefined);
+    });
+
+    it('clears cached results when source or configuration state changes', () => {
+        const cache = new CompletionContextCache<TestContext>();
+        cache.set('file:///source.cpp', 'entry', { caretOffset: 100, value: 'cached' }, defaultPolicy);
+
+        cache.clear();
+
+        strictEqual(cache.size, 0);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, defaultPolicy), undefined);
+    });
+
+    it('does not repopulate after an in-flight computation is invalidated', () => {
+        const cache = new CompletionContextCache<TestContext>();
+        const computationGeneration = cache.currentGeneration;
+
+        cache.clear();
+
+        strictEqual(
+            cache.set('file:///source.cpp', 'stale-entry', { caretOffset: 100, value: 'stale' }, defaultPolicy, computationGeneration),
+            false);
+        strictEqual(cache.size, 0);
+        strictEqual(
+            cache.set('file:///source.cpp', 'current-entry', { caretOffset: 100, value: 'current' }, defaultPolicy),
+            true);
+        strictEqual(cache.get('file:///source.cpp', 100, 8, defaultPolicy)?.result.value, 'current');
+    });
+
+    it('redacts request and result URIs from diagnostics', () => {
+        const requestCanary = 'file:///private/request-canary.cpp';
+        const resultCanary = 'file:///private/result-canary.cpp';
+        const diagnostic = formatCompletionContextLocation(requestCanary, resultCanary, 42);
+
+        strictEqual(diagnostic, '(response.uriMatchesRequest:false)(response.caretOffset:42)');
+        doesNotMatch(diagnostic, /request-canary|result-canary/);
+    });
+
+    it('disposes registrations that complete after provider disposal', () => {
+        const store = new DisposableStore<{ dispose(): void }>();
+        let disposed = 0;
+
+        strictEqual(store.add({ dispose: () => disposed++ }), true);
+        store.dispose();
+        strictEqual(disposed, 1);
+        strictEqual(store.add({ dispose: () => disposed++ }), false);
+        strictEqual(disposed, 2);
+    });
+});

--- a/Extension/test/unit/copilotCompletionContextCache.test.ts
+++ b/Extension/test/unit/copilotCompletionContextCache.test.ts
@@ -4,8 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { describe } from 'mocha';
-import { doesNotMatch, strictEqual } from 'node:assert';
-import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore, formatCompletionContextLocation } from '../../src/LanguageServer/copilotCompletionContextCache';
+import { strictEqual } from 'node:assert';
+import { CompletionContextCache, CompletionContextCachePolicy, DisposableStore } from '../../src/LanguageServer/copilotCompletionContextCache';
 
 interface TestContext {
     caretOffset: number;
@@ -56,15 +56,6 @@ describe('Copilot completion context cache', () => {
             cache.set('file:///source.cpp', 'current-entry', { caretOffset: 100, value: 'current' }, defaultPolicy),
             true);
         strictEqual(cache.get('file:///source.cpp', 100, 8, defaultPolicy)?.result.value, 'current');
-    });
-
-    it('redacts request and result URIs from diagnostics', () => {
-        const requestCanary = 'file:///private/request-canary.cpp';
-        const resultCanary = 'file:///private/result-canary.cpp';
-        const diagnostic = formatCompletionContextLocation(requestCanary, resultCanary, 42);
-
-        strictEqual(diagnostic, '(response.uriMatchesRequest:false)(response.caretOffset:42)');
-        doesNotMatch(diagnostic, /request-canary|result-canary/);
     });
 
     it('disposes registrations that complete after provider disposal', () => {


### PR DESCRIPTION
## Summary

Ensures Copilot completion context cache entries are reused only when the caret distance and request options still match. It also invalidates shared cache state on C/C++ document and configuration changes and prevents in-flight computations from repopulating invalidated entries.

> This PR was investigated and created by Copilot with `GPT-5.6 Sol` (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Details

- Associate cached results with the feature, count, length, and aggregation policy used to compute them.
- Correct stale-distance evaluation and reject late results from an invalidated cache generation.
- Clear shared cache and parameter state when relevant documents or configurations change.
- Dispose registrations that complete after the provider has already been disposed.

## Validation

- TypeScript compilation
- ESLint on the changed source and test files
- All 219 extension unit tests