### PR TITLE
Update bundled LLVM tools for the shared bin layout

### DIFF
--- a/Extension/.gitignore
+++ b/Extension/.gitignore
@@ -11,6 +11,8 @@ debugAdapters
 LLVM
 bin/assert_dialog.sh
 bin/binaryVersion.json
+bin/clang-format
+bin/clang-tidy
 bin/cpptools*
 bin/edge_cli
 bin/isense_driver

--- a/Extension/.scripts/clean.ts
+++ b/Extension/.scripts/clean.ts
@@ -14,7 +14,7 @@ import { $root, Git, brightGreen, cyan, getModifiedIgnoredFiles, rimraf } from '
 // list all untracked and ignored files that are modified/created: `git clean -Xd -n`
 
 export async function main() {
-    await rimraf(resolve($root, 'dist'));
+    await rimraf(resolve($root, 'dist'), resolve($root, 'LLVM'));
 }
 
 export async function all() {

--- a/Extension/.scripts/copyExtensionBinaries.ts
+++ b/Extension/.scripts/copyExtensionBinaries.ts
@@ -10,7 +10,7 @@ import { verbose } from '../src/Utility/Text/streams';
 import { $args, $root, Git, green, heading, note, warn } from './common';
 
 const extensionPrefix = 'ms-vscode.cpptools-';
-const foldersToCopy = ['bin', 'debugAdapters', 'LLVM'] as const;
+const foldersToCopy = ['bin', 'debugAdapters'] as const;
 
 type InstalledExtension = {
     path: string;
@@ -166,6 +166,14 @@ export async function main(sourcePath = $args[0]): Promise<string | undefined> {
         await rm(destination, { recursive: true, force: true });
         await cp(source, destination, { recursive: true, force: true });
     }
+
+    const legacyLLVMBin: string = join(installedExtensionPath, 'LLVM', 'bin');
+    const legacyLLVMInfo = await stat(legacyLLVMBin).catch(() => undefined);
+    if (legacyLLVMInfo?.isDirectory()) {
+        console.log(`Copying ${green('LLVM/bin')} from ${legacyLLVMBin}`);
+        await cp(legacyLLVMBin, join($root, 'bin'), { recursive: true, force: true });
+    }
+    await rm(join($root, 'LLVM'), { recursive: true, force: true });
 
     note(`Copied installed binaries into ${$root}`);
 

--- a/Extension/.scripts/vscode.test.mjs
+++ b/Extension/.scripts/vscode.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -38,6 +38,49 @@ function createInstaller() {
         './vscodeTestPath': { getVSCodeTestIsolate: () => join(tmpdir(), 'cpptools-acquisition-unit') }
     });
     return { ...installer, download, resolveCli, wait, mkdir, write, warn };
+}
+
+for (const clangToolsFolder of ['bin', join('LLVM', 'bin')]) {
+    test(`copies installed clang tools from ${clangToolsFolder} into bin`, async () => {
+        const testRoot = mkdtempSync(join(tmpdir(), 'cpptools-binary-copy-'));
+        const installedExtension = join(testRoot, 'vscode', 'extensions', 'ms-vscode.cpptools-1.2.3');
+        const destination = join(testRoot, 'workspace');
+        mkdirSync(join(installedExtension, 'bin'), { recursive: true });
+        mkdirSync(join(installedExtension, 'debugAdapters'), { recursive: true });
+        mkdirSync(join(installedExtension, clangToolsFolder), { recursive: true });
+        writeFileSync(join(installedExtension, 'bin', 'cpptools'), 'cpptools');
+        writeFileSync(join(installedExtension, 'debugAdapters', 'OpenDebugAD7'), 'debug adapter');
+        writeFileSync(join(installedExtension, clangToolsFolder, 'clang-format'), 'clang-format');
+        writeFileSync(join(installedExtension, clangToolsFolder, 'clang-tidy'), 'clang-tidy');
+        mkdirSync(join(destination, 'LLVM', 'bin'), { recursive: true });
+        writeFileSync(join(destination, 'LLVM', 'bin', 'stale-clang-format'), 'stale');
+
+        const Git = sinon.stub().resolves({ code: 0, stdio: { all: () => [] } });
+        const copy = proxyquire(fileURLToPath(new URL('copyExtensionBinaries.ts', import.meta.url)), {
+            '../src/Utility/Text/streams': { verbose: sinon.stub() },
+            'node:os': { homedir: () => join(testRoot, 'home') },
+            './common': {
+                $args: [],
+                $root: destination,
+                Git,
+                green: value => value,
+                heading: value => value,
+                note: sinon.stub(),
+                warn: sinon.stub()
+            }
+        });
+
+        try {
+            assert.equal(await copy.main(testRoot), '1.2.3');
+            assert.equal(readFileSync(join(destination, 'bin', 'cpptools'), 'utf8'), 'cpptools');
+            assert.equal(readFileSync(join(destination, 'bin', 'clang-format'), 'utf8'), 'clang-format');
+            assert.equal(readFileSync(join(destination, 'bin', 'clang-tidy'), 'utf8'), 'clang-tidy');
+            assert.equal(readFileSync(join(destination, 'debugAdapters', 'OpenDebugAD7'), 'utf8'), 'debug adapter');
+            assert.equal(existsSync(join(destination, 'LLVM')), false);
+        } finally {
+            rmSync(testRoot, { recursive: true, force: true });
+        }
+    });
 }
 
 test('successful acquisition preserves the version, cache and CLI arguments without retries', async () => {

--- a/Extension/src/LanguageServer/settings.ts
+++ b/Extension/src/LanguageServer/settings.ts
@@ -299,7 +299,7 @@ export class CppSettings extends Settings {
                 // Attempt to invoke both our own version of clang-* to see if we can successfully execute it, and to get its version.
                 let bundledVersion: string;
                 try {
-                    const bundledPath: string = getExtensionFilePath(`./LLVM/bin/${clangName}`);
+                    const bundledPath: string = getExtensionFilePath(`./bin/${clangName}`);
                     const output: string = execFileSync(bundledPath, ['--version']).toString();
                     bundledVersion = output.match(/(\d+\.\d+\.\d+)/)?.[1] ?? "";
                     if (!semver.valid(bundledVersion)) {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -193,8 +193,8 @@ async function makeBinariesExecutable(): Promise<void> {
             "./bin/cpptools-srv",
             "./bin/cpptools-srv2",
             "./bin/cpptools-wordexp",
-            "./LLVM/bin/clang-format",
-            "./LLVM/bin/clang-tidy",
+            "./bin/clang-format",
+            "./bin/clang-tidy",
             "./debugAdapters/bin/OpenDebugAD7"
         ];
         commonBinaries.forEach(binary => promises.push(util.allowExecution(util.getExtensionFilePath(binary))));


### PR DESCRIPTION
Update the extension to find clang-format and clang-tidy under `Extension/bin`
after their relocation from `Extension/LLVM/bin`.

The bundled-version check and Unix executable-permission setup now use the new
paths. The local binary bootstrap accepts both released extensions using the
legacy layout and extensions using the new layout, normalizing either into
`bin`. Prepublish cleanup also removes stale `LLVM` directories.

This is coordinated with the native change that packages the LLVM tools beside
the VC runtime DLLs.

Validation:
- TypeScript build passes.
- ESLint passes.
- Bootstrap tests pass for both legacy and new layouts.
- `git diff --check` passes.