### PR TITLE
Update changelog and version for 1.35.0

### DIFF
--- a/Extension/CHANGELOG.md
+++ b/Extension/CHANGELOG.md
@@ -1,5 +1,16 @@
 # C/C++ for Visual Studio Code Changelog
 
+## Version 1.35.0: September 10, 2026
+### Enhancement
+* Improve workspace indexing performance.
+
+### Bug Fixes
+* Fix false IntelliSense errors when initializing a variable with a value from the same unnamed enum. [#14726](https://github.com/microsoft/vscode-cpptools/issues/14726)
+* Fix the workspace parsing status briefly reporting completion while a newer parse is still running.
+* Fix 'Create Declaration/Definition' incorrectly being offered for explicit template instantiations.
+* Fix tag parser hangs when database initialization fails or shutdown interrupts a pending request.
+* Various localization updates.
+
 ## Version 1.34.4: September 9, 2026
 ### Enhancements
 * Add folding support for C++ `public`, `private`, and `protected` access sections. [#14645](https://github.com/microsoft/vscode-cpptools/issues/14645)

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
     "name": "cpptools",
     "displayName": "C/C++",
     "description": "C/C++ IntelliSense, debugging, and code browsing.",
-    "version": "1.34.4-main",
+    "version": "1.35.0-main",
     "publisher": "ms-vscode",
     "icon": "LanguageCCPP_color_128x.png",
     "readme": "README.md",


### PR DESCRIPTION
## Summary
Add the 1.35.0 changelog for the September 10, 2026 pre-release and update the extension version to `1.35.0-main`.

> This PR was investigated and created by GitHub Copilot (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Validation
- Verified the release date, version consistency, issue link, and changelog ordering.
- Confirmed prior release notes are unchanged and the manifest differs only in its version.
- Ran the registered JSON formatter, JSON validation, and whitespace checks.