### PR TITLE
Remove remnants of the `recursiveIncludes.reduce` option

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -1359,17 +1359,6 @@
                         "markdownDescription": "%c_cpp.configuration.default.dotConfig.markdownDescription%",
                         "scope": "resource"
                     },
-                    "C_Cpp.default.recursiveIncludes.reduce": {
-                        "type": "string",
-                        "enum": [
-                            "",
-                            "always",
-                            "never",
-                            "default"
-                        ],
-                        "markdownDescription": "%c_cpp.configuration.default.recursiveIncludes.reduce.markdownDescription%",
-                        "scope": "resource"
-                    },
                     "C_Cpp.default.recursiveIncludes.priority": {
                         "type": "string",
                         "enum": [

--- a/Extension/package.nls.json
+++ b/Extension/package.nls.json
@@ -733,12 +733,6 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     },
-    "c_cpp.configuration.default.recursiveIncludes.reduce.markdownDescription": {
-        "message": "The value to use in a configuration if `recursiveIncludes.reduce` is either not specified or set to `${default}`.",
-        "comment": [
-            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
-        ]
-    },
     "c_cpp.configuration.default.recursiveIncludes.priority.markdownDescription": {
         "message": "The value to use in a configuration if `recursiveIncludes.priority` is either not specified or set to `${default}`.",
         "comment": [

--- a/Extension/src/LanguageServer/configurations.ts
+++ b/Extension/src/LanguageServer/configurations.ts
@@ -113,7 +113,6 @@ export interface Browse {
 }
 
 export interface RecursiveIncludes {
-    reduce?: string;
     priority?: string;
     order?: string;
 }

--- a/Extension/ui/settings.html
+++ b/Extension/ui/settings.html
@@ -738,21 +738,6 @@
         </div>
 
         <div class="section">
-            <div class="section-title" data-loc-id="recursiveIncludes.reduce">Recursive includes: reduce</div>
-            <div class="section-text">
-                <span data-loc-id="recursiveIncludes.reduce.description">Set to <code>always</code> to reduce the number of recursive include paths provided to IntelliSense to only those paths currently referenced by #include statements. This requires first parsing files to determine which files are included. Set to <code>never</code> to provide all recursive include paths to IntelliSense. Reducing the number of recursive include paths may improve IntelliSense performance when a very large number of recursive include paths are involved. Not reducing the number of recursive include paths can improve IntelliSense performance by avoiding the need to parse files to determine which include paths to provide.</span>
-            </div>
-            <div>
-            <select name="inputValue" id="recursiveIncludes.reduce" class="select-default">
-                <option value="${default}">${default}</option>
-                <option value="always">always</option>
-                <option value="never">never</option>
-                <option value="default">default</option>
-            </select>
-            </div>
-        </div>
-
-        <div class="section">
             <div class="section-title" data-loc-id="recursiveIncludes.priority">Recursive includes: priority</div>
             <div class="section-text">
                 <span data-loc-id="recursiveIncludes.priority.description">The priority of recursive include paths. If set to <code>beforeSystemIncludes</code>, the recursive include paths will be searched before system include paths. If set to <code>afterSystemIncludes</code>, the recursive include paths will be searched after system include paths.</span>


### PR DESCRIPTION
Removes some lingering remnants of the `recursiveIncludes.reduce` option

`recursiveIncludes.reduce` had already been removed from the `cpp_properties.json` schema.  The native process now implements recursive includes in an efficient manner that no longer requires a 'reduce' phase.