### PR TITLE
Enable PR CI for release and insiders

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release, insiders ]
   workflow_dispatch:
     inputs:
       target-ref:

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release, insiders ]
   workflow_dispatch:
     inputs:
       target-ref:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release, insiders ]
   workflow_dispatch:
     inputs:
       target-ref:


### PR DESCRIPTION
## Summary

Run the existing Linux, macOS, and Windows CI workflows for pull requests targeting `release` and `insiders`, in addition to `main`. Push triggers remain `main`-only, and checkout and manual-dispatch behavior are unchanged.

Related to #14750: release-targeted PRs did not start fresh platform CI runs because the pull-request branch filters included only `main`. After this change lands in `main`, it can be merged into `seanmcm/1_34_4_release` to trigger that PR's own CI runs.

> This PR was investigated and created by GitHub Copilot (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Parsed all three workflow files and verified PR triggers for `main`, `release`, and `insiders`, with unrelated target branches excluded.
- Confirmed all other workflow configuration is unchanged and the diff contains only three branch-filter edits.
- Passed whitespace validation while preserving the files' existing CRLF line endings.