### PR TITLE
Retry session-state test cleanup on Windows

### DIFF
--- a/Extension/test/scenarios/SingleRootProject/tests/buildAndDebug.test.ts
+++ b/Extension/test/scenarios/SingleRootProject/tests/buildAndDebug.test.ts
@@ -86,7 +86,7 @@ suite("BuildAndDebug SessionState Tests", () => {
             await assertSessionState(true, false);
         } finally {
             await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
-            await fs.promises.rm(temporaryDirectory, { recursive: true, force: true });
+            await fs.promises.rm(temporaryDirectory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
         }
     });
 


### PR DESCRIPTION
## Summary

Retry removal of the temporary directory used by the active-document language-change session-state test when Windows briefly reports a filesystem lock after the editor closes.

- Set `maxRetries: 10` and `retryDelay: 100` on the existing recursive `fs.promises.rm` call. Linear backoff allows up to 5.5 seconds of retry delays, with no added delay when deletion succeeds immediately.
- Keep the session-state assertions unchanged and continue to report persistent cleanup failures.
- Addresses the cleanup failure in [this Windows CI job](https://github.com/microsoft/vscode-cpptools/actions/runs/34289645603/job/102273099013), following #14736.

> This PR was investigated and created by GitHub Copilot (in VS Code). Any message starting with `✨Copilot:` was sent by Copilot.

## Validation

- Native Windows Node reproduction: a child process holding the temporary directory as its working directory causes the original cleanup to fail with `EBUSY`; the edited cleanup succeeds after the lock is released.
- Focused probes using the test's actual cleanup options cover immediate success, transient `EBUSY`, retry exhaustion for persistent `EBUSY`, and propagation of unrelated `EACCES` errors, with the original cleanup as a negative control.
- TypeScript formatting and syntax/transpilation checks passed. The one-line diff preserves the existing CRLF line endings and passes the corresponding whitespace check.
- The full VS Code integration suite was not rerun locally; Windows, Linux, and macOS CI will provide that validation.
